### PR TITLE
fix: schema validation for core artifacts

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -493,3 +493,20 @@ jobs:
           GITHUB_DEFAULT_BRANCH: "${{ github.event.repository.default_branch || 'main' }}"
         run: |
           python3 scripts/check_github_governance.py
+
+  validate-schema:
+    name: Validate Schemas
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install pyyaml jsonschema
+
+      - name: Validate CONFIG.yaml and work artifact schemas
+        run: python3 scripts/validate_schema.py

--- a/docs/SCHEMA-GUIDE.md
+++ b/docs/SCHEMA-GUIDE.md
@@ -1,0 +1,117 @@
+# Schema Validation Guide
+
+This document describes the schema validation system for core Agentic Enterprise framework artifacts.
+
+## Overview
+
+Two categories of artifacts are validated:
+
+| Artifact | Schema | Validator |
+|---|---|---|
+| `CONFIG.yaml` | `schemas/config.schema.json` | JSON Schema (jsonschema) |
+| `work/signals/*.md` | `schemas/work/signal.schema.json` | Custom markdown rules |
+| `work/missions/**/mission-brief.md` | `schemas/work/mission-brief.schema.json` | Custom markdown rules |
+| `work/releases/*release-contract*.md` | `schemas/work/release-contract.schema.json` | Custom markdown rules |
+
+Validation runs automatically on every `push` and `pull_request` to `main` via the **Validate Schemas** CI job (`.github/workflows/validate.yml`).
+
+---
+
+## Schema Locations
+
+```
+schemas/
+├── config.schema.json            # JSON Schema for CONFIG.yaml
+└── work/
+    ├── signal.schema.json        # Markdown schema for signal artifacts
+    ├── mission-brief.schema.json # Markdown schema for mission briefs
+    └── release-contract.schema.json  # Markdown schema for release contracts
+```
+
+---
+
+## CONFIG.yaml Schema
+
+`schemas/config.schema.json` is a [JSON Schema (draft-07)](https://json-schema.org/draft-07/json-schema-release-notes) document. It enforces:
+
+- **`framework_version`** — required, must match `MAJOR.MINOR.PATCH` semver.
+- **`company`** — required fields: `name`, `short_name`, `repo_slug`, `domain`.
+- **`vision`** — required fields: `north_star`, `mission`.
+- **`strategic_beliefs`** — at least one belief, each with `id`, `title`, `summary`.
+- **`ventures`** — at least one venture, each with `id`, `name`, `description`.
+- **`divisions`** — object of division arrays, each division with `id`, `name`, `description`.
+- **`toolchain`** — required: `git_host` (one of `GitHub`, `GitLab`, `Bitbucket`), `ci_cd`.
+- **`quality`** — required: `code_coverage_minimum` (0-100), `api_response_p95_ms`.
+
+Unknown top-level keys are permitted (`additionalProperties: true`) to allow future extension.
+
+---
+
+## Work Artifact Schemas
+
+Work artifact schemas are custom JSON documents interpreted by `scripts/validate_schema.py`. They support two rule types:
+
+### `required_sections`
+A list of `## Heading` names that must appear in the markdown file.
+
+### `required_fields`
+A list of inline field definitions. Each field entry supports:
+
+| Key | Description |
+|---|---|
+| `name` | Human-readable field name (used in error messages) |
+| `inline_pattern` | Regex to extract the field value from the markdown text |
+| `allowed_values` | Optional list of permitted values (case-insensitive) |
+| `id_pattern` | Optional regex the extracted value must fully match |
+| `required` | `true` (default) — field must be present |
+
+---
+
+## Running Validation Locally
+
+```bash
+pip install pyyaml jsonschema
+python3 scripts/validate_schema.py
+```
+
+Exit code `0` = all checks passed. Exit code `1` = validation failures.
+
+---
+
+## Adding or Updating a Schema
+
+### CONFIG.yaml Schema
+Edit `schemas/config.schema.json` following JSON Schema draft-07 conventions. Test locally with `python3 scripts/validate_schema.py`.
+
+### Work Artifact Schemas
+Edit the relevant file under `schemas/work/`. The custom schema keys are:
+
+```json
+{
+  "artifact_type": "markdown",
+  "filename_pattern": "<regex for the filename>",
+  "required_sections": ["Section Name", ...],
+  "required_fields": [
+    {
+      "name": "Field Label",
+      "inline_pattern": "\\*\\*Field Label:\\*\\*\\s*([^|\\n]+)",
+      "allowed_values": ["value1", "value2"],
+      "id_pattern": "^PREFIX-\\d{4}-\\d{3,}$",
+      "required": true
+    }
+  ]
+}
+```
+
+### Adding a New Artifact Type
+1. Create `schemas/work/<artifact-type>.schema.json`.
+2. Add a discovery function and validation call in `scripts/validate_schema.py`.
+3. Update this document.
+
+---
+
+## CI Integration
+
+The `validate-schema` job in `.github/workflows/validate.yml` installs `pyyaml` and `jsonschema`, then runs `python3 scripts/validate_schema.py`. The job fails if any schema violation is detected, blocking merge to `main`.
+
+Template files (`_TEMPLATE-*.md`) and `README.md` files are automatically excluded from work-artifact validation.

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,0 +1,23 @@
+# Schemas
+
+This directory contains schema definitions for core Agentic Enterprise framework artifacts.
+
+| File | Target | Validator |
+|---|---|---|
+| `config.schema.json` | `CONFIG.yaml` | JSON Schema (draft-07) via `jsonschema` |
+| `work/signal.schema.json` | `work/signals/*.md` | Custom markdown rules |
+| `work/mission-brief.schema.json` | `work/missions/**/BRIEF.md` | Custom markdown rules |
+| `work/release-contract.schema.json` | `work/releases/*release-contract*.md` | Custom markdown rules |
+
+## How Validation Works
+
+`scripts/validate_schema.py` runs during CI (`validate-schema` job in `.github/workflows/validate.yml`) and locally:
+
+```bash
+pip install pyyaml jsonschema
+python3 scripts/validate_schema.py
+```
+
+## Adding a New Schema
+
+See [docs/SCHEMA-GUIDE.md](../docs/SCHEMA-GUIDE.md) for the full contribution workflow.

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/wlfghdr/agentic-enterprise/schemas/config.schema.json",
+  "title": "Agentic Enterprise CONFIG.yaml",
+  "description": "Schema for the root CONFIG.yaml framework configuration file.",
+  "type": "object",
+  "required": [
+    "framework_version",
+    "company",
+    "vision",
+    "strategic_beliefs",
+    "ventures",
+    "divisions",
+    "toolchain",
+    "quality",
+    "org_size"
+  ],
+  "additionalProperties": true,
+  "properties": {
+    "framework_version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$",
+      "description": "Semantic version of the framework (MAJOR.MINOR.PATCH)."
+    },
+    "company": {
+      "type": "object",
+      "required": ["name", "short_name", "repo_slug", "domain"],
+      "additionalProperties": true,
+      "properties": {
+        "name": { "type": "string" },
+        "short_name": { "type": "string" },
+        "repo_slug": { "type": "string" },
+        "domain": { "type": "string" }
+      }
+    },
+    "vision": {
+      "type": "object",
+      "required": ["north_star", "mission"],
+      "additionalProperties": true,
+      "properties": {
+        "north_star": { "type": "string" },
+        "mission": { "type": "string" }
+      }
+    },
+    "strategic_beliefs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["id", "title", "summary"],
+        "additionalProperties": true,
+        "properties": {
+          "id": { "type": "string", "pattern": "^[a-z0-9-]+$" },
+          "title": { "type": "string", "minLength": 1 },
+          "summary": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "ventures": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["id", "name", "description"],
+        "additionalProperties": true,
+        "properties": {
+          "id": { "type": "string", "pattern": "^[a-z0-9-]+$" },
+          "name": { "type": "string", "minLength": 1 },
+          "description": { "type": "string" }
+        }
+      }
+    },
+    "divisions": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["id", "name", "description"],
+          "additionalProperties": true,
+          "properties": {
+            "id": { "type": "string", "pattern": "^[a-z0-9-]+$" },
+            "name": { "type": "string", "minLength": 1 },
+            "description": { "type": "string" }
+          }
+        }
+      }
+    },
+    "toolchain": {
+      "type": "object",
+      "required": ["git_host", "ci_cd"],
+      "additionalProperties": true,
+      "properties": {
+        "git_host": {
+          "type": "string",
+          "enum": ["GitHub", "GitLab", "Bitbucket"]
+        },
+        "ci_cd": { "type": "string", "minLength": 1 }
+      }
+    },
+    "quality": {
+      "type": "object",
+      "required": ["code_coverage_minimum", "api_response_p95_ms"],
+      "additionalProperties": true,
+      "properties": {
+        "code_coverage_minimum": { "type": "integer", "minimum": 0, "maximum": 100 },
+        "api_response_p95_ms": { "type": "integer", "minimum": 1 },
+        "dashboard_load_p95_ms": { "type": "integer", "minimum": 1 },
+        "agent_tool_call_p95_ms": { "type": "integer", "minimum": 1 },
+        "accessibility_standard": { "type": "string" },
+        "deployment_rollback_target_min": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "org_size": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+    "integrations": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "products": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    }
+  }
+}

