### PR TITLE
feat(ci): enforce locking/exclusive paths via CI gate (fix #24)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -485,6 +485,26 @@ jobs:
         run: |
           python3 scripts/check_github_governance.py
 
+  validate-locks:
+    name: Enforce Path Locks
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Check protected paths have active locks
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+        run: python3 scripts/check_locks.py
+
   validate-schema:
     name: Validate Schemas
     runs-on: ubuntu-latest

--- a/docs/LOCK-ENFORCEMENT.md
+++ b/docs/LOCK-ENFORCEMENT.md
@@ -1,0 +1,54 @@
+# Lock Enforcement CI Gate
+
+> **Version:** 1.0 | **Last updated:** 2025-07-22
+
+## Overview
+
+A CI job (`validate-locks`) blocks PRs that modify **protected paths** without a corresponding active lock file in `work/locks/`.
+
+## How It Works
+
+1. The job diffs the PR against the base branch to find changed files.
+2. Each changed file is matched against glob patterns in **`locks.yaml`** (repo root).
+3. If a file matches a protected pattern, the job checks `work/locks/*.md` for an active (non-expired) lock whose **Target** covers the file.
+4. If no lock is found, the job fails with an actionable error message.
+
+## Protected Paths (default)
+
+Defined in `locks.yaml`:
+
+| Pattern | What it protects |
+|---|---|
+| `COMPANY.md` | Company identity |
+| `OPERATING-MODEL.md` | Operating model |
+| `AGENTS.md` | Agent framework |
+| `CONFIG.yaml` | Global configuration |
+| `org/4-quality/policies/*.md` | Quality policies |
+| `**/[_]TEMPLATE-*.md` | Global templates |
+| `locks.yaml` | The lock config itself |
+
+To add a new protected path, edit `locks.yaml` and open a PR (which itself requires a lock on `locks.yaml`).
+
+## Creating a Lock
+
+1. Copy `work/locks/_TEMPLATE-lock.md` to `work/locks/<lock-id>.md`
+2. Fill in **Target**, **Owner**, **Reason**, **Expires**
+3. The **Target** field must be an exact path or glob matching the file(s) you plan to change
+4. Merge the lock (or include it in the first commit of your PR)
+
+See `work/locks/README.md` for the full protocol.
+
+## Exceptions
+
+Add `ci:lock-exempt` anywhere in a commit message to bypass enforcement for that PR. Use sparingly — this is for emergencies.
+
+## Extending
+
+- Edit `locks.yaml` to add/remove protected patterns
+- The script (`scripts/check_locks.py`) uses only Python stdlib — no extra dependencies
+
+## Changelog
+
+| Version | Date | Change |
+|---|---|---|
+| 1.0 | 2025-07-22 | Initial CI gate |

--- a/locks.yaml
+++ b/locks.yaml
@@ -1,0 +1,22 @@
+# locks.yaml — Protected paths requiring a lock before modification
+# See docs/LOCK-ENFORCEMENT.md for details.
+#
+# Each entry defines a glob pattern. Any PR that modifies files matching
+# a protected pattern must have a corresponding lock file in work/locks/
+# OR an inline exception (ci:lock-exempt in the commit message).
+
+protected_paths:
+  # Core operating model & identity
+  - "COMPANY.md"
+  - "OPERATING-MODEL.md"
+  - "AGENTS.md"
+  - "CONFIG.yaml"
+
+  # Quality policies
+  - "org/4-quality/policies/*.md"
+
+  # Global templates (cross-cutting changes)
+  - "**/[_]TEMPLATE-*.md"
+
+  # Lock convention itself (meta-protection)
+  - "locks.yaml"

--- a/scripts/check_locks.py
+++ b/scripts/check_locks.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""CI gate: enforce locking for protected paths.
+
+Checks that every file changed in a PR that matches a protected-path glob
+has a corresponding active (non-expired) lock in work/locks/.
+
+Exit codes:
+  0 — no violations
+  1 — violations found (CI should block)
+
+Environment variables:
+  BASE  — base commit SHA (required for diff)
+  HEAD  — head commit SHA (required for diff)
+"""
+
+import fnmatch
+import os
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO = Path(".")
+LOCKS_DIR = REPO / "work" / "locks"
+CONFIG_PATH = REPO / "locks.yaml"
+EXEMPT_MARKER = "ci:lock-exempt"
+
+
+def load_protected_paths() -> list[str]:
+    """Parse locks.yaml without external deps (no PyYAML required)."""
+    text = CONFIG_PATH.read_text(encoding="utf-8")
+    patterns: list[str] = []
+    in_list = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("protected_paths:"):
+            in_list = True
+            continue
+        if in_list:
+            if stripped.startswith("- "):
+                value = stripped[2:].strip().strip('"').strip("'")
+                if value and not value.startswith("#"):
+                    patterns.append(value)
+            elif stripped == "" or stripped.startswith("#"):
+                continue
+            else:
+                break  # next top-level key
+    return patterns
+
+
+def get_changed_files(base: str, head: str) -> list[str]:
+    result = subprocess.run(
+        ["git", "diff", "--name-only", "--diff-filter=ACMR", base, head],
+        capture_output=True, text=True,
+    )
+    return [f.strip() for f in result.stdout.splitlines() if f.strip()]
+
+
+def matches_any(filepath: str, patterns: list[str]) -> bool:
+    """Check if filepath matches any glob pattern."""
+    for pat in patterns:
+        if fnmatch.fnmatch(filepath, pat):
+            return True
+        # For patterns without directory separators, also match basename
+        if "/" not in pat and fnmatch.fnmatch(Path(filepath).name, pat):
+            return True
+    return False
+
+
+def parse_lock_target(lock_path: Path) -> str | None:
+    """Extract Target path from a lock file."""
+    text = lock_path.read_text(encoding="utf-8")
+    m = re.search(r"\*\*Target:\*\*\s*`([^`]+)`", text)
+    return m.group(1) if m else None
+
+
+def parse_lock_expires(lock_path: Path) -> datetime | None:
+    """Extract Expires timestamp from a lock file."""
+    text = lock_path.read_text(encoding="utf-8")
+    m = re.search(r"\*\*Expires:\*\*\s*(\S+)", text)
+    if not m:
+        return None
+    raw = m.group(1)
+    for fmt in ("%Y-%m-%dT%H:%M:%SZ", "%Y-%m-%dT%H:%M:%S%z", "%Y-%m-%d"):
+        try:
+            dt = datetime.strptime(raw, fmt)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt
+        except ValueError:
+            continue
+    return None
+
+
+def get_active_locks() -> dict[str, Path]:
+    """Return {target_path: lock_file} for all non-expired locks."""
+    locks: dict[str, Path] = {}
+    if not LOCKS_DIR.is_dir():
+        return locks
+
+    now = datetime.now(timezone.utc)
+    for lf in LOCKS_DIR.glob("*.md"):
+        if lf.name.startswith("_TEMPLATE"):
+            continue
+        if lf.name == "README.md":
+            continue
+        target = parse_lock_target(lf)
+        if not target:
+            continue
+        expires = parse_lock_expires(lf)
+        if expires and expires < now:
+            continue  # expired
+        locks[target] = lf
+    return locks
+
+
+def file_covered_by_lock(filepath: str, locks: dict[str, Path]) -> bool:
+    """Check if a file is covered by any active lock target (exact or glob)."""
+    for target in locks:
+        if fnmatch.fnmatch(filepath, target):
+            return True
+        if filepath == target:
+            return True
+        # Lock target may be a directory — check prefix
+        if filepath.startswith(target.rstrip("/") + "/"):
+            return True
+    return False
+
+
+def commit_has_exempt(base: str, head: str) -> bool:
+    """Check if any commit in the range has the exempt marker."""
+    result = subprocess.run(
+        ["git", "log", "--format=%B", f"{base}..{head}"],
+        capture_output=True, text=True,
+    )
+    return EXEMPT_MARKER in result.stdout
+
+
+def main() -> int:
+    base = os.environ.get("BASE", "").strip()
+    head = os.environ.get("HEAD", "").strip()
+
+    if not base:
+        print("No BASE SHA — skipping lock enforcement (initial push).")
+        return 0
+
+    if not CONFIG_PATH.exists():
+        print("locks.yaml not found — skipping lock enforcement.")
+        return 0
+
+    patterns = load_protected_paths()
+    if not patterns:
+        print("No protected paths defined — nothing to enforce.")
+        return 0
+
+    changed = get_changed_files(base, head)
+    protected_changed = [f for f in changed if matches_any(f, patterns)]
+
+    if not protected_changed:
+        print(f"No protected paths touched among {len(changed)} changed files. ✓")
+        return 0
+
+    # Check for blanket exemption
+    if commit_has_exempt(base, head):
+        print(f"Found '{EXEMPT_MARKER}' in commit messages — skipping enforcement for {len(protected_changed)} file(s).")
+        return 0
+
+    # Check locks
+    locks = get_active_locks()
+    violations: list[str] = []
+
+    for f in protected_changed:
+        if not file_covered_by_lock(f, locks):
+            violations.append(f)
+
+    if not violations:
+        print(f"All {len(protected_changed)} protected file(s) have active locks. ✓")
+        return 0
+
+    print("╔══════════════════════════════════════════════════════╗")
+    print("║  LOCK ENFORCEMENT FAILED                            ║")
+    print("╚══════════════════════════════════════════════════════╝")
+    print()
+    print(f"  {len(violations)} protected file(s) changed without an active lock:\n")
+    for v in violations:
+        print(f"    ✗ {v}")
+    print()
+    print("  To fix, either:")
+    print("    1. Create a lock file in work/locks/ covering the target path")
+    print("       (see work/locks/README.md and work/locks/_TEMPLATE-lock.md)")
+    print("    2. Add 'ci:lock-exempt' to a commit message for an exception")
+    print()
+    print(f"  Protected path patterns (from locks.yaml): {patterns}")
+    print(f"  Active locks found: {len(locks)}")
+    for target, lf in locks.items():
+        print(f"    • {target} → {lf}")
+    print()
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes #24 — adds a CI gate that enforces the existing locking convention in `work/locks/`.

### What changed

- **`locks.yaml`** (repo root) — declares protected path patterns (globs)
- **`scripts/check_locks.py`** — stdlib-only Python script that:
  - Diffs PR changed files against base
  - Matches changed files against protected patterns
  - Verifies an active (non-expired) lock file exists in `work/locks/` with a matching Target
  - Provides actionable error messages on failure
- **`.github/workflows/validate.yml`** — new `validate-locks` job (blocking, PR-only)
- **`docs/LOCK-ENFORCEMENT.md`** — explains protected paths, how to create locks, and the `ci:lock-exempt` escape hatch

### How it works

1. PR touches `COMPANY.md` → CI checks `work/locks/` for a lock with `Target: COMPANY.md`
2. No active lock → CI fails with clear instructions
3. Emergency bypass: add `ci:lock-exempt` to any commit message

### Protected paths (default)

- `COMPANY.md`, `OPERATING-MODEL.md`, `AGENTS.md`, `CONFIG.yaml`
- `org/4-quality/policies/*.md`
- `**/[_]TEMPLATE-*.md`
- `locks.yaml` (meta-protection)