### PR TITLE
chore: clean up framework taxonomy and generic agent defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,25 @@ _Changes merged to `main` but not yet tagged as a release go here. Move to a new
 
 ### Added
 
+**Framework taxonomy cleanup for generic adoption (Issue #concept-review)**
+
+_Execution divisions:_
+- `CONFIG.yaml` — bumped `framework_version` from `2.2.0` to `2.3.0`; removed `ai-intelligence` and `quality-security-engineering` from default division lists and kept them as commented optional extensions instead
+- `org/README.md` — added version metadata and reframed execution divisions into core defaults, optional extensions, and company-specific product divisions; clarified that Quality & Security Engineering should not be implied as a default standalone split
+- `CUSTOMIZATION-GUIDE.md` — updated division customization guidance so AI & Intelligence, GTM Web, and Quality & Security Engineering are treated as optional extensions rather than assumed defaults
+- `org/3-execution/divisions/engineering-foundation/DIVISION.md`, `org/3-execution/divisions/core-services/DIVISION.md`, `org/3-execution/divisions/infrastructure-operations/DIVISION.md`, `org/3-execution/divisions/legal/DIVISION.md`, `org/3-execution/divisions/ai-intelligence/DIVISION.md` — removed stale assumptions that Quality & Security Engineering is a mandatory adjacent default and aligned interfaces with the new split between execution implementation and Quality-layer governance
+
+_Agent registry guidance:_
+- `org/agents/README.md` — added version metadata plus explicit criteria for what belongs in the base template, when to use configuration instead of new agent types, and common anti-patterns such as tool-level and task-level agent definitions
+- `org/agents/execution/README.md` — added version metadata, a recommended execution starter set, and consolidation guidance for deploy, monitoring, coding, and customer-service agent boundaries
+
+_Targeted execution-agent cleanup:_
+- `org/agents/execution/feature-flag-agent.md` — deprecated in favor of `exec-deploy-agent`
+- `org/agents/execution/canary-agent.md` — deprecated in favor of `exec-deploy-agent`
+- `org/agents/execution/rollback-agent.md` — deprecated in favor of `exec-deploy-agent`
+- `org/agents/execution/team-specific-coding-agents.md` — deprecated in favor of `exec-coding-agent-fleet`
+- `examples/generic-feature-lifecycle.md` — updated rollout example to use `deploy-agent` for feature-flag management to match the cleaned execution taxonomy
+
 **Connector pattern foundation for real system integrations (Issue #10)**
 
 _Integration architecture and governance:_

--- a/CONFIG.yaml
+++ b/CONFIG.yaml
@@ -14,7 +14,7 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # Tracks the overall framework release. Update when cutting a new version.
 # See CHANGELOG.md for what changed. Uses semantic versioning (MAJOR.MINOR.PATCH).
-framework_version: "2.2.0"
+framework_version: "2.3.0"
 # ═══════════════════════════════════════════════════════════════════════════
 
 # ───────────────────────────────────────────────────────────────────────────
@@ -121,9 +121,10 @@ divisions:
     - id: "core-applications"
       name: "Core Applications"
       description: "UI layer, dashboards, search, navigation"
-    - id: "ai-intelligence"
-      name: "AI & Intelligence"
-      description: "AI reasoning, NL interfaces, agent orchestration, AI safety"
+    # Optional extension for AI-native products or companies building agent platforms:
+    # - id: "ai-intelligence"
+    #   name: "AI & Intelligence"
+    #   description: "AI reasoning, NL interfaces, agent orchestration, AI safety"
 
   engineering_domain:
     - id: "core-domain-1"
@@ -140,9 +141,12 @@ divisions:
     - id: "infrastructure-operations"
       name: "Infrastructure Operations"
       description: "Cloud accounts, IaC, cost management, production operations, incident management"
-    - id: "quality-security-engineering"
-      name: "Quality & Security Engineering"
-      description: "Security testing, privacy, compliance, quality gates, supply chain"
+    # Optional extension when execution-side security implementation warrants its own division.
+    # For the generic template, quality governance stays in the Quality Layer and
+    # security implementation work is owned by Engineering Foundation / Infrastructure Operations.
+    # - id: "quality-security-engineering"
+    #   name: "Quality & Security Engineering"
+    #   description: "Security testing, privacy, compliance evidence, supply chain hardening"
 
   gtm:
     - id: "product-marketing"

--- a/CUSTOMIZATION-GUIDE.md
+++ b/CUSTOMIZATION-GUIDE.md
@@ -1,6 +1,6 @@
 # Customization Guide — Agentic Enterprise Operating Model
 
-> **Version:** 2.1 | **Last updated:** 2026-02-25
+> **Version:** 2.2 | **Last updated:** 2026-03-07
 
 > **Start here** after cloning this framework.
 > This guide walks you through every step of making this operating model your own.
@@ -220,11 +220,12 @@ After the quick start, customize layer by layer. Each section below tells you **
 2. **What are your ventures?** Ventures are market-facing offerings. Create one charter per venture in `org/1-strategy/ventures/`. The framework ships with placeholder examples — replace them with yours (e.g., "Cloud Migration", "DevOps Suite", "Security Suite", "Customer Analytics").
 
 3. **What are your divisions?** Divisions are execution teams — each groups agents by expert knowledge, specialized tools, and domain-specific goals. Create one folder per division in `org/3-execution/divisions/`. The framework ships with generic categories:
-   - **Core divisions:** Data Foundation, Core Services, Core Applications, AI & Intelligence
+   - **Core divisions:** Data Foundation, Core Services, Core Applications
    - **Domain divisions:** Placeholders — fill with your product-specific domains
-   - **Ops divisions:** Engineering Foundation, Infrastructure Operations, Quality & Security
+   - **Ops divisions:** Engineering Foundation, Infrastructure Operations
    - **GTM divisions:** Product Marketing, Knowledge & Enablement
    - **Customer divisions:** Customer Experience
+   - **Optional extensions:** AI & Intelligence, GTM Web, Quality & Security Engineering when your operating model truly needs dedicated execution-side specialization
 
    **To add a division:** Create `org/3-execution/divisions/<name>/DIVISION.md` using the template pattern.
 

--- a/examples/generic-feature-lifecycle.md
+++ b/examples/generic-feature-lifecycle.md
@@ -890,9 +890,9 @@ With all streams merged and quality evaluations passed, the `release-coordinator
 
 ## Phase 12: Deployment & Validation
 
-**Layer:** Execution · **Loop:** Ship · **Agent type:** `deploy-agent`, `feature-flag-agent`
+**Layer:** Execution · **Loop:** Ship · **Agent type:** `deploy-agent`
 
-The `deploy-agent` executes the progressive rollout defined in the release contract. The `feature-flag-agent` manages the `bulk_export_enabled` flag.
+The `deploy-agent` executes the progressive rollout defined in the release contract, including management of the `bulk_export_enabled` flag.
 
 ### Stage 1: Canary (5%) — 24 hours
 
@@ -908,7 +908,7 @@ The `deploy-agent` executes the progressive rollout defined in the release contr
 
 ### Stage 2: Early Adopters (25%) — 48 hours
 
-- `feature-flag-agent` targets the 25% cohort to include the 8 requesting enterprise customers
+- `deploy-agent` targets the 25% cohort to include the 8 requesting enterprise customers
 - Customer Success is notified (via signal: `work/signals/2026-04-09-bulk-export-early-access-available.md`)
 - **Results after 48 hours:**
   - 5 enterprise customers have used the export feature
@@ -920,7 +920,7 @@ The `deploy-agent` executes the progressive rollout defined in the release contr
 
 ### Stage 3: General Availability (100%)
 
-- `feature-flag-agent` enables for all customers
+- `deploy-agent` enables for all customers
 - `deploy-agent` runs post-deployment validation:
   - Smoke tests passing ✅
   - Error rates within normal bounds ✅
@@ -1020,7 +1020,7 @@ The NRR metric improves from "at-risk" to "on-track" based on the 8 secured rene
 
 ## Phase 14: Operate
 
-**Layer:** Execution · **Loop:** Operate · **Agent types:** `monitoring-agent`, `incident-response-agent`, `feature-flag-agent`
+**Layer:** Execution · **Loop:** Operate · **Agent types:** `monitoring-agent`, `incident-response-agent`, `deploy-agent`
 
 The mission is complete, but the feature is now in production. The Operate Loop takes over.
 
@@ -1046,7 +1046,7 @@ If the error had been outside the agent's remediation authority (e.g., requiring
 
 ### Feature Flag Lifecycle
 
-The `feature-flag-agent` tracks the `bulk_export_enabled` flag:
+The `deploy-agent` tracks the `bulk_export_enabled` flag:
 - **Week 1–2:** Progressive rollout (managed above)
 - **Week 4:** Flag has been at 100% for 3 weeks with stable metrics. Agent recommends flag cleanup.
 - **Week 6:** Human approves flag removal. Agent creates a PR to remove the flag and replace conditional code with permanent implementation.

--- a/org/3-execution/divisions/ai-intelligence/DIVISION.md
+++ b/org/3-execution/divisions/ai-intelligence/DIVISION.md
@@ -4,6 +4,7 @@
 > **Type:** Core
 > **Layer:** Execution
 > **Status:** Active
+> **Version:** 1.1 | **Last updated:** 2026-03-07
 
 ---
 
@@ -23,7 +24,7 @@ Owns AI reasoning, natural language interfaces, agent orchestration, workflow au
 ### Out of Scope
 - Data storage and pipelines (→ Data Foundation)
 - UI and dashboard rendering (→ Core Applications)
-- Security scanning of code artifacts (→ Quality & Security Engineering)
+- Final security policy enforcement and compliance evaluation (→ Quality Layer)
 
 ## Key Responsibilities
 

--- a/org/3-execution/divisions/core-services/DIVISION.md
+++ b/org/3-execution/divisions/core-services/DIVISION.md
@@ -4,6 +4,7 @@
 > **Type:** Core
 > **Layer:** Execution
 > **Status:** Active
+> **Version:** 1.1 | **Last updated:** 2026-03-07
 
 ---
 
@@ -23,7 +24,7 @@ Owns identity, authentication, authorization, RBAC, API lifecycle management, an
 ### Out of Scope
 - UI layer and dashboards (→ Core Applications)
 - Infrastructure provisioning (→ Infrastructure Operations)
-- Security scanning and vulnerability management (→ Quality & Security Engineering)
+- Security scanning implementation and final compliance evaluation (→ Engineering Foundation / Quality Layer)
 
 ## Key Responsibilities
 

--- a/org/3-execution/divisions/engineering-foundation/DIVISION.md
+++ b/org/3-execution/divisions/engineering-foundation/DIVISION.md
@@ -4,6 +4,7 @@
 > **Type:** Operations
 > **Layer:** Execution
 > **Status:** Active
+> **Version:** 1.1 | **Last updated:** 2026-03-07
 
 ---
 
@@ -24,7 +25,7 @@ Owns the developer portal, build infrastructure, CI/CD pipelines, golden paths, 
 
 ### Out of Scope
 - Cloud infrastructure provisioning (→ Infrastructure Operations)
-- Security scanning and vulnerability triage (→ Quality & Security Engineering)
+- Final security policy enforcement and compliance verdicts (→ Quality Layer)
 - Application code implementation (→ domain-specific divisions)
 
 ## Key Responsibilities
@@ -41,7 +42,7 @@ Owns the developer portal, build infrastructure, CI/CD pipelines, golden paths, 
 |-----------|------|-----------|
 | Receives from | Strategy Layer | Mission briefs involving this division |
 | Delivers to | Quality Layer | Work outputs for quality evaluation |
-| Collaborates with | Infrastructure Operations, Quality & Security Engineering | Shared data contracts / APIs |
+| Collaborates with | Infrastructure Operations, Quality Layer | Shared data contracts / APIs |
 
 ## Quality Policies
 

--- a/org/3-execution/divisions/infrastructure-operations/DIVISION.md
+++ b/org/3-execution/divisions/infrastructure-operations/DIVISION.md
@@ -4,6 +4,7 @@
 > **Type:** Operations
 > **Layer:** Execution
 > **Status:** Active
+> **Version:** 1.1 | **Last updated:** 2026-03-07
 
 ---
 
@@ -26,7 +27,7 @@ Owns cloud accounts, infrastructure-as-code, container orchestration, production
 
 ### Out of Scope
 - CI/CD pipeline management (→ Engineering Foundation)
-- Security vulnerability scanning (→ Quality & Security Engineering)
+- Security policy authorship and final compliance evaluation (→ Quality Layer)
 - Application-level code changes (→ domain-specific divisions)
 
 ## Key Responsibilities
@@ -44,7 +45,7 @@ Owns cloud accounts, infrastructure-as-code, container orchestration, production
 |-----------|------|-----------|
 | Receives from | Strategy Layer | Mission briefs involving this division |
 | Delivers to | Quality Layer | Work outputs for quality evaluation |
-| Collaborates with | Engineering Foundation, Quality & Security Engineering | Shared data contracts / APIs |
+| Collaborates with | Engineering Foundation, Quality Layer | Shared data contracts / APIs |
 
 ## Quality Policies
 

--- a/org/3-execution/divisions/legal/DIVISION.md
+++ b/org/3-execution/divisions/legal/DIVISION.md
@@ -4,6 +4,7 @@
 > **Type:** Corporate Function
 > **Layer:** Execution
 > **Status:** Active
+> **Version:** 1.1 | **Last updated:** 2026-03-07
 
 ---
 
@@ -28,7 +29,7 @@ Owns legal advisory, contract management, regulatory compliance, intellectual pr
 ### Out of Scope
 - Day-to-day HR operations (→ People)
 - Financial reporting and tax filings (→ Finance & Procurement)
-- Security policy enforcement (→ Quality & Security Engineering)
+- Security policy enforcement (→ Quality Layer)
 - Procurement decisions and purchase orders (→ Finance & Procurement)
 
 ## Key Responsibilities
@@ -47,7 +48,7 @@ Owns legal advisory, contract management, regulatory compliance, intellectual pr
 | Receives from | All Divisions | Contract requests, compliance questions, IP review requests via signals |
 | Receives from | People | Employment contract needs, HR compliance questions |
 | Receives from | Finance & Procurement | Vendor contract review requests |
-| Receives from | Quality & Security Engineering | Regulatory requirements for security policies |
+| Receives from | Quality Layer | Policy requirements and control expectations that have legal implications |
 | Delivers to | Quality Layer | Legal compliance evaluations (privacy, regulatory) |
 | Delivers to | Steering Layer | Legal risk assessments, regulatory change signals |
 | Delivers to | All Divisions | Compliance guidance, contract templates, legal advisory |

--- a/org/README.md
+++ b/org/README.md
@@ -1,5 +1,7 @@
 # Organizational Structure
 
+> **Version:** 1.1 | **Last updated:** 2026-03-07
+
 > **What this is:** The static structure of the agentic enterprise {{COMPANY_SHORT}} organization — who exists, where they sit, what they own, how they relate. This covers the **entire company**, not just R&D: engineering, delivery, go-to-market, sales, customer success, and support all operate within the same 5-layer model.  
 > **What it replaces:** Legacy role hierarchies, ticket-based coordination, manual phase gates, and siloed functional departments.  
 > **Governance:** Changes via Pull Request → Steering Layer (structural) or Strategy Layer (operational) approval
@@ -106,16 +108,59 @@ The critical addition — Layer 0: Steering — embeds what was historically inv
 
 Divisions are the **execution units** of the organization — each owns a domain of work, has a team of humans + agents, and produces artifacts. Each division groups agents by expert knowledge, specialized tools, and domain-specific goals.
 
-### Engineering Divisions — Core
+### Engineering Divisions — Core Defaults
 
 | Division | What It Owns |
 |-----------|-------------|
 | **Data Foundation** | Core data storage, query and analytics engine, data governance, enrichment, semantic normalization |
 | **Core Services** | IAM, RBAC, tokens, lifecycle management, serverless runtime, APIs |
-| **Core Applications** | Dashboards, notebooks, search, navigation, conversational interface |
-| **AI & Intelligence** | AI reasoning layer, conversational interface backend, agent orchestration, natural language interfaces, AI safety |
+| **Core Applications** | Dashboards, portals, search, navigation, and user-facing application experiences |
 
-### Engineering Divisions — Domain
+### Engineering Divisions — Shared Operations Defaults
+
+| Division | What It Owns |
+|-----------|-------------|
+| **Engineering Foundation** | Golden paths, developer portal, build infra, CI/CD, release engineering, test automation |
+| **Infrastructure Operations** | Cloud accounts, IaC, runtime platforms, networking, SLOs, incident management |
+
+### Company-Specific Product Divisions
+
+> These are important extension points, but they are **not** safe defaults for every adopting company.
+
+| Division | Use When |
+|-----------|----------|
+| **AI & Intelligence** | Your product itself contains AI or agent runtime capabilities as a first-class product area |
+| **Core Domain 1 / 2** | You need domain execution units tied to your specific market, product, or regulated capability set |
+
+### Commercial And Experience Defaults
+
+| Division | What It Owns |
+|-----------|-------------|
+| **Product Marketing** | GTM strategy execution, launch orchestration, press releases, analyst relations, competitive positioning |
+| **Knowledge & Enablement** | Product docs, API docs, tutorials, release notes, knowledge base, demos, battlecards, training, certifications |
+| **Customer Experience** | Onboarding, adoption tracking, health scores, QBRs, renewal management, support, incident resolution, knowledge base, SLA management |
+
+### Corporate Function Defaults
+
+| Division | What It Owns |
+|-----------|-------------|
+| **People** | Recruiting, onboarding, performance, workforce planning, learning programs |
+| **Legal & Compliance** | Contracting, legal review, privacy law, and regulatory interpretation |
+| **Finance & Procurement** | Budgeting, spend controls, vendor sourcing, and procurement operations |
+
+### Optional Commercial Extensions
+
+| Division | Use When |
+|-----------|----------|
+| **GTM Web** | You run a dedicated web-growth or web-experience engineering function separate from product applications |
+
+### Avoid As A Default Split
+
+| Pattern | Why |
+|---------|-----|
+| **Quality & Security Engineering** as a standalone default execution division | It mixes implementation work with governance. In the generic template, security tooling belongs in Engineering Foundation / Infrastructure Operations, while policy authorship and enforcement stay in the Quality Layer |
+
+### Engineering Divisions — Domain Templates
 
 > **Customize this section.** Add divisions specific to your product domain. Examples:
 
@@ -123,27 +168,6 @@ Divisions are the **execution units** of the organization — each owns a domain
 |-----------|-------------|
 | **{{DOMAIN_CAP_1_NAME}}** | {{DOMAIN_CAP_1_DESCRIPTION}} |
 | **{{DOMAIN_CAP_2_NAME}}** | {{DOMAIN_CAP_2_DESCRIPTION}} |
-
-### Engineering Divisions — Operational Excellence
-
-| Division | What It Owns |
-|-----------|-------------|
-| **Engineering Foundation** | Golden paths, developer portal, build infra, CI/CD, release engineering, feature flags, deployment pipelines |
-| **Infrastructure Operations** | Cloud accounts, IaC, cost management, K8s runtime, networking, SLOs, incident management, on-call |
-| **Quality & Security Engineering** | Security testing, privacy, compliance, quality gates, supply chain |
-
-### Go-to-Market Divisions
-
-| Division | What It Owns |
-|-----------|-------------|
-| **Product Marketing** | GTM strategy execution, launch orchestration, press releases, analyst relations, competitive positioning |
-| **Knowledge & Enablement** | Product docs, API docs, tutorials, release notes, knowledge base, demos, battlecards, training, certifications |
-
-### Customer Divisions
-
-| Division | What It Owns |
-|-----------|-------------|
-| **Customer Experience** | Onboarding, adoption tracking, health scores, QBRs, renewal management, support, incident resolution, knowledge base, SLA management |
 
 ---
 
@@ -232,3 +256,10 @@ org/
 - **Division changes** require the Division Tech Lead approval
 - All changes are version-controlled, auditable, and reversible via git history
 - See [../CODEOWNERS](../CODEOWNERS) for the complete approval mapping
+
+## Changelog
+
+| Version | Date | Change |
+|---|---|---|
+| 1.1 | 2026-03-07 | Reframed execution divisions into core defaults, optional extensions, and company-specific product divisions; removed AI & Intelligence and Quality & Security Engineering as implied defaults |
+| 1.0 | 2026-02-19 | Initial version |

--- a/org/agents/README.md
+++ b/org/agents/README.md
@@ -1,5 +1,7 @@
 # Agent Type Registry
 
+> **Version:** 1.1 | **Last updated:** 2026-03-07
+
 > **What this is:** The governed, versioned registry of all agent types in the {{COMPANY_SHORT}} agentic enterprise. Each agent type has a YAML definition file that describes its capabilities, lifecycle status, scaling parameters, and ownership.  
 > **Governance:** New agent types require Steering Layer evaluation and CTO approval via PR. This registry is the operational source of truth for all agent types.
 
@@ -66,6 +68,30 @@ proposed → approved → implementing → active → deprecated → retired
 5. Implementation begins (skills, MCP connections, tool bindings, instructions)
 6. Quality validation → status updated to `active`
 
+## What Belongs In The Base Template
+
+Base-template agent types should pass all of these checks:
+
+1. **Universal enough** — most adopting companies will plausibly need this capability.
+2. **Stable boundary** — the agent owns a durable workflow boundary, not a single step inside another agent's workflow.
+3. **More than a tool wrapper** — the capability is not just one feature flag system, one rollout mode, or one API binding.
+4. **More than a task name** — names like "blog", "rollback", or "battlecard" are often outputs or skills, not durable agent types.
+5. **Configuration is insufficient** — if an existing agent can handle the work with a division profile, tool profile, or skill set, prefer configuration over a new registry entry.
+
+## Use Configuration Instead Of New Types When
+
+- The difference is only environment-specific, such as one cloud provider, one monitoring backend, or one feature flag platform.
+- The difference is only a delivery step inside a broader workflow, such as canary analysis or rollback inside deployment.
+- The difference is only channel or artifact format, such as blog vs battlecard vs release notes inside content production.
+- The difference is only team specialization, such as frontend vs backend coding profiles inside one coding fleet.
+
+## Common Anti-Patterns
+
+- **Task-level agent types** — one agent for onboarding, another for renewal, another for advocacy, even though one cleaner domain boundary would suffice.
+- **Tool-level agent types** — one agent exists mainly because a feature flag, canary, or rollback tool exists.
+- **Monitor explosion** — separate host, process, network, and container monitors when one infrastructure-health monitor with pluggable scopes would do.
+- **Governance leakage** — execution-layer agent types quietly take on policy ownership that belongs in the Quality Layer.
+
 ## How to Deprecate an Agent Type
 
 1. File an evolution proposal (see `org/0-steering/_TEMPLATE-evolution-proposal.md`)
@@ -93,3 +119,10 @@ proposed → approved → implementing → active → deprecated → retired
 | **OPERATING-MODEL.md** | Documents the design principles and organizational structure that inform agent type design. |
 | **Division definitions** (`org/3-execution/divisions/`) | Divisions define domain context. Agent types define capabilities. An agent type belongs to a division (for Execution agents) or to a layer. |
 | **AGENT.md files** (`org/<layer>/AGENT.md`) | Layer instructions define behavioral rules. Agent type definitions specify capabilities & scaling. Both are needed for a complete agent specification. |
+
+## Changelog
+
+| Version | Date | Change |
+|---|---|---|
+| 1.1 | 2026-03-07 | Added base-template fit criteria, configuration-vs-type guidance, and anti-patterns to reduce micro-specialized agent definitions |
+| 1.0 | 2026-02-23 | Initial version |

--- a/org/agents/execution/README.md
+++ b/org/agents/execution/README.md
@@ -1,6 +1,38 @@
 # Agent Type Registry — Execution Layer
 
+> **Version:** 1.1 | **Last updated:** 2026-03-07
+
 Agent types that operate at the Execution Layer — producing code, content, documentation, customer deliverables, sales materials, and support responses.
+
+## Base Template Starter Set
+
+The generic template should start from a smaller core set and treat the remaining files in this directory as optional extensions or proposals under consolidation review.
+
+### Recommended Core Defaults
+
+- `technical-design-agent`
+- `coding-agent-fleet`
+- `build-agent`
+- `deploy-agent`
+- `doc-generation-agent`
+- `release-notes-agent`
+- `production-health-agent`
+- `incident-response-agent`
+- `infrastructure-provisioning-agent`
+- `content-creation-agent`
+- `customer-health-analyzer`
+- `support-triage-agent`
+- `recruiting-coordinator-agent`
+- `budget-analyst-agent`
+- `procurement-agent`
+- `compliance-advisor-agent`
+
+### Consolidation Guidance
+
+- Treat rollout mechanics such as feature flags, canaries, and rollback as `deploy-agent` capabilities unless a company has a proven reason to separate them.
+- Treat team or language specialization as `coding-agent-fleet` configuration unless the boundary changes responsibilities, tooling, and evaluation criteria.
+- Prefer one infrastructure-health boundary over separate monitor types for hosts, networks, processes, containers, and cloud resources.
+- Prefer a small number of customer-service and customer-health boundaries over a dozen lifecycle-step agents.
 
 ## Registered Agent Types
 
@@ -10,18 +42,18 @@ Agent types that operate at the Execution Layer — producing code, content, doc
 |----------|------|--------|
 | technical-design-agent | Technical Design Agent | proposed |
 | coding-agent-fleet | Coding Agent Fleet | proposed |
-| team-specific-coding-agents | Team-Specific Coding Agents | proposed |
+| team-specific-coding-agents | Team-Specific Coding Agents | deprecated |
 | team-specific-test-agents | Team-Specific Test Agents | proposed |
 | build-agent | Build Agent | proposed |
 | deploy-agent | Deploy Agent | proposed |
 | doc-generation-agent | Doc Generation Agent | proposed |
 | release-notes-agent | Release Notes Agent | proposed |
-| feature-flag-agent | Feature Flag Agent | proposed |
+| feature-flag-agent | Feature Flag Agent | deprecated |
 | quality-gate-agent | Quality Gate Agent | proposed |
 | schema-management-agent | Schema Management Agent | proposed |
 | performance-agent | Performance Agent | proposed |
-| canary-agent | Canary Agent | proposed |
-| rollback-agent | Rollback Agent | proposed |
+| canary-agent | Canary Agent | deprecated |
+| rollback-agent | Rollback Agent | deprecated |
 
 ### Operations & Monitoring
 
@@ -123,3 +155,10 @@ Agent types that operate at the Execution Layer — producing code, content, doc
 | user-experience-agent | User Experience Agent | proposed |
 
 **Total: 78 agent types**
+
+## Changelog
+
+| Version | Date | Change |
+|---|---|---|
+| 1.1 | 2026-03-07 | Added core starter set and consolidation guidance to distinguish generic defaults from extension proposals |
+| 1.0 | 2026-02-23 | Initial version |

--- a/org/agents/execution/canary-agent.md
+++ b/org/agents/execution/canary-agent.md
@@ -1,6 +1,6 @@
 # Agent Type Definition: Canary Agent
 
-> **Status:** proposed | **Proposed date:** 2026-02-18
+> **Status:** deprecated | **Proposed date:** 2026-02-18
 > **Governance:** New types require Steering Layer evaluation + CTO approval via PR.
 
 ---
@@ -11,7 +11,7 @@
 |-------|-------|
 | **ID** | `exec-canary-agent` |
 | **Name** | Canary Agent |
-| **Version** | 1.0.0 |
+| **Version** | 1.1.0 |
 
 ## Classification
 
@@ -25,13 +25,13 @@
 
 | Field | Value |
 |-------|-------|
-| **Status** | proposed |
+| **Status** | deprecated |
 | **Proposed date** | 2026-02-18 |
 | **Approved date** | |
 | **Active date** | |
-| **Deprecated date** | |
+| **Deprecated date** | 2026-03-07 |
 | **Retired date** | |
-| **Superseded by** | |
+| **Superseded by** | `exec-deploy-agent` |
 
 ## Ownership
 
@@ -44,13 +44,13 @@
 ## Description
 
 **What this agent does:**
-Monitors canary deployments vs baseline health. Auto-promotes or rolls back based on statistical analysis.
+Historically proposed as a standalone execution agent for canary analysis and promotion decisions.
 
 **Problem solved:**
 Progressive delivery with evidence-based promotion prevents bad releases from reaching all users.
 
 **Value proposition:**
-Every enterprise following the agentic operating model benefits from this agent because it addresses a universal organizational need that scales with agent fleet adoption.
+Canary analysis remains important, but the generic framework now treats it as a deployment strategy owned by `exec-deploy-agent` rather than a standalone base-template agent type.
 
 ## Capabilities
 
@@ -122,4 +122,5 @@ per-mission
 
 | Date | Change | Author |
 |------|--------|--------|
+| 2026-03-07 | Deprecated in the base template; canary evaluation is now treated as a Deploy Agent capability | GitHub Copilot |
 | 2026-02-18 | Initial proposal — bootstrapped from Agentic Enterprise Blueprint | System |

--- a/org/agents/execution/feature-flag-agent.md
+++ b/org/agents/execution/feature-flag-agent.md
@@ -1,6 +1,6 @@
 # Agent Type Definition: Feature Flag Agent
 
-> **Status:** proposed | **Proposed date:** 2026-02-18
+> **Status:** deprecated | **Proposed date:** 2026-02-18
 > **Governance:** New types require Steering Layer evaluation + CTO approval via PR.
 
 ---
@@ -11,7 +11,7 @@
 |-------|-------|
 | **ID** | `exec-feature-flag-agent` |
 | **Name** | Feature Flag Agent |
-| **Version** | 1.0.0 |
+| **Version** | 1.1.0 |
 
 ## Classification
 
@@ -25,13 +25,13 @@
 
 | Field | Value |
 |-------|-------|
-| **Status** | proposed |
+| **Status** | deprecated |
 | **Proposed date** | 2026-02-18 |
 | **Approved date** | |
 | **Active date** | |
-| **Deprecated date** | |
+| **Deprecated date** | 2026-03-07 |
 | **Retired date** | |
-| **Superseded by** | |
+| **Superseded by** | `exec-deploy-agent` |
 
 ## Ownership
 
@@ -44,13 +44,13 @@
 ## Description
 
 **What this agent does:**
-Manages feature flag lifecycle — evaluation, progressive rollout, health-driven rollback, and A/B experimentation.
+Historically proposed as a standalone execution agent for feature flag lifecycle management.
 
 **Problem solved:**
 Progressive delivery and experimentation are essential for managing risk in modern software.
 
 **Value proposition:**
-Every enterprise following the agentic operating model benefits from this agent because it addresses a universal organizational need that scales with agent fleet adoption.
+The capability is still broadly useful, but the framework now treats feature flag management as a `deploy-agent` capability by default rather than a separate base-template agent type.
 
 ## Capabilities
 
@@ -122,4 +122,5 @@ per-mission
 
 | Date | Change | Author |
 |------|--------|--------|
+| 2026-03-07 | Deprecated in the base template; feature flag management is now treated as a Deploy Agent capability | GitHub Copilot |
 | 2026-02-18 | Initial proposal — bootstrapped from Agentic Enterprise Blueprint | System |

--- a/org/agents/execution/rollback-agent.md
+++ b/org/agents/execution/rollback-agent.md
@@ -1,6 +1,6 @@
 # Agent Type Definition: Rollback Agent
 
-> **Status:** proposed | **Proposed date:** 2026-02-18
+> **Status:** deprecated | **Proposed date:** 2026-02-18
 > **Governance:** New types require Steering Layer evaluation + CTO approval via PR.
 
 ---
@@ -11,7 +11,7 @@
 |-------|-------|
 | **ID** | `exec-rollback-agent` |
 | **Name** | Rollback Agent |
-| **Version** | 1.0.0 |
+| **Version** | 1.1.0 |
 
 ## Classification
 
@@ -25,13 +25,13 @@
 
 | Field | Value |
 |-------|-------|
-| **Status** | proposed |
+| **Status** | deprecated |
 | **Proposed date** | 2026-02-18 |
 | **Approved date** | |
 | **Active date** | |
-| **Deprecated date** | |
+| **Deprecated date** | 2026-03-07 |
 | **Retired date** | |
-| **Superseded by** | |
+| **Superseded by** | `exec-deploy-agent` |
 
 ## Ownership
 
@@ -44,13 +44,13 @@
 ## Description
 
 **What this agent does:**
-Executes rollback procedures with blast radius estimation. Ensures safe rollback verification.
+Historically proposed as a standalone execution agent for rollback planning and execution.
 
 **Problem solved:**
 When things go wrong, fast and safe rollback is critical. Every production system needs this.
 
 **Value proposition:**
-Every enterprise following the agentic operating model benefits from this agent because it addresses a universal organizational need that scales with agent fleet adoption.
+Rollback remains a universal need, but the generic framework now treats it as a deployment capability owned by `exec-deploy-agent` rather than a separate base-template agent type.
 
 ## Capabilities
 
@@ -122,4 +122,5 @@ per-mission
 
 | Date | Change | Author |
 |------|--------|--------|
+| 2026-03-07 | Deprecated in the base template; rollback is now treated as a Deploy Agent capability | GitHub Copilot |
 | 2026-02-18 | Initial proposal — bootstrapped from Agentic Enterprise Blueprint | System |

--- a/org/agents/execution/team-specific-coding-agents.md
+++ b/org/agents/execution/team-specific-coding-agents.md
@@ -1,6 +1,6 @@
 # Agent Type Definition: Team-Specific Coding Agents
 
-> **Status:** proposed | **Proposed date:** 2026-02-18
+> **Status:** deprecated | **Proposed date:** 2026-02-18
 > **Governance:** New types require Steering Layer evaluation + CTO approval via PR.
 
 ---
@@ -11,7 +11,7 @@
 |-------|-------|
 | **ID** | `exec-team-specific-coding-agents` |
 | **Name** | Team-Specific Coding Agents |
-| **Version** | 1.0.0 |
+| **Version** | 1.1.0 |
 
 ## Classification
 
@@ -25,13 +25,13 @@
 
 | Field | Value |
 |-------|-------|
-| **Status** | proposed |
+| **Status** | deprecated |
 | **Proposed date** | 2026-02-18 |
 | **Approved date** | |
 | **Active date** | |
-| **Deprecated date** | |
+| **Deprecated date** | 2026-03-07 |
 | **Retired date** | |
-| **Superseded by** | |
+| **Superseded by** | `exec-coding-agent-fleet` |
 
 ## Ownership
 
@@ -44,13 +44,13 @@
 ## Description
 
 **What this agent does:**
-Specialized coding agents per team domain (core, data, security, frontend, DevEx, customer-facing, GTM tooling, operations).
+Historically proposed as a standalone registry entry for team-specialized coding variants.
 
 **Problem solved:**
 Different domains have different patterns and constraints. Specialization improves quality.
 
 **Value proposition:**
-Every enterprise following the agentic operating model benefits from this agent because it addresses a universal organizational need that scales with agent fleet adoption.
+Team specialization is still valuable, but the generic framework now treats those differences as configuration profiles of `exec-coding-agent-fleet` rather than separate base-template agent types.
 
 ## Capabilities
 
@@ -122,4 +122,5 @@ per-mission
 
 | Date | Change | Author |
 |------|--------|--------|
+| 2026-03-07 | Deprecated in the base template; team specialization now belongs in Coding Agent Fleet configuration profiles | GitHub Copilot |
 | 2026-02-18 | Initial proposal — bootstrapped from Agentic Enterprise Blueprint | System |


### PR DESCRIPTION
## Summary
- clean up the generic execution-division defaults so company-specific splits are treated as optional extensions
- add clearer base-template rules for agent types and starter-set guidance for execution agents
- deprecate redundant execution agent types that are better modeled as deploy or coding-fleet capabilities

## Why
The framework template had drifted toward product-specific and overly micro-specialized defaults. This PR reduces that bias and makes the template safer for broad adoption across different company shapes.

## Testing
- validated edited files with editor error checks
- verified remote branch push succeeded

## Notes
- direct pushes to main are blocked by branch protection, so this PR is opened from `chore/framework-taxonomy-cleanup`