--- a/schemas/work/mission-brief.schema.json
+++ b/schemas/work/mission-brief.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/wlfghdr/agentic-enterprise/schemas/work/mission-brief.schema.json",
+  "title": "Mission Brief Work Artifact",
+  "description": "Validation schema for work/missions/**/BRIEF.md and mission-brief.md files (excluding templates).",
+  "artifact_type": "markdown",
+  "filename_pattern": "(BRIEF|mission-brief)\\.md$",
+  "required_sections": [
+    "Objective",
+    "Scope",
+    "Divisions Involved"
+  ],
+  "required_fields": [
+    {
+      "name": "Status",
+      "inline_pattern": "\\*\\*Status:\\*\\*\\s*([^|\\n]+)",
+      "allowed_values": ["proposed", "approved", "active", "paused", "completed"],
+      "required": true
+    },
+    {
+      "name": "Mission ID",
+      "inline_pattern": "\\*\\*Mission ID[:\\*]*\\*?\\s*\\|?\\s*([A-Z][^|\\n]+)",
+      "id_pattern": "^MISSION-\\d{4}-\\d{3,}",
+      "required": true
+    }
+  ]
+}

--- a/schemas/work/release-contract.schema.json
+++ b/schemas/work/release-contract.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/wlfghdr/agentic-enterprise/schemas/work/release-contract.schema.json",
+  "title": "Release Contract Work Artifact",
+  "description": "Validation schema for work/releases/*.md files (excluding templates).",
+  "artifact_type": "markdown",
+  "filename_pattern": ".*release-contract\\.md$",
+  "required_sections": [
+    "Release Summary",
+    "Changes Included",
+    "Rollback Plan"
+  ],
+  "required_fields": [
+    {
+      "name": "Status",
+      "inline_pattern": "\\*\\*Status:\\*\\*\\s*([^|\\n]+)",
+      "allowed_values": ["draft", "approved", "deploying", "deployed", "rolled-back"],
+      "required": true
+    },
+    {
+      "name": "Release ID",
+      "inline_pattern": "\\*\\*Release ID:\\*\\*\\s*([^|\\n]+)",
+      "id_pattern": "^REL-\\d{4}-\\d{3,}$",
+      "required": true
+    },
+    {
+      "name": "Release Manager",
+      "inline_pattern": "\\*\\*Release Manager:\\*\\*\\s*([^|\\n]+)",
+      "required": true
+    }
+  ]
+}

