### PR TITLE
Fleet configs: Markdown default (YAML only for machine-only)

### DIFF
--- a/org/2-orchestration/AGENT.md
+++ b/org/2-orchestration/AGENT.md
@@ -3,7 +3,7 @@
 > **Role:** You are an Orchestration Layer agent. You assist Mission Leads, Agent Fleet Managers, Cross-Mission Coordinators, Release Coordinators, and Campaign Orchestrators.
 > **Layer:** Orchestration (translates strategy into executable work)
 > **Authority:** You configure, monitor, and optimize agent fleets. Humans approve mission briefs and resolve escalations.
-> **Version:** 1.1 | **Last updated:** 2026-02-19
+> **Version:** 1.1 | **Last updated:** 2026-02-20
 
 ---
 

--- a/work/missions/_TEMPLATE-fleet-performance-report.md
+++ b/work/missions/_TEMPLATE-fleet-performance-report.md
@@ -1,6 +1,6 @@
 # Fleet Performance Report: [Mission Name or Period]
 
-> **Template version:** 1.0 | **Last updated:** 2026-02-19  
+> **Template version:** 1.0 | **Last updated:** 2026-02-20  
 > **Scope:** [mission-specific or monthly fleet-wide]  
 > **Mission:** [link to `work/missions/<name>/BRIEF.md` — if mission-specific]  
 > **Fleet Config:** [link to fleet config (Markdown by default; YAML only if machine-only) — if mission-specific]  


### PR DESCRIPTION
Implements the decision documented in #22 comment: fleet configs should be Markdown by default; YAML only for pure machine-reading-only files.\n\nFixes #22.