### PR TITLE
docs: Archive Policy + AGENTS.md Rule 14 (work artifact lifecycle)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,6 +196,29 @@ This operating model is derived from the [Agentic Enterprise](https://github.com
 - Never blindly merge upstream — evaluate each change against your company's customizations and policies. Some updates may conflict with deliberate local choices.
 - **Version tracking:** Record your current upstream framework version in `CONFIG.yaml → framework_version`. This makes it easy to see how far behind (or ahead) your instance is.
 
+### 14. Archive completed work — keep active directories clean
+
+Work directories accumulate artifacts over time. Without active archiving, agents waste time scanning irrelevant closed items, and active work becomes hard to find.
+
+**Policy:** Every `work/<area>/` directory has an `archive/` subfolder. Completed, closed, or superseded items move there. Full details in `docs/ARCHIVE-POLICY.md`.
+
+**When to archive:**
+- Signals: status = `done` or `upstream-issued` + action confirmed
+- Missions: STATUS.md says `closed`, `completed`, or `consolidated` → archive **entire folder**
+- Triage records: corresponding signal was archived
+- Reports: older than 30 days
+- Run logs: monthly rotation (if applicable)
+
+**How:**
+- Use `git mv` (preserves blame) or an automation script
+- **Never delete** work artifacts — always archive (git history = audit trail)
+- Templates (`_TEMPLATE-*`) and README.md files are never archived
+
+**Agent responsibility:**
+- **After closing a mission or completing a signal**: archive it in the same PR/commit
+- **Orchestration agents**: periodically scan for archivable items and archive them
+- **All agents**: when scanning `work/missions/` or `work/signals/`, ignore the `archive/` subfolder — only active items live in the parent directory
+
 ## Repository Structure (Quick Reference)
 
 ```

--- a/docs/ARCHIVE-POLICY.md
+++ b/docs/ARCHIVE-POLICY.md
@@ -1,0 +1,72 @@
+# Archive Policy (Work Artifact Lifecycle)
+
+All `work/` directories follow the same lifecycle: **active → done → archived**.
+
+Archiving keeps active directories clean and scannable while preserving full history in git.
+
+## Archive Mechanics
+
+Every `work/<area>/` directory may contain an `archive/` subfolder. When items reach a terminal state, they move there.
+
+```
+work/
+  signals/
+    archive/          ← closed/actioned signals
+  signals/triage/
+    archive/          ← triage records for archived signals
+  missions/
+    archive/          ← closed/completed/consolidated missions (entire folder)
+  reports/
+    archive/          ← old daily/weekly reports
+  research/
+    archive/          ← superseded research digests
+  retrospectives/
+    archive/          ← past retros (keep recent 2)
+  decisions/
+    archive/          ← implemented/superseded decisions
+  designs/
+    archive/          ← superseded design docs
+```
+
+## When to Archive
+
+| Area | Archive trigger |
+|------|----------------|
+| **signals** | Signal status = `done` or `upstream-issued` + action confirmed |
+| **signals/triage** | Corresponding signal archived |
+| **missions** | STATUS.md says `closed`, `completed`, or `consolidated` |
+| **reports** | Older than 30 days (configurable) |
+| **research** | Digest superseded by newer cycle |
+| **retrospectives** | Keep only most recent 2 |
+| **decisions** | Decision implemented + referenced in mission/PR |
+| **designs** | Design superseded by newer version or implementation complete |
+
+## How to Archive
+
+**Option A: git mv** (preferred — preserves blame)
+```bash
+git mv work/signals/my-signal.md work/signals/archive/
+git mv work/missions/old-mission/ work/missions/archive/
+```
+
+**Option B: automation script** (if provided by your instance)
+```bash
+./scripts/archive_work.sh          # archives all eligible items
+./scripts/archive_work.sh --dry-run  # preview only
+```
+
+## Rules
+
+1. **Never delete** work artifacts from the repo — always archive (git history = audit trail)
+2. **Archive entire mission folders** (not individual files inside a mission)
+3. **Templates** (`_TEMPLATE-*`) are never archived
+4. **Active/parked items** stay in place — only done/closed/completed items move
+5. **README.md** files in each directory stay (never archived)
+6. **Agents ignore `archive/`** — when scanning active work, skip the archive subfolder
+
+## Agent Integration
+
+This policy is referenced in AGENTS.md Rule 14. All agents should:
+- Archive items they close (in the same commit/PR)
+- Orchestration agents: periodically scan for archivable items
+- Never scan `archive/` subfolders when looking for active work


### PR DESCRIPTION
## What

Adds a consistent archive pattern for all `work/` directories in the template.

### New: `docs/ARCHIVE-POLICY.md`
- Defines when/how to archive each artifact type (signals, missions, triage, reports, research, decisions, designs)
- 'Never delete, always archive' principle — git history as audit trail
- Clear triggers per area type
- Agent integration guidance

### Updated: `AGENTS.md` — new Rule 14
- References the archive policy
- Mandates agents archive items they close
- Orchestration agents scan periodically
- All agents skip `archive/` subfolders when scanning active work

## Why

Without a lifecycle policy, `work/` directories accumulate closed/completed items indefinitely. This makes it harder for agents (and humans) to find active work, increases scan time, and creates cognitive noise.

## Impact

- Template adopters get a clean work directory pattern out of the box
- Agents have clear instructions on when and how to archive
- No breaking changes — archive folders are opt-in and backward compatible