--- a/schemas/work/signal.schema.json
+++ b/schemas/work/signal.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/wlfghdr/agentic-enterprise/schemas/work/signal.schema.json",
+  "title": "Signal Work Artifact",
+  "description": "Validation schema for work/signals/*.md files (excluding templates and digests).",
+  "artifact_type": "markdown",
+  "filename_pattern": "^\\d{4}-\\d{2}-\\d{2}-.+\\.md$",
+  "required_sections": [
+    "Source",
+    "Observation",
+    "Initial Assessment",
+    "Recommended Disposition"
+  ],
+  "required_fields": [
+    {
+      "name": "Category",
+      "inline_pattern": "\\*\\*Category:\\*\\*\\s*([^|\\n]+)",
+      "allowed_values": ["market", "customer", "technical", "internal", "competitive", "financial"],
+      "required": true
+    },
+    {
+      "name": "Confidence",
+      "inline_pattern": "\\*\\*Confidence:\\*\\*\\s*([^|\\n]+)",
+      "allowed_values": ["high", "medium", "low"],
+      "required": true
+    },
+    {
+      "name": "Urgency",
+      "inline_pattern": "\\*\\*Urgency:\\*\\*\\s*([^|\\n]+)",
+      "allowed_values": ["immediate", "next-cycle", "monitor"],
+      "required": true
+    },
+    {
+      "name": "Potential impact",
+      "inline_pattern": "\\*\\*Potential impact:\\*\\*\\s*([^|\\n]+)",
+      "allowed_values": ["high", "medium", "low"],
+      "required": true
+    }
+  ]
+}

--- a/scripts/validate_schema.py
+++ b/scripts/validate_schema.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""
+Schema validation for core Agentic Enterprise framework artifacts.
+
+Validates:
+  - CONFIG.yaml             → schemas/config.schema.json       (JSON Schema)
+  - work/signals/**         → schemas/work/signal.schema.json  (custom markdown)
+  - work/missions/**/mission-brief.md  → schemas/work/mission-brief.schema.json
+  - work/releases/**        → schemas/work/release-contract.schema.json
+
+Usage:
+  python3 scripts/validate_schema.py [--strict]
+
+Exit codes:
+  0  All validations passed
+  1  One or more validation failures (schema errors)
+  2  Setup/import error (jsonschema not installed)
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+# ── Dependency check ──────────────────────────────────────────────────────────
+try:
+    import yaml
+except ImportError:
+    print("ERROR: pyyaml is required. Install with: pip install pyyaml", file=sys.stderr)
+    sys.exit(2)
+
+try:
+    import jsonschema
+    from jsonschema import validate, ValidationError, SchemaError
+except ImportError:
+    print("ERROR: jsonschema is required. Install with: pip install jsonschema", file=sys.stderr)
+    sys.exit(2)
+
+# ── Repo root ─────────────────────────────────────────────────────────────────
+REPO = Path(__file__).parent.parent.resolve()
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def load_json(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def load_yaml(path: Path) -> object:
+    with path.open("r", encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+def _strip_value(raw: str) -> str:
+    """Strip trailing whitespace, inline comments and `_` emphasis chars."""
+    value = raw.strip()
+    # Remove trailing markdown italic wrapper: e.g. "true _(...)"
+    value = re.sub(r"\s+_\(.*$", "", value)
+    return value.strip()
+
+
+# ── CONFIG.yaml validation (JSON Schema) ─────────────────────────────────────
+
+
+def validate_config(schema_path: Path, config_path: Path) -> list[str]:
+    """Validate CONFIG.yaml against its JSON Schema. Returns list of error messages."""
+    errors: list[str] = []
+    schema = load_json(schema_path)
+
+    try:
+        instance = load_yaml(config_path)
+    except yaml.YAMLError as exc:
+        return [f"CONFIG.yaml: YAML parse error — {exc}"]
+
+    if instance is None:
+        return ["CONFIG.yaml: file is empty"]
+
+    try:
+        validate(instance=instance, schema=schema)
+    except ValidationError as exc:
+        path_str = " → ".join(str(p) for p in exc.absolute_path) or "(root)"
+        errors.append(f"CONFIG.yaml [{path_str}]: {exc.message}")
+    except SchemaError as exc:
+        errors.append(f"Schema error in {schema_path.name}: {exc.message}")
+
+    return errors
+
+
+# ── Markdown work-artifact validation ─────────────────────────────────────────
+
+
+def get_sections(text: str) -> set[str]:
+    """Return the set of second-level heading titles (## ...) found in markdown text."""
+    return {m.group(1).strip() for m in re.finditer(r"^##\s+(.+)", text, re.MULTILINE)}
+
+
+def validate_markdown_artifact(path: Path, schema: dict) -> list[str]:
+    """Validate a single markdown artifact file against a custom markdown schema."""
+    errors: list[str] = []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [f"{path}: cannot read file — {exc}"]
+
+    rel = path.relative_to(REPO)
+
+    # ── Filename pattern ───────────────────────────────────────────────────
+    filename_pattern = schema.get("filename_pattern")
+    if filename_pattern and not re.search(filename_pattern, path.name):
+        errors.append(
+            f"{rel}: filename '{path.name}' does not match expected pattern '{filename_pattern}'"
+        )
+
+    # ── Required sections ──────────────────────────────────────────────────
+    present_sections = get_sections(text)
+    for section in schema.get("required_sections", []):
+        if section not in present_sections:
+            errors.append(f"{rel}: missing required section '## {section}'")
+
+    # ── Required fields ────────────────────────────────────────────────────
+    for field_def in schema.get("required_fields", []):
+        name = field_def["name"]
+        pattern = field_def["inline_pattern"]
+        required = field_def.get("required", True)
+
+        match = re.search(pattern, text, re.IGNORECASE)
+        if not match:
+            if required:
+                errors.append(f"{rel}: missing required field '**{name}:**'")
+            continue
+
+        raw_value = match.group(1) if match.lastindex else ""
+        value = _strip_value(raw_value)
+
+        # Skip unfilled template placeholders like [text] or YYYY-MM-DD
+        if value.startswith("[") or value.startswith("YYYY") or value == "":
+            # Unfilled template field — only warn if strictly required
+            # (templates themselves are excluded from scanning, so this
+            #  indicates an actual artifact was left unfilled)
+            errors.append(
+                f"{rel}: field '**{name}:**' appears unfilled (value: '{value}')"
+            )
+            continue
+
+        # Enum check
+        allowed = field_def.get("allowed_values")
+        if allowed and value.lower() not in [v.lower() for v in allowed]:
+            errors.append(
+                f"{rel}: field '**{name}:**' has invalid value '{value}' "
+                f"(expected one of: {', '.join(allowed)})"
+            )
+
+        # ID pattern check
+        id_pattern = field_def.get("id_pattern")
+        if id_pattern and not re.match(id_pattern, value, re.IGNORECASE):
+            errors.append(
+                f"{rel}: field '**{name}:**' value '{value}' does not match "
+                f"expected pattern '{id_pattern}'"
+            )
+
+    return errors
+
+
+# ── File discovery ────────────────────────────────────────────────────────────
+
+def is_template(path: Path) -> bool:
+    return "_TEMPLATE" in path.name or "stale.yml" in path.name
+
+
+def discover_signals() -> list[Path]:
+    """Find non-template signal markdown files (top-level in work/signals/, not in digests/)."""
+    signals_dir = REPO / "work" / "signals"
+    if not signals_dir.exists():
+        return []
+    return [
+        p for p in signals_dir.glob("*.md")
+        if p.is_file() and not is_template(p) and p.name != "README.md"
+    ]
+
+
+def discover_mission_briefs() -> list[Path]:
+    """Find BRIEF.md / mission-brief.md files in work/missions/ subdirectories."""
+    missions_dir = REPO / "work" / "missions"
+    if not missions_dir.exists():
+        return []
+    results = []
+    for pattern in ("BRIEF.md", "mission-brief.md"):
+        results.extend(
+            p for p in missions_dir.rglob(pattern)
+            if p.is_file() and not is_template(p)
+        )
+    return results
+
+
+def discover_release_contracts() -> list[Path]:
+    """Find release-contract.md files in work/releases/."""
+    releases_dir = REPO / "work" / "releases"
+    if not releases_dir.exists():
+        return []
+    return [
+        p for p in releases_dir.glob("*.md")
+        if p.is_file()
+        and not is_template(p)
+        and p.name != "README.md"
+        and "release-contract" in p.name
+    ]
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+
+def main() -> int:
+    all_errors: list[str] = []
+    all_ok: list[str] = []
+
+    # ── 1. CONFIG.yaml ─────────────────────────────────────────────────────
+    config_schema_path = REPO / "schemas" / "config.schema.json"
+    config_path = REPO / "CONFIG.yaml"
+
+    if not config_schema_path.exists():
+        all_errors.append(f"Schema file missing: {config_schema_path.relative_to(REPO)}")
+    elif not config_path.exists():
+        all_errors.append("CONFIG.yaml not found at repository root")
+    else:
+        errs = validate_config(config_schema_path, config_path)
+        if errs:
+            all_errors.extend(errs)
+        else:
+            all_ok.append("CONFIG.yaml")
+
+    # ── 2. Signal artifacts ────────────────────────────────────────────────
+    signal_schema_path = REPO / "schemas" / "work" / "signal.schema.json"
+    if signal_schema_path.exists():
+        signal_schema = load_json(signal_schema_path)
+        signal_files = discover_signals()
+        if not signal_files:
+            print("INFO: No non-template signal files found — skipping signal validation.")
+        for f in signal_files:
+            errs = validate_markdown_artifact(f, signal_schema)
+            if errs:
+                all_errors.extend(errs)
+            else:
+                all_ok.append(str(f.relative_to(REPO)))
+    else:
+        all_errors.append(f"Schema file missing: {signal_schema_path.relative_to(REPO)}")
+
+    # ── 3. Mission briefs ──────────────────────────────────────────────────
+    mission_schema_path = REPO / "schemas" / "work" / "mission-brief.schema.json"
+    if mission_schema_path.exists():
+        mission_schema = load_json(mission_schema_path)
+        mission_files = discover_mission_briefs()
+        if not mission_files:
+            print("INFO: No non-template mission-brief files found — skipping mission validation.")
+        for f in mission_files:
+            errs = validate_markdown_artifact(f, mission_schema)
+            if errs:
+                all_errors.extend(errs)
+            else:
+                all_ok.append(str(f.relative_to(REPO)))
+    else:
+        all_errors.append(f"Schema file missing: {mission_schema_path.relative_to(REPO)}")
+
+    # ── 4. Release contracts ───────────────────────────────────────────────
+    release_schema_path = REPO / "schemas" / "work" / "release-contract.schema.json"
+    if release_schema_path.exists():
+        release_schema = load_json(release_schema_path)
+        release_files = discover_release_contracts()
+        if not release_files:
+            print("INFO: No non-template release-contract files found — skipping release validation.")
+        for f in release_files:
+            errs = validate_markdown_artifact(f, release_schema)
+            if errs:
+                all_errors.extend(errs)
+            else:
+                all_ok.append(str(f.relative_to(REPO)))
+    else:
+        all_errors.append(f"Schema file missing: {release_schema_path.relative_to(REPO)}")
+
+    # ── Report ──────────────────────────────────────────────────────────────
+    for ok in all_ok:
+        print(f"  ✓  {ok}")
+
+    if all_errors:
+        print(f"\n{len(all_errors)} schema validation error(s):")
+        for err in all_errors:
+            print(f"  ✗  {err}")
+        print(
+            "\nSee schemas/ for definitions and docs/SCHEMA-GUIDE.md for contribution guidelines."
+        )
+        return 1
+
+    total = len(all_ok)
+    print(f"\nSchema validation passed ({total} artifact(s) checked).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Fixes #27 — adds schema validation for `CONFIG.yaml` and core work artifacts.

### What was added

**Schemas** (`schemas/`):
- `config.schema.json` — JSON Schema (draft-07) for `CONFIG.yaml`; validates required top-level keys (`framework_version`, `company`, `vision`, `strategic_beliefs`, `ventures`, `divisions`, `toolchain`, `quality`), field types, and enum values.
- `work/signal.schema.json` — Custom markdown schema for `work/signals/*.md`; validates required sections (`Source`, `Observation`, `Initial Assessment`, `Recommended Disposition`) and field enums (`Category`, `Confidence`, `Urgency`, `Potential impact`).
- `work/mission-brief.schema.json` — Custom markdown schema for `work/missions/**/BRIEF.md`; validates `Status`, `Mission ID` format, and required sections.
- `work/release-contract.schema.json` — Custom markdown schema for `work/releases/*release-contract*.md`; validates `Status`, `Release ID` format, and required sections.

**Validation script** (`scripts/validate_schema.py`):
- Validates `CONFIG.yaml` via `jsonschema`
- Validates non-template work artifact markdown files against their custom schemas
- Prints clear `✓ / ✗` output and exits non-zero on any violation

**CI** (`.github/workflows/validate.yml`):
- Adds `validate-schema` job: installs `pyyaml` + `jsonschema`, runs `python3 scripts/validate_schema.py`

**Documentation**:
- `schemas/README.md` — quick reference table
- `docs/SCHEMA-GUIDE.md` — full contribution guide (schema locations, how to add/update schemas, how to run locally)

### Acceptance criteria coverage

| Criterion | Status |
|---|---|
| Define schemas for CONFIG.yaml | ✅ `schemas/config.schema.json` |
| Define schemas for ≥1 core work artifact type | ✅ signal, mission-brief, release-contract |
| Add CI validation step | ✅ `validate-schema` job |
| Document schema locations and contribution workflow | ✅ `docs/SCHEMA-GUIDE.md` |