### PR TITLE
Governance enforcement: required GitHub settings + advisory CI check

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -465,3 +465,16 @@ jobs:
 
           print("\nAll changed governed files have updated version/date fields.")
           PY
+
+  validate-github-governance:
+    name: Validate GitHub Governance (advisory)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Advisory check: CODEOWNERS + branch protection
+        env:
+          GITHUB_DEFAULT_BRANCH: ${{ github.event.repository.default_branch || 'main' }}
+        run: |
+          python3 scripts/check_github_governance.py

--- a/docs/REQUIRED-GITHUB-SETTINGS.md
+++ b/docs/REQUIRED-GITHUB-SETTINGS.md
@@ -1,0 +1,67 @@
+# Required GitHub Settings (Governance Enforcement)
+
+This framework assumes **GitHub enforces governance**. The repository can document roles (via `CODEOWNERS`) and quality gates (via Actions), but **only GitHub branch protection** makes these rules binding.
+
+Use this checklist when you fork/customize the framework.
+
+---
+
+## 1) Enable Issues (recommended)
+
+Repo → **Settings → General → Features**
+- ✅ Issues
+
+---
+
+## 2) Protect the default branch (`main`)
+
+Repo → **Settings → Branches → Branch protection rules**
+
+Recommended minimum rule for `main`:
+
+### Required
+- ✅ **Require a pull request before merging**
+- ✅ **Require approvals** (recommend: 1–2)
+- ✅ **Require review from Code Owners**
+- ✅ **Require status checks to pass before merging**
+  - Select the workflow checks from `.github/workflows/validate.yml` (e.g., "Validate Framework")
+- ✅ **Require branches to be up to date before merging** (optional but recommended)
+
+### Strongly recommended
+- ✅ **Restrict who can push to matching branches** (admins/maintainers only)
+- ✅ **Do not allow bypassing the above settings** (or restrict bypass to a very small set)
+
+### Optional hardening
+- ✅ Require signed commits
+- ✅ Require linear history
+- ✅ Require conversation resolution
+
+---
+
+## 3) CODEOWNERS must exist and be meaningful
+
+- Keep `CODEOWNERS` current.
+- Treat it as **executable RACI**: sensitive paths (policies, operating model, agent instructions) must have explicit owners.
+
+---
+
+## 4) Required checks: keep the gate list small and non-controversial
+
+Start with the repo’s built-in validation workflow:
+- YAML parse checks
+- Markdown internal link checks
+- Structure checks
+- Versioning/metadata checks
+
+Then add stronger gates (security scans, policy-as-code) as you adopt them.
+
+---
+
+## 5) Operating model note
+
+The model’s rule of thumb:
+- **PRs = decisions**
+- **CODEOWNERS = RACI**
+- **CI = quality gates**
+
+Without branch protection, these become advisory.

--- a/scripts/check_github_governance.py
+++ b/scripts/check_github_governance.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Advisory governance check for GitHub-hosted repos.
+
+This check is intentionally *warning-only* by default.
+
+It verifies:
+- CODEOWNERS exists
+- Default branch protection appears enabled (if the token has permission to read it)
+
+It is best-effort because GitHub Actions tokens often lack permission to read
+branch protection settings in some org configurations.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.request
+from pathlib import Path
+
+
+def api_get(url: str, token: str) -> tuple[int, dict | str]:
+    req = urllib.request.Request(url)
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    req.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(req, timeout=20) as resp:
+            data = resp.read().decode("utf-8", errors="replace")
+            try:
+                return resp.status, json.loads(data)
+            except Exception:
+                return resp.status, data
+    except Exception as e:
+        # urllib raises for non-2xx; try to extract status code if present
+        status = getattr(getattr(e, "fp", None), "status", None)
+        if status is None:
+            return 0, str(e)
+        try:
+            body = e.fp.read().decode("utf-8", errors="replace")
+            return int(status), body
+        except Exception:
+            return int(status), str(e)
+
+
+def warn(msg: str) -> None:
+    print(f"::warning::{msg}")
+
+
+def main() -> int:
+    repo = os.environ.get("GITHUB_REPOSITORY", "").strip()  # owner/name
+    token = os.environ.get("GITHUB_TOKEN", "").strip()
+    default_branch = os.environ.get("GITHUB_DEFAULT_BRANCH", "main").strip() or "main"
+
+    # 1) CODEOWNERS existence
+    if not Path("CODEOWNERS").exists():
+        warn("CODEOWNERS file is missing at repo root. Governance via CODEOWNERS cannot be enforced.")
+
+    # 2) Branch protection (best-effort)
+    if not repo:
+        warn("GITHUB_REPOSITORY not set; skipping branch protection check.")
+        return 0
+
+    if not token:
+        warn("GITHUB_TOKEN not set; skipping branch protection check.")
+        return 0
+
+    url = f"https://api.github.com/repos/{repo}/branches/{default_branch}/protection"
+    status, payload = api_get(url, token)
+
+    if status == 200:
+        # Protection exists.
+        return 0
+
+    if status in (403, 404):
+        # 404 can mean "not protected" or "not accessible" depending on permissions.
+        warn(
+            f"Unable to confirm branch protection for '{default_branch}' (HTTP {status}). "
+            "Ensure branch protection + require CODEOWNERS review + required status checks are enabled. "
+            "See docs/REQUIRED-GITHUB-SETTINGS.md"
+        )
+        return 0
+
+    # Any other unexpected condition
+    warn(
+        f"Branch protection check returned unexpected status (HTTP {status}). "
+        "Please verify branch protection manually."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Implements part of #4 (advisory / warn-only):\n- Adds docs/REQUIRED-GITHUB-SETTINGS.md (branch protection + CODEOWNERS enforcement checklist)\n- Adds an advisory CI job that best-effort checks CODEOWNERS and tries to detect branch protection (warn-only if not accessible).\n\nCloses duplicate #29 scope via #4.