### PR TITLE
feat: Rule 12 — Deduplicate before acting + Rule 13a upstream-first workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Agent Instructions (Global)
 
-> **Version:** 2.1 | **Last updated:** 2026-02-25
+> **Version:** 2.2 | **Last updated:** 2026-03-05
 
 > **Scope:** Every AI agent working in this repository — regardless of layer, role, or task — must follow these instructions.
 > **This file is the top of the instruction hierarchy.** Layer-specific and division-specific instructions extend (never contradict) these rules.
@@ -158,18 +158,38 @@ When working on an **instance**, the completion gate is human review:
 
 **Why this matters:** Framework changes affect every agent and every future instance derived from the template. A regression in a template propagates silently until someone notices. The push-and-verify discipline plus the CI gate exist to catch problems before they reach the entire operating model.
 
-### 12. Participate in the framework ecosystem
+### 12. Deduplicate before acting
+
+Multi-agent systems are prone to duplicate work — multiple agents independently creating issues, PRs, or artifacts for the same problem. This wastes effort, creates merge conflicts, and obscures the audit trail.
+
+**Before creating any work artifact, PR, or issue:**
+1. **Search for existing work** — check open PRs, issues, active missions, in-progress tasks, and recent commits that address the same topic. Use Git history, issue trackers, and `work/missions/*/TASKS.md` as sources.
+2. **Check task ownership** — if a TASKS.md exists for the mission, verify whether someone (human or agent) already has the task `in-progress`. If so, do not create parallel work — coordinate or wait.
+3. **Check signal deduplication** — before filing a new signal, search `work/signals/` for existing signals covering the same observation. Use the `Supersedes` field if your signal replaces an older one; link as `Related Signals` if it's additive.
+4. **Link, don't duplicate** — if a PR or issue already exists that addresses the problem, reference it rather than creating a new one. Add context to the existing artifact if needed.
+
+**When you discover you've created duplicate work:**
+- Close or withdraw the duplicate immediately with a note linking to the original
+- Do not leave duplicate PRs or issues open "just in case"
+
+**Orchestration agents** bear special responsibility: before decomposing a mission into tasks, scan for active missions with overlapping scope. Before dispatching work streams, verify no existing PR or branch already addresses the task.
+
+**Execution agents** bear special responsibility: before creating a PR, search for open PRs on the same branch prefix, touching the same files, or referencing the same task ID. Before opening an issue, search existing issues for the same topic.
+
+### 13. Participate in the framework ecosystem
 
 This operating model is derived from the [Agentic Enterprise](https://github.com/wlfghdr/agentic-enterprise) open-source framework. Every running instance is both a consumer and a potential contributor. Treat this as a two-way relationship.
 
-#### 12a. Contribute improvements back to the upstream template
+#### 13a. Contribute improvements back to the upstream template
 - When you discover a pattern, fix, policy improvement, or structural insight that is **not company-specific**, it likely benefits every adopter of the framework.
+- **Prefer upstream-first for generic changes.** When a change is identified as generic during planning (not company-specific), open the PR or issue against the upstream template repository first. Once merged upstream, adopt it into your fork via the normal adoption process (Rule 13b). This prevents drift and ensures the upstream framework is the source of truth for generic patterns.
+- **When upstream-first is not practical** (e.g., urgency, experimental change, unclear generalizability), implement locally first but immediately file an upstream issue or PR to propose the change. Do not let local-only generic changes accumulate silently — they create invisible drift.
 - **File upstream:** Open an issue or PR against the upstream template repository (`github.com/wlfghdr/agentic-enterprise`) describing the improvement. Use the framework's `CONTRIBUTING.md` guidelines.
 - What belongs upstream: bug fixes in templates, new generic agent types, policy improvements, process refinements, documentation fixes, structural patterns that generalize across companies.
 - What stays in your fork: company-specific configuration, proprietary strategies, division details, custom integrations, internal signals and missions.
 - This is a natural extension of Rule 7 (Continuously improve the company) — except the improvement target is the framework itself, not just your instance. If the improvement helps the ecosystem, share it.
 
-#### 12b. Adopt upstream template updates
+#### 13b. Adopt upstream template updates
 - The upstream framework evolves. New patterns, policies, templates, and structural improvements are released as new versions.
 - **Periodically check** for upstream changes (recommended: at least monthly, or as part of the Steering Layer's evolution cycle). Compare `CHANGELOG.md` in the upstream repo against your current framework version.
 - When relevant updates are available, **propose adoption** as a signal in `work/signals/` with source `upstream-framework`. The Steering Layer triages and decides which updates to merge.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,30 @@ _Changes merged to `main` but not yet tagged as a release go here. Move to a new
 
 ### Added
 
+**Work deduplication — Rule 12: Deduplicate before acting**
+
+> Multi-agent systems are prone to duplicate work — multiple agents independently creating issues, PRs, or artifacts for the same problem. This rule makes deduplication a first-class obligation at every layer.
+
+_Global agent rules:_
+- `AGENTS.md` Rule 12 — new non-negotiable rule: search for existing work before creating PRs, issues, branches, or signals. Close duplicates immediately.
+
+_Orchestration Layer:_
+- `org/2-orchestration/AGENT.md` — new "Work Deduplication" section: mandatory overlap scan across active missions, open PRs, and TASKS.md before decomposing or dispatching work.
+
+_Execution Layer:_
+- `org/3-execution/AGENT.md` — new "Work Deduplication" section: mandatory duplicate check before creating PRs, issues, or branches. Check `Linked PRs/Issues` field on tasks.
+
+_Templates:_
+- `work/missions/_TEMPLATE-tasks.md` — added `Linked PRs/Issues` field per task to track active PRs/issues and prevent parallel work on the same task.
+
+**Upstream contribution workflow — Rule 13a clarified: upstream-first for generic changes**
+
+> Rule 13a (formerly 12a) now explicitly recommends upstream-first workflow for generic improvements. When a change is identified as non-company-specific during planning, open the PR against the upstream repo first, then adopt downstream. Local-first is acceptable for urgent or experimental changes, but must be followed by an upstream PR to prevent invisible drift.
+
+_Note:_ Previous Rule 12 (framework ecosystem participation) is now Rule 13. References updated in `CUSTOMIZATION-GUIDE.md`.
+
+---
+
 **Observability-driven design: shift observability left into design and discovery phases**
 
 > Observability-driven AI development shifts software engineering from reactive fixes to predictive prevention by using real production data during design. Agents evaluate architecture, performance, and resilience upfront — flagging risky assumptions before coding begins.

--- a/CUSTOMIZATION-GUIDE.md
+++ b/CUSTOMIZATION-GUIDE.md
@@ -429,7 +429,7 @@ When your agents (or you) discover a pattern, fix, or improvement that is **not 
 What belongs upstream: bug fixes in templates, new generic agent types, policy refinements, structural patterns, documentation improvements.
 What stays in your fork: company identity, proprietary strategies, division details, custom integrations, internal work artifacts.
 
-**Why this matters:** Every instance that contributes back makes the framework better for all adopters. Your agents already observe friction and file improvement signals (Rule 7 in AGENTS.md) — extending that habit to the upstream framework is a natural evolution. Rule 12 in AGENTS.md instructs agents to do this automatically.
+**Why this matters:** Every instance that contributes back makes the framework better for all adopters. Your agents already observe friction and file improvement signals (Rule 7 in AGENTS.md) — extending that habit to the upstream framework is a natural evolution. Rule 13 in AGENTS.md instructs agents to do this automatically.
 
 ---
 

--- a/org/2-orchestration/AGENT.md
+++ b/org/2-orchestration/AGENT.md
@@ -3,7 +3,7 @@
 > **Role:** You are an Orchestration Layer agent. You assist Mission Leads, Agent Fleet Managers, Cross-Mission Coordinators, Release Coordinators, and Campaign Orchestrators.
 > **Layer:** Orchestration (translates strategy into executable work)
 > **Authority:** You configure, monitor, and optimize agent fleets. Humans approve mission briefs and resolve escalations.
-> **Version:** 1.4 | **Last updated:** 2026-02-25
+> **Version:** 1.5 | **Last updated:** 2026-03-05
 
 ---
 
@@ -29,6 +29,14 @@ Translate mission briefs from the Strategy Layer into executable agent fleet con
 - Identify which divisions are involved
 - Map dependencies between work streams
 - Estimate agent fleet composition
+
+### Work Deduplication (AGENTS.md Rule 12)
+Before decomposing a mission or dispatching work:
+- **Scan active missions** for overlapping scope — check `work/missions/*/BRIEF.md` for missions targeting the same deliverables, components, or objectives
+- **Scan open PRs and issues** for existing work addressing the same problem — use Git branch names, PR titles, and linked task IDs as search criteria
+- **Scan TASKS.md** across active missions for tasks with similar descriptions or targeting the same files/components
+- If overlap is found: **link rather than duplicate** — reference the existing mission/task/PR in the new mission's brief or TASKS.md, and coordinate sequencing
+- If a new mission fully overlaps with existing active work, **escalate to Strategy Layer** rather than creating parallel missions
 
 ### Task Decomposition (Divide & Conquer)
 - **Produce TASKS.md** (`work/missions/_TEMPLATE-tasks.md`) for every mission that involves Execution Layer work — this is **required** before a mission can transition to `active` status
@@ -167,6 +175,7 @@ Surface improvement signals to `work/signals/` when you observe:
 
 | Version | Date | Change |
 |---|---|---|
+| 1.5 | 2026-03-05 | Added Work Deduplication section (AGENTS.md Rule 12) — mandatory overlap scan before mission decomposition and work dispatch |
 | 1.4 | 2026-02-25 | Added observability design verification to Technical Design Gate; added observability policy assignment to Fleet Configuration |
 | 1.3 | 2026-02-25 | Added Release Preparation (Ship Loop) section with input/process/output/handoff; added Dependency Management section with deadlock detection and escalation path |
 | 1.2 | 2026-02-24 | Added Task Decomposition section (TASKS.md requirement for active missions); added `planning` and `cancelled` to status transitions; added TASKS.md to versioning table |

--- a/org/3-execution/AGENT.md
+++ b/org/3-execution/AGENT.md
@@ -3,7 +3,7 @@
 > **Role:** You are an Execution Layer agent. You produce work — code, tests, docs, content, proposals, analyses, customer deliverables — under the direction of division leads across all company functions.
 > **Layer:** Execution (where work gets done)
 > **Authority:** You implement within defined constraints. Humans own architecture decisions, key relationships, novel patterns, and critical path resolution.
-> **Version:** 1.3 | **Last updated:** 2026-02-25
+> **Version:** 1.4 | **Last updated:** 2026-03-05
 
 ---
 
@@ -32,6 +32,14 @@ Execute the work defined in mission briefs and fleet configurations. This spans 
 - Upon completion, set the task status to `completed`, link the generated assets, and check off acceptance criteria
 - If you cannot complete a task, set it to `blocked` and surface a blocker in STATUS.md — do not silently stall
 - If TASKS.md does not exist for an active mission, **file an improvement signal** — this indicates an orchestration gap (see [docs/mission-lifecycle.md](../../docs/mission-lifecycle.md))
+
+### Work Deduplication (AGENTS.md Rule 12)
+Before creating any PR, issue, or branch:
+- **Search open PRs** for existing work on the same topic — check branch names, PR titles, changed files, and linked task IDs
+- **Search open issues** for duplicates — check titles, labels, and linked missions/tasks
+- **Check TASKS.md** to verify the task is not already `in-progress` by another agent
+- **Check the `Linked PRs/Issues` field** on your task — if a PR already exists, contribute to it rather than opening a new one
+- If you discover you've created a duplicate: close it immediately with a note linking to the original, and update TASKS.md accordingly
 
 ### Technical Design Production
 For missions marked `design-required: true`:
@@ -138,6 +146,7 @@ Surface improvement signals to `work/signals/` when you observe:
 
 | Version | Date | Change |
 |---|---|---|
+| 1.4 | 2026-03-05 | Added Work Deduplication section (AGENTS.md Rule 12) — mandatory duplicate check before creating PRs, issues, or branches |
 | 1.3 | 2026-02-25 | Added observability design to Technical Design Production (instrumentation, metrics, SLOs, dashboards, alerting); added production baseline consultation and impact assessment for modified components |
 | 1.2 | 2026-02-24 | Added Task Pickup section (TASKS.md as primary work intake); added TASKS.md as first item in Context You Must Read |
 | 1.1 | 2026-02-19 | Added Versioning Your Outputs section |

--- a/work/missions/_TEMPLATE-tasks.md
+++ b/work/missions/_TEMPLATE-tasks.md
@@ -1,6 +1,6 @@
 # Tasks: [Mission Name]
 
-> **Template version:** 1.0 | **Last updated:** 2026-02-24
+> **Template version:** 1.1 | **Last updated:** 2026-03-05
 > **Mission:** [link to BRIEF.md]
 > **Mission ID:** MISSION-YYYY-NNN
 > **Revision:** 1 | **Last updated:** YYYY-MM-DD
@@ -41,6 +41,7 @@ The **Orchestrator** creates this file by decomposing the Mission Brief and Outc
 | **Depends on** | None / TASK-NNN |
 | **Priority** | critical / high / medium / low |
 | **Target date** | YYYY-MM-DD |
+| **Linked PRs/Issues** | _(Fill when work begins — prevents duplicate PRs/issues per AGENTS.md Rule 12)_ |
 
 **Description:**
 [What needs to be done. Be specific enough that the assigned agent can start without further clarification.]
@@ -64,6 +65,7 @@ The **Orchestrator** creates this file by decomposing the Mission Brief and Outc
 | **Depends on** | TASK-001 |
 | **Priority** | critical / high / medium / low |
 | **Target date** | YYYY-MM-DD |
+| **Linked PRs/Issues** | _(Fill when work begins — prevents duplicate PRs/issues per AGENTS.md Rule 12)_ |
 
 **Description:**
 [What needs to be done.]
@@ -98,4 +100,5 @@ The **Orchestrator** creates this file by decomposing the Mission Brief and Outc
 
 | Version | Date | Change |
 |---|---|---|
+| 1.1 | 2026-03-05 | Added `Linked PRs/Issues` field per task to prevent duplicate work (AGENTS.md Rule 12) |
 | 1.0 | 2026-02-24 | Initial version |


### PR DESCRIPTION
## Summary

Two framework improvements driven by operational experience in a multi-agent deployment:

### 1. New Rule 12: Deduplicate before acting

Multi-agent systems are prone to duplicate work — multiple agents independently creating issues, PRs, or artifacts for the same problem. This wastes effort, creates merge conflicts, and obscures the audit trail.

**Changes:**
- `AGENTS.md` — New Rule 12 with search-first obligations for all agents
- `org/2-orchestration/AGENT.md` — Work Deduplication section (overlap scan before mission decomposition)
- `org/3-execution/AGENT.md` — Work Deduplication section (duplicate check before PR/issue creation)
- `work/missions/_TEMPLATE-tasks.md` — New `Linked PRs/Issues` field per task

### 2. Rule 13a clarified: upstream-first for generic changes

Rule 13a (formerly 12a) now explicitly recommends **upstream-first** workflow: when a change is identified as generic during planning, open the PR upstream first, then adopt downstream. Local-first is acceptable for urgent/experimental changes but must be followed by an upstream PR.

This clarification was triggered by the observation that the dedup rule itself was initially implemented only in a fork — exactly the kind of invisible drift the rule should prevent.

### Renumbering
Previous Rule 12 (framework ecosystem) → Rule 13. Reference in CUSTOMIZATION-GUIDE.md updated.

### Version bumps
- AGENTS.md: 2.1 → 2.2
- Orchestration AGENT.md: 1.4 → 1.5
- Execution AGENT.md: 1.3 → 1.4
- TASKS.md template: 1.0 → 1.1