### PR TITLE
feat(integrations): connector pattern for MCP/A2A + side-effect governance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ _Changes merged to `main` but not yet tagged as a release go here. Move to a new
 
 ### Added
 
+**Connector pattern foundation for real system integrations (Issue #10)**
+
+_Integration architecture and governance:_
+- `docs/integrations/connector-pattern.md` — new reference pattern for MCP/A2A/business-system connectors with capability levels (L1–L4), read-only-first rollout, policy-gated side effects, and observability requirements
+- `org/integrations/README.md` — added explicit side-effect gating model (`none`/`low`/`high`) and link to connector pattern guidance
+- `org/integrations/_TEMPLATE-integration.md` — template v1.0 → v1.1: added `Access Mode`, `Side-Effect Level`, and `Approval Mode` fields; extended security/compliance and validation checklist; updated template changelog
+
 **Work deduplication — Rule 12: Deduplicate before acting**
 
 > Multi-agent systems are prone to duplicate work — multiple agents independently creating issues, PRs, or artifacts for the same problem. This rule makes deduplication a first-class obligation at every layer.

--- a/docs/integrations/connector-pattern.md
+++ b/docs/integrations/connector-pattern.md
@@ -1,0 +1,81 @@
+# Connector Pattern — MCP/A2A/Business Systems
+
+> **Version:** 1.0 | **Last updated:** 2026-03-07
+> **Scope:** External system integrations for agentic-enterprise adopters
+
+## Purpose
+
+This pattern defines a safe, auditable way to connect agents to real enterprise systems
+(Jira, ServiceNow, CRM, CI/CD, observability, communication platforms) using open protocols
+and governed activation.
+
+## Design Principles
+
+1. **Registry-first, never ad-hoc**
+   - Every connector must be registered in `org/integrations/` and `CONFIG.yaml`.
+2. **Read-only first**
+   - New connectors begin in read-only mode before any side effects are allowed.
+3. **Policy-gated side effects**
+   - Write/update/delete actions require explicit policy mapping and approval mode.
+4. **Observable by default**
+   - Every connector call emits telemetry with actor, target system, operation, and outcome.
+5. **Human escalation path**
+   - High-impact actions must support approve/reject/escalate decisions.
+
+## Reference Architecture
+
+```text
+Agent Runtime
+  ├─ Connector Adapter (MCP or A2A client/server)
+  ├─ Policy Guard (allow/deny/escalate)
+  ├─ Secret Provider (token retrieval only, no inline secrets)
+  └─ Telemetry Emitter (OTel spans/events)
+         │
+         ▼
+External Systems (Jira / ServiceNow / CRM / CI/CD / Messaging / etc.)
+```
+
+## Pattern Selection
+
+| Pattern | Best for | Notes |
+|---|---|---|
+| MCP | Tool-like access from agents to external systems | Preferred default for agent tool interfaces |
+| A2A | Agent-to-agent delegation between systems | Use when responsibility crosses system boundaries |
+| Native API/Webhook | Legacy systems without MCP/A2A support | Wrap behind connector adapter + policy guard |
+
+## Connector Capability Levels
+
+| Level | Capability | Allowed operations | Approval |
+|---|---|---|---|
+| L1 | Observe | Read/list/query only | Not required |
+| L2 | Assist | Draft/propose actions, no execution | Optional |
+| L3 | Act (bounded) | Approved writes in scoped resources | Required |
+| L4 | Act (privileged) | Cross-system or destructive actions | Mandatory human approval |
+
+## Security & Governance Requirements
+
+A connector is eligible for activation only if it defines:
+
+- authentication model (OAuth/service account/API key + rotation owner)
+- data classification for payloads and responses
+- side-effect level (`none`, `low`, `high`)
+- failure behavior (fail-closed vs degraded read-only)
+- audit trail fields (who/what/when/result)
+- quality policy mapping in `org/4-quality/policies/`
+
+## Minimal Delivery Sequence (recommended)
+
+1. **Foundation:** register connector + architecture/security metadata
+2. **Read-only rollout:** enable L1/L2 capabilities and validate observability
+3. **Controlled writes:** enable selected L3 actions with explicit approvals
+4. **Privileged actions:** enable L4 only after policy and risk review
+
+## Starter Connector Backlog (read-only)
+
+- Jira: issue read/search
+- ServiceNow: incident read/search
+- GitHub: issue/PR read
+- CRM: account/opportunity read
+- Observability: dashboards/query read
+
+These can be implemented incrementally without introducing external side effects.

--- a/org/integrations/README.md
+++ b/org/integrations/README.md
@@ -72,6 +72,9 @@ Each integration entry defines:
 - **How it connects** — MCP, API, webhook, data export, OpenTelemetry
 - **What it enables** — which layers, loops, and agent types benefit
 - **Governance** — who approves activation, what data flows, what policies apply
+- **Risk posture** — read-only vs side-effecting behavior, approval mode, and audit requirements
+
+See also: [`docs/integrations/connector-pattern.md`](../../docs/integrations/connector-pattern.md) for the reference connector architecture and rollout model.
 
 ---
 
@@ -106,3 +109,13 @@ As agent fleets grow, filesystem-based governance alone cannot provide the real-
 ### 5. Open standards preferred, proprietary supported
 
 Prefer OpenTelemetry for telemetry, MCP for tool connections, and open APIs for data exchange. But real enterprises use proprietary platforms — and that's fine. The registry supports both.
+
+### 6. Side effects are gated
+
+Integrations that can mutate external systems (create/update/delete) must declare their side-effect level and approval mode before activation:
+
+- **none** — read-only operations
+- **low** — bounded writes with operational approval
+- **high** — privileged or destructive actions requiring explicit human approval
+
+This keeps the default rollout path safe (`read-only first`) while enabling controlled operational automation over time.

--- a/org/integrations/_TEMPLATE-integration.md
+++ b/org/integrations/_TEMPLATE-integration.md
@@ -1,6 +1,6 @@
 # Integration Registration: {{INTEGRATION_NAME}}
 
-> **Template version:** 1.0 | **Last updated:** 2026-02-19
+> **Template version:** 1.1 | **Last updated:** 2026-03-07
 > **Status:** `proposed` | `active` | `deprecated`
 > **Category:** `observability` | `enterprise-toolchain` | `business-system` | `communication`
 > **Owner:** {{APPROVING_LAYER}} Layer
@@ -16,6 +16,9 @@
 | **Vendor / Project** | {{VENDOR_OR_PROJECT}} |
 | **Category** | {{CATEGORY}} |
 | **Connection Pattern** | MCP Server / API / Webhook / Data Export / OpenTelemetry |
+| **Access Mode** | Read-only / Read-write |
+| **Side-Effect Level** | none / low / high |
+| **Approval Mode** | auto / operational-approval / human-approval |
 | **Layers Affected** | Steering / Strategy / Orchestration / Execution / Quality |
 | **Loops Affected** | Discover / Build / Ship / Operate |
 
@@ -87,6 +90,9 @@ Outbound:  Operating model → External system (actions, updates, notifications)
 - **Data classification:** What data flows through this integration?
 - **Retention:** What retention policies apply?
 - **Audit:** How is usage logged and auditable?
+- **Access mode:** Read-only or read-write?
+- **Side-effect level:** none / low / high
+- **Approval mode:** auto / operational-approval / human-approval
 - **Policy references:** Which quality policies apply?
   - [ ] `org/4-quality/policies/security.md`
   - [ ] `org/4-quality/policies/delivery.md`
@@ -121,6 +127,8 @@ integrations:
 - [ ] Security review completed
 - [ ] Data governance review completed (if required)
 - [ ] Connection tested and documented
+- [ ] Access mode and side-effect level declared
+- [ ] Approval mode declared for side-effecting operations
 - [ ] Failure mode and fallback defined
 - [ ] Affected agent types updated with integration awareness
 - [ ] Quality policies reviewed for compliance
@@ -130,4 +138,5 @@ integrations:
 
 | Version | Date | Change |
 |---|---|---|
+| 1.1 | 2026-03-07 | Added access mode, side-effect level, and approval mode governance fields/checks |
 | 1.0 | 2026-02-19 | Initial version |


### PR DESCRIPTION
## Summary
Implements the first concrete slice of roadmap issue #10 by adding a governed connector pattern for real enterprise systems (MCP/A2A/business systems).

### What’s included
- New guide: `docs/integrations/connector-pattern.md`
  - MCP vs A2A usage guidance
  - Connector capability levels (L1-L4)
  - Read-only-first rollout model
  - Side-effect gating and observability requirements
- `org/integrations/README.md` updates
  - Explicit side-effect gating model (`none`/`low`/`high`)
  - Link to connector pattern guide
- `org/integrations/_TEMPLATE-integration.md` v1.1
  - Added governance fields: Access Mode, Side-Effect Level, Approval Mode
  - Extended Security/Compliance and validation checklist
  - Added template changelog entry
- `CHANGELOG.md` entry under Unreleased

## Why this helps
This establishes a safe baseline for integrating real systems without jumping directly into write-capable automations. It keeps rollout incremental and auditable.

## Follow-ups (next PRs)
1. Add side-effect policy checks in quality policies
2. Add read-only starter connector specs (Jira/ServiceNow/GitHub/CRM)

Refs #10
