### PR TITLE
Add governance exception template

### DIFF
--- a/work/decisions/_TEMPLATE-governance-exception.md
+++ b/work/decisions/_TEMPLATE-governance-exception.md
@@ -1,0 +1,44 @@
+# Governance Exception: <short title>
+
+> **Template version:** 1.0 | **Last updated:** 2026-02-20
+
+## Summary
+
+- **Exception ID:** EXC-YYYY-NNN
+- **Owner:** @<handle>
+- **Scope:** <what rule/policy is being exceptioned>
+- **Reason:** <why this exception is needed>
+- **Risk:** <what risk is introduced>
+- **Mitigation:** <how the risk is reduced>
+- **Duration:** <time-boxed; include expiry>
+- **Approvers:** @<required approvers>
+- **Related PR(s):** <links>
+- **Related Issue(s):** <links>
+
+## Details
+
+### What rule is being overridden
+
+- Canonical rule/policy reference (file + section)
+- What changes (exactly)
+
+### Why it is necessary
+
+- Constraints
+- Tradeoffs
+
+### Safety checks
+
+- What still must pass
+- What is explicitly *not* waived
+
+### Expiry / rollback
+
+- Expiry date
+- How to revert the exception
+
+## Changelog
+
+| Version | Date | Change |
+|---|---|---|
+| 1.0 | 2026-02-20 | Initial template |


### PR DESCRIPTION
Fixes #30 (part 1).\n\nAdds a first-class governance exception template under work/decisions/.\n\nNext step (separate PR): CI enforcement to require an exception record when protected policies are weakened.