### PR TITLE
feat!: v3.0.0 - Work Backend Abstraction (multi-backend work tracking)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,7 +1,7 @@
 # Copilot Instructions — Agentic Enterprise
 
-This repository is a Git-native operating model for running organizations with
-AI agents.
+This repository is an operating model for running organizations with
+AI agents. Work tracking is configurable — see `CONFIG.yaml → work_backend`.
 
 ## Read First
 
@@ -14,17 +14,20 @@ AI agents.
 
 - 5 layers: Steering → Strategy → Orchestration → Execution → Quality
 - 4 loops: Discover → Build → Ship → Operate
-- Git is the operating system:
-  - PRs = decisions
+- Git is the governance backbone:
+  - PRs = governance decisions (org structure, policies, templates)
   - CODEOWNERS = RACI
   - CI/CD = quality gates
+- Work tracking adapts to configured backend:
+  - Git files (`work/`) or issue tracker (GitHub Issues)
+  - See `CONFIG.yaml → work_backend` and `docs/WORK-BACKENDS.md`
 
 ## Required Behaviors
 
 - Ground recommendations in evidence
 - Do not silently make strategic decisions for humans
 - Stay in your layer boundaries
-- Surface improvement signals to `work/signals/`
+- Surface improvement signals (to `work/signals/` or as issues with `artifact:signal` label)
 - Prefer minimal, focused changes over broad rewrites
 
 ## Template vs. Instance — Know Which You Are Touching
@@ -40,6 +43,7 @@ The repo contains two fundamentally different kinds of files. Identify the type 
 
 **Instances** (work artifacts created during operations):
 - Everything under `work/` — signals, missions, decisions, releases, retrospectives
+- Or: issues in the configured issue tracker with `artifact:*` labels
 - Division-specific files created during execution
 
 ## Releasing Template Changes
@@ -47,6 +51,7 @@ The repo contains two fundamentally different kinds of files. Identify the type 
 When you have finished changing a template or framework file, use `/deploy` to complete the release. The `/deploy` prompt walks through the full checklist: version fields, changelog entry, commit, push, and CI verification.
 
 For instances (files under `work/`): create/update the file, increment `Revision`, open a PR — human approval via merge is the gate.
+For instances (issue backend): create/update the issue with appropriate labels — human approval via label change is the gate.
 
 ## Key Paths
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Agent Instructions (Global)
 
-> **Version:** 2.2 | **Last updated:** 2026-03-05
+> **Version:** 3.0 | **Last updated:** 2026-03-07
 
 > **Scope:** Every AI agent working in this repository — regardless of layer, role, or task — must follow these instructions.
 > **This file is the top of the instruction hierarchy.** Layer-specific and division-specific instructions extend (never contradict) these rules.
@@ -36,14 +36,15 @@ You are an agent working within the {{COMPANY_NAME}} Agentic Enterprise Operatin
 
 ### 2. Humans decide, agents recommend
 - You never commit scope, timelines, resources, or strategic direction
-- You draft, analyze, propose, and recommend — humans approve via PR merge
+- You draft, analyze, propose, and recommend — humans approve (via PR merge, issue label change, or the configured approval mechanism)
 - When you're uncertain, escalate. Never guess silently on decisions that matter.
 
-### 3. Process is the repo
-- All work artifacts are Markdown or YAML files in this repository
-- All changes go through Pull Requests
-- All approvals are PR merges by the appropriate human(s)
-- The Git history is the audit trail — write meaningful commit messages
+### 3. Process is governed
+- All work artifacts are tracked in the **configured work backend** — either as Markdown files in `work/` or as issues in the configured issue tracker (see `CONFIG.yaml → work_backend` and [docs/WORK-BACKENDS.md](docs/WORK-BACKENDS.md))
+- **Git-files backend:** All changes go through Pull Requests. All approvals are PR merges. Git history is the audit trail.
+- **Issue backend:** All changes go through issue state transitions. Approvals are label changes by authorized humans. Issue activity logs are the audit trail.
+- **Regardless of backend:** Governance backbone files (org structure, policies, agent instructions, templates, CONFIG.yaml) always live in Git and are governed via PRs.
+- Write meaningful commit messages (for Git-backed artifacts) or clear issue descriptions (for issue-backed artifacts)
 
 ### 4. Policies are law
 - Quality policies in `org/4-quality/policies/` are mandatory, not advisory
@@ -63,7 +64,7 @@ You are an agent working within the {{COMPANY_NAME}} Agentic Enterprise Operatin
 
 ### 7. Continuously improve the company
 - Every agent is a sensor. You observe friction, inefficiency, policy gaps, structural problems, and opportunities in the course of your work.
-- When you notice something that could improve the organization, process, or operating model, **file an improvement signal** in `work/signals/`.
+- When you notice something that could improve the organization, process, or operating model, **file an improvement signal** (in `work/signals/` for git-files backend, or as an issue with `artifact:signal` label for issue backend).
 - You don't need permission to observe and signal. Signals are low-cost, high-value. The Steering Layer aggregates and acts on patterns.
 - Improvement signals include: division scope overlaps, process bottlenecks, policy contradictions, missing divisions, outdated instructions, structural inefficiencies, untapped opportunities.
 - This is not extra work — it is part of every agent's core responsibility. A company that observes itself through every agent improves exponentially faster than one that relies on periodic top-down reviews.
@@ -138,8 +139,10 @@ The repository contains two fundamentally different kinds of files (see [docs/FI
 - `CONFIG.yaml`, `OPERATING-MODEL.md`, integration definitions in `org/integrations/`
 
 **Instances** (work artifacts created by agents or humans during operations):
-- Non-template files under `work/` — signals, missions, decisions, releases, retrospectives, locks
+- **Git-files backend:** Non-template files under `work/` — signals, missions, decisions, releases, retrospectives, locks
+- **Issue backend:** Issues in the configured tracker with `artifact:*` labels — signals, missions, tasks, decisions, releases, retrospectives
 - Division-specific files created during execution
+- Persistent documentation artifacts always in Git regardless of backend (technical designs, asset registry, governance exceptions)
 
 **Different completion criteria apply:**
 
@@ -152,9 +155,8 @@ When working on a **template or framework file**, the task is NOT done until all
 6. If CI fails: investigate, fix the root cause, commit the fix, push again, and re-verify — do **not** mark the task complete while any check is red
 
 When working on an **instance**, the completion gate is human review:
-- Create or update the file, increment `Revision`, update `Last updated`
-- Open a Pull Request — human approval via PR merge is the gate
-- CI must still pass, but you do not need to push-and-watch before raising the PR
+- **Git-files backend:** Create or update the file, increment `Revision`, update `Last updated`. Open a Pull Request — human approval via PR merge is the gate. CI must still pass.
+- **Issue backend:** Create or update the issue with appropriate labels and structured body. Human approval is via label change (e.g., `status:proposed` → `status:approved`) or issue state transition by an authorized human.
 
 **Why this matters:** Framework changes affect every agent and every future instance derived from the template. A regression in a template propagates silently until someone notices. The push-and-verify discipline plus the CI gate exist to catch problems before they reach the entire operating model.
 
@@ -163,9 +165,9 @@ When working on an **instance**, the completion gate is human review:
 Multi-agent systems are prone to duplicate work — multiple agents independently creating issues, PRs, or artifacts for the same problem. This wastes effort, creates merge conflicts, and obscures the audit trail.
 
 **Before creating any work artifact, PR, or issue:**
-1. **Search for existing work** — check open PRs, issues, active missions, in-progress tasks, and recent commits that address the same topic. Use Git history, issue trackers, and `work/missions/*/TASKS.md` as sources.
-2. **Check task ownership** — if a TASKS.md exists for the mission, verify whether someone (human or agent) already has the task `in-progress`. If so, do not create parallel work — coordinate or wait.
-3. **Check signal deduplication** — before filing a new signal, search `work/signals/` for existing signals covering the same observation. Use the `Supersedes` field if your signal replaces an older one; link as `Related Signals` if it's additive.
+1. **Search for existing work** — check open PRs, issues, active missions, in-progress tasks, and recent commits that address the same topic. Use Git history, the configured work backend (issue tracker or `work/` files), and task lists as sources.
+2. **Check task ownership** — verify whether someone (human or agent) already has the task `in-progress` (via TASKS.md for git-files backend, or via issue assignment/labels for issue backend). If so, do not create parallel work — coordinate or wait.
+3. **Check signal deduplication** — before filing a new signal, search existing signals (in `work/signals/` or via issue tracker search with `artifact:signal` label). Use the `Supersedes` field or cross-references if your signal replaces an older one; link as related if it's additive.
 4. **Link, don't duplicate** — if a PR or issue already exists that addresses the problem, reference it rather than creating a new one. Add context to the existing artifact if needed.
 
 **When you discover you've created duplicate work:**
@@ -196,9 +198,11 @@ This operating model is derived from the [Agentic Enterprise](https://github.com
 - Never blindly merge upstream — evaluate each change against your company's customizations and policies. Some updates may conflict with deliberate local choices.
 - **Version tracking:** Record your current upstream framework version in `CONFIG.yaml → framework_version`. This makes it easy to see how far behind (or ahead) your instance is.
 
-### 14. Archive completed work — keep active directories clean
+### 14. Archive completed work — keep active views clean
 
-Work directories accumulate artifacts over time. Without active archiving, agents waste time scanning irrelevant closed items, and active work becomes hard to find.
+Work artifacts accumulate over time. Without active archiving, agents waste time scanning irrelevant closed items, and active work becomes hard to find.
+
+**Git-files backend:**
 
 **Policy:** Every `work/<area>/` directory has an `archive/` subfolder. Completed, closed, or superseded items move there. Full details in `docs/ARCHIVE-POLICY.md`.
 
@@ -214,10 +218,17 @@ Work directories accumulate artifacts over time. Without active archiving, agent
 - **Never delete** work artifacts — always archive (git history = audit trail)
 - Templates (`_TEMPLATE-*`) and README.md files are never archived
 
-**Agent responsibility:**
-- **After closing a mission or completing a signal**: archive it in the same PR/commit
-- **Orchestration agents**: periodically scan for archivable items and archive them
-- **All agents**: when scanning `work/missions/` or `work/signals/`, ignore the `archive/` subfolder — only active items live in the parent directory
+**Issue backend:**
+
+- **Close** completed issues — the issue tracker's closed state is the equivalent of archiving
+- Ensure final status labels are applied before closing (e.g., `status:completed`, `status:done`)
+- Closed issues remain searchable as historical record — no data is lost
+- **Never delete** issues — close them with a resolution note
+
+**Agent responsibility (both backends):**
+- **After closing a mission or completing a signal**: archive/close it in the same action
+- **Orchestration agents**: periodically scan for archivable/closable items
+- **All agents**: when scanning active work, filter for active items only (ignore `archive/` subfolder for git-files, filter by open status for issues)
 
 ## Repository Structure (Quick Reference)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,62 @@ The framework uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html): `
 
 _Changes merged to `main` but not yet tagged as a release go here. Move to a new version section when cutting a release._
 
+---
+
+## [3.0.0] — 2026-03-07
+
+> **Agentic Enterprise goes multi-backend.** This is a major release that decouples work tracking from Git files, introduces GitHub Issues as a first-class work backend, and brings sweeping consistency improvements across all five layers of the operating model.
+
 ### Added
+
+**Work Backend Abstraction — configurable work tracking (MAJOR)**
+
+> Operational work artifacts (signals, missions, tasks, decisions, releases, retrospectives) can now be tracked in either Git files (the original model) or an issue tracker (GitHub Issues). The choice is made at instance configuration time via `CONFIG.yaml → work_backend`. This is a breaking conceptual change — the framework no longer assumes Git-only work tracking.
+
+_Core concept:_
+- `docs/WORK-BACKENDS.md` — new comprehensive guide: three file categories (governance backbone, persistent docs, configurable work artifacts), label taxonomy for issue backends, structural conventions, agent behavior differences, migration paths
+- `CONFIG.yaml` — new section 8 `work_backend` with `type` (`git-files` | `github-issues`), `github_issues` configuration, and per-artifact `overrides`; bumped `framework_version` from `2.3.0` to `3.0.0`
+
+_Agent rules updated:_
+- `AGENTS.md` — Rule 3 renamed from "Process is the repo" to "Process is governed"; now describes both git-files and issue backends; Rule 2 updated approval mechanism; Rule 7 updated signal filing; Rule 11 updated instance definition for issue backend; Rule 12 updated deduplication for both backends; Rule 14 renamed from "keep active directories clean" to "keep active views clean" with issue-backend archiving (close issues); version bumped to 3.0
+- `.github/copilot-instructions.md` — updated to reflect configurable work backend
+
+_Documentation updated:_
+- `OPERATING-MODEL.md` — softened "git is the only way" language; now describes Git as governance backbone with configurable work tracking; updated artifact flow, collaboration pattern, human interaction model, and mapping table; version bumped to 3.0
+- `work/README.md` — added dual-backend structure, issue backend artifact/label table
+- `CUSTOMIZATION-GUIDE.md` — new Step 4 "Choose Your Work Backend"; updated "What You Don't Need" section; updated initialization sequence for both backends; version bumped to 3.0
+- `docs/GITHUB-ISSUES.md` — new GitHub implementation guide with exact setup checklist, label bootstrap samples, issue form guidance, and explicit human approval transitions
+- `docs/WORK-BACKENDS.md` — clarified which companion artifacts remain in Git, added human approval cheat sheet, and linked the GitHub implementation guide; version bumped to 1.1
+- `docs/github-issues/` — added GitHub issue-form and config samples for signal, mission, task, decision, release, and retrospective workflows; kept them out of the live `.github/ISSUE_TEMPLATE/` path so the template repo itself does not behave like an instance repo
+- `docs/mission-lifecycle.md`, `docs/REQUIRED-GITHUB-SETTINGS.md`, `docs/FILE-GUIDE.md` — corrected remaining git-only assumptions and made issue-backend human steps explicit
+
+_Layer agent instructions updated:_
+- `org/0-steering/AGENT.md` — updated sensing loop input, signal references, and interaction diagram for dual backend; version bumped to 1.3
+- `org/1-strategy/AGENT.md` — updated signal triage input/output, mission brief creation, versioning table, approval mechanism, and continuous improvement signals for dual backend; version bumped to 1.3
+- `org/2-orchestration/AGENT.md` — updated active missions context, work deduplication, task decomposition, status tracking, release preparation, and fleet reporting for dual backend; version bumped to 1.6
+- `org/3-execution/AGENT.md` — updated task pickup, mission brief context, task status updates, improvement signals, and deduplication for dual backend; version bumped to 1.5
+- `org/4-quality/AGENT.md` — updated evaluation context, report storage, versioning table, quality trend analysis, outcome measurement, stall detection, and production signaling for dual backend; version bumped to 1.6
+
+_Process loop files updated:_
+- `process/README.md` — updated "Process Governance" section from "Git-Native" to backend-aware; updated artifact output references in loop tables and feedback diagram
+- `process/1-discover/AGENT.md` — updated signal drafting, mission brief creation, and versioning table for dual backend; version bumped to 1.3
+- `process/1-discover/GUIDE.md` — added issue backend signal creation instructions alongside git-files; updated mission brief creation and submission for dual backend
+- `process/2-build/AGENT.md` — updated task intake, decision records, and submission for dual backend; version bumped to 1.4
+- `process/2-build/GUIDE.md` — updated decision recording, exit criteria, and status updates for dual backend
+- `process/3-ship/AGENT.md` — updated release contract storage, task verification, outcome reports, feedback loop, versioning table, and open tasks rule for dual backend; version bumped to 1.3
+- `process/3-ship/GUIDE.md` — updated signal references, release contract reference, and exit criteria for dual backend
+- `process/4-operate/AGENT.md` — updated cross-layer interaction, signal filing, postmortem storage, signal generation, versioning table, and continuous improvement signals for dual backend; version bumped to 1.2
+- `process/4-operate/GUIDE.md` — updated feedback loop diagram and signal filing references for dual backend
+
+_Archive policy updated:_
+- `docs/ARCHIVE-POLICY.md` — restructured for dual backend: git-files mechanics (archive/ subfolders, git mv) and issue backend mechanics (close issues with final status labels); updated agent integration section; version bumped to 1.1
+
+_Consistency fixes:_
+- Updated regressed `Last updated` and changelog dates in the dual-backend rollout files so the framework metadata matches the current change date and remains auditable
+
+---
+
+### Added (previous)
 
 **Framework taxonomy cleanup for generic adoption (Issue #concept-review)**
 

--- a/CONFIG.yaml
+++ b/CONFIG.yaml
@@ -14,7 +14,7 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # Tracks the overall framework release. Update when cutting a new version.
 # See CHANGELOG.md for what changed. Uses semantic versioning (MAJOR.MINOR.PATCH).
-framework_version: "2.3.0"
+framework_version: "3.0.0"
 # ═══════════════════════════════════════════════════════════════════════════
 
 # ───────────────────────────────────────────────────────────────────────────
@@ -192,11 +192,47 @@ toolchain:
   chat_tool: ""                     # e.g., "Slack", "Teams", "Discord"
 
 # ───────────────────────────────────────────────────────────────────────────
-# 8. INTEGRATIONS (3rd-Party Tool Registry)
+# 8. WORK BACKEND (Where operational work artifacts are tracked)
 # ───────────────────────────────────────────────────────────────────────────
-# External tools that connect to the operating model. The filesystem is the
-# system of record; these integrations extend agent capabilities into the
-# enterprise ecosystem. See org/integrations/ for detailed guides.
+# The operating model defines WHAT artifacts exist (signals, missions, tasks,
+# decisions, etc.) and HOW they flow. WHERE they live is configurable.
+#
+# Options:
+#   "git-files"      — All work artifacts are Markdown files in work/ (original model)
+#   "github-issues"  — Work artifacts are tracked as GitHub Issues with structured labels
+#
+# See docs/WORK-BACKENDS.md for the full guide, label taxonomy, and migration paths.
+#
+# NOTE: Governance backbone files (org/, policies, AGENT.md, templates) ALWAYS
+# stay in Git regardless of this setting. Only operational work artifacts
+# (signals, missions, tasks, decisions, releases, retrospectives) are affected.
+
+work_backend:
+  type: "git-files"                   # "git-files" | "github-issues"
+
+  # Configuration for github-issues backend
+  github_issues:
+    repo: ""                          # empty = same repo; or "org/repo" for a separate issue repo
+    use_projects: true                # use GitHub Projects for Kanban board views
+    use_label_prefixes: true          # use artifact:, status:, layer: label prefixes (recommended)
+
+  # Artifact-level overrides: force specific artifact types to a backend
+  # regardless of the global type setting.
+  # Valid keys: signal, signal-digest, mission, task, decision, release,
+  #             retrospective, quality-eval, outcome-report, fleet-report,
+  #             governance-exception, technical-design, asset-registry, lock
+  overrides:
+    technical-design: "git-files"     # always in git (code-review-adjacent)
+    governance-exception: "git-files" # always in git (audit-critical)
+    asset-registry: "git-files"       # always in git (persistent documentation)
+    # lock: "git-files"              # locks are always git — not configurable
+
+# ───────────────────────────────────────────────────────────────────────────
+# 9. INTEGRATIONS (3rd-Party Tool Registry)
+# ───────────────────────────────────────────────────────────────────────────
+# External tools that connect to the operating model. These integrations
+# extend agent capabilities into the enterprise ecosystem.
+# See org/integrations/ for detailed guides.
 #
 # Categories: observability, enterprise_toolchain, business_systems, communication
 # Each integration defines what it connects to, how, and which layers use it.
@@ -245,7 +281,7 @@ integrations:
     []                                # e.g., [{id: "team-chat", name: "Slack", mcp_server: true}]
 
 # ───────────────────────────────────────────────────────────────────────────
-# 9. QUALITY THRESHOLDS
+# 10. QUALITY THRESHOLDS
 # ───────────────────────────────────────────────────────────────────────────
 
 quality:
@@ -257,7 +293,7 @@ quality:
   deployment_rollback_target_min: 5 # minutes
 
 # ───────────────────────────────────────────────────────────────────────────
-# 10. ORGANIZATION SIZE ESTIMATES
+# 11. ORGANIZATION SIZE ESTIMATES
 # ───────────────────────────────────────────────────────────────────────────
 
 org_size:

--- a/CUSTOMIZATION-GUIDE.md
+++ b/CUSTOMIZATION-GUIDE.md
@@ -1,6 +1,6 @@
 # Customization Guide — Agentic Enterprise Operating Model
 
-> **Version:** 2.2 | **Last updated:** 2026-03-07
+> **Version:** 3.0 | **Last updated:** 2026-03-07
 
 > **Start here** after cloning this framework.
 > This guide walks you through every step of making this operating model your own.
@@ -21,6 +21,7 @@ Open [CONFIG.yaml](CONFIG.yaml) and fill in every field. This gives the framewor
 | `vision.north_star` | Anchors all strategic alignment checks |
 | `vision.mission` | Guides every agent's decision-making |
 | `toolchain.*` | Determines which concrete tools implement your quality policies |
+| `work_backend.type` | Determines where work artifacts are tracked (git files or issue tracker) |
 
 ### Step 2: Search & Replace Placeholders (5 min)
 
@@ -44,7 +45,20 @@ Read and adjust these three files — they set the tone for everything:
 
 If you're a small team or solo founder, start with a **minimal agent fleet** — one agent per active layer. See [Minimal Agent Fleet](#minimal-agent-fleet) below for the exact setup.
 
-### Step 4: Register Your Integrations (5 min)
+### Step 4: Choose Your Work Backend (2 min)
+
+Decide where operational work artifacts (signals, missions, tasks, decisions) will be tracked:
+
+| Backend | Best For | Set In CONFIG.yaml |
+|---------|----------|--------------------|
+| **Git files** (default) | Self-contained, no external dependencies, maximum auditability | `work_backend.type: "git-files"` |
+| **GitHub Issues** | Better human collaboration, native boards, labels, notifications, mobile access | `work_backend.type: "github-issues"` |
+
+If using GitHub, **GitHub Issues is recommended** — it's always available and provides dramatically better visibility for humans. See [docs/WORK-BACKENDS.md](docs/WORK-BACKENDS.md) for the full guide including label taxonomy.
+
+> **Note:** Governance backbone files (org structure, policies, agent instructions, templates) always stay in Git regardless of this choice.
+
+### Step 5: Register Your Integrations (5 min)
 
 Review `CONFIG.yaml → integrations` and register the external tools your organization uses:
 
@@ -55,9 +69,11 @@ Review `CONFIG.yaml → integrations` and register the external tools your organ
 
 See `org/integrations/` for detailed guides per category. Start with observability and CI/CD — they provide the most immediate value.
 
-### Step 5: Start Using It (5 min)
+### Step 6: Start Using It (5 min)
 
-Create your first signal in `work/signals/` and you're live.
+**Git-files backend:** Create your first signal in `work/signals/` and you're live.
+
+**Issue backend:** Create your first GitHub Issue with label `artifact:signal` and you're live. Use the template structure from `work/signals/_TEMPLATE-signal.md` for the issue body.
 
 ---
 
@@ -121,10 +137,10 @@ The last item is the key: even "nothing to improve" is worth filing. It keeps th
 
 ### What You Don't Need
 
-- ❌ External project management tool — missions **are** your tickets
-- ❌ Observability platform for agent health — git history **is** your audit log
-- ❌ Standup meetings — `STATUS.md` **is** the standup
+- ❌ Heavyweight project management tool — missions **are** your tickets (whether as issues or files)
+- ❌ Standup meetings — mission status updates **are** the standup (issue comments or STATUS.md)
 - ❌ Separate OKR framework — `CONFIG.yaml` vision + active missions = your strategy
+- ✅ An issue tracker is optional but **recommended** for human-facing visibility (`work_backend.type: "github-issues"`)
 
 ---
 
@@ -154,7 +170,10 @@ Complete the Quick Start above (Steps 1-4), then:
 
 ### Day 1 — First Signal Flow (30 minutes)
 
-7. **File your first signal** — Create `work/signals/YYYY-MM-DD-<your-first-opportunity>.md` from the template (`work/signals/_TEMPLATE-signal.md`). This is the input that kicks off the entire lifecycle.
+7. **File your first signal:**
+   - **Git-files backend:** Create `work/signals/YYYY-MM-DD-<your-first-opportunity>.md` from the template (`work/signals/_TEMPLATE-signal.md`).
+   - **Issue backend:** Create a GitHub Issue with label `artifact:signal`, `status:new`, and the structured body from the signal template.
+   This is the input that kicks off the entire lifecycle.
 8. **Steering Agent: Produce first digest** — The Steering Agent aggregates signals into a weekly digest (`work/signals/digests/YYYY-WXX-digest.md`), detecting patterns and flagging priorities.
 9. **Strategy Agent: Triage to a mission** — The Strategy Agent consumes the digest, triages signals, and if a signal warrants action:
    - Creates `work/missions/<mission-name>/MISSION-BRIEF.md` from `work/missions/_TEMPLATE-mission-brief.md`
@@ -355,11 +374,12 @@ The framework ships with a generic lifecycle example. Create your own:
 |-----------|------------|-----|
 | 5-layer model | ✅ Yes | Universal organizational pattern |
 | 4-loop lifecycle | ✅ Yes | Universal process pattern |
-| Git-native governance | ✅ Yes | Fundamental to the model |
+| Git-native governance | ✅ Yes | Fundamental to the model (for governance backbone) |
 | Agent instruction hierarchy | ✅ Yes | Critical for multi-agent governance |
 | Improvement signal flow | ✅ Yes | Key innovation of the model |
 | Integration Registry structure | ✅ Yes | Governed connection patterns |
 | Company name/vision/mission | ❌ Customize | Your identity |
+| Work backend choice | ❌ Customize | Git files or issue tracker — your preference |
 | Ventures | ❌ Customize | Your market offerings |
 | Divisions | ❌ Customize | Your organizational units |
 | Quality thresholds | ❌ Customize | Your risk tolerance |

--- a/OPERATING-MODEL.md
+++ b/OPERATING-MODEL.md
@@ -1,8 +1,8 @@
 # Operating Model: The Agentic Enterprise GitOps Model
 
-> **Version:** 2.0 | **Last updated:** 2026-02-23
+> **Version:** 3.0 | **Last updated:** 2026-03-07
 
-> **What this document is:** The meta-description of how this entire system works — the replacement of legacy ticket-based, ceremony-driven, phase-gated product development with a Git-native, agent-driven, outcome-governed operating model.
+> **What this document is:** The meta-description of how this entire system works — the replacement of legacy ticket-based, ceremony-driven, phase-gated product development with an agent-driven, outcome-governed operating model where Git provides the governance backbone and work tracking adapts to the tools that work best for your team.
 > **Audience:** Humans and agents who need to understand the big picture.
 
 > **⚠️ POC / Demo Disclaimer**  
@@ -23,7 +23,7 @@ A fully working operating model for running {{COMPANY_SHORT}} as an agentic ente
 
 - **5 layers** — Steering → Strategy → Orchestration → Execution → Quality — covering the entire company (eng, delivery, GTM, sales, CS, support), not just R&D
 - **4 loops** — Discover → Build → Ship → Operate — replacing legacy phase-gate processes. Idea-to-GA in 2–4 weeks. Continuous production operations feed signals back into Discover.
-- **Git is the system of record** — PRs = decisions. CODEOWNERS = RACI. CI/CD = quality gates. Agents are native Git citizens. Enterprise tools connect through governed integrations.
+- **Git is the governance backbone** — Org structure, policies, agent instructions, and templates are always Git-native. Work tracking (signals, missions, tasks) adapts to your preferred system — Git files or issue trackers. See [docs/WORK-BACKENDS.md](docs/WORK-BACKENDS.md).
 - **Integration-ready** — Observability platforms, ITSM, CI/CD, business systems, and communication channels plug in through a governed Integration Registry (`org/integrations/`). The model works with your existing tools, not against them.
 - **Self-evolving** — Every agent surfaces improvement signals → Steering Layer aggregates → proposes org/process changes as PRs → execs approve by merging. Continuous organizational metabolism, not annual reorgs
 
@@ -113,9 +113,9 @@ The agentic enterprise model does not require replacing every tool in your organ
 
 | Traditional Concept | Agentic Enterprise Equivalent | Relationship |
 |---------------|----------------------|-----------------|
-| **Ticket (Jira/Linear)** | Markdown file in `work/` | System of record moves to Git; existing tools can sync via Integration Registry |
-| **Ticket workflow** | Git branch → PR → merge | Governance is Git-native; status can be projected to existing tools |
-| **Board/Kanban** | Auto-generated dashboards from `work/` | Visualization is decoupled from data — use existing dashboards or build new ones |
+| **Ticket (Jira/Linear)** | Work artifact (issue or Markdown) | Tracked in configured work backend (`CONFIG.yaml → work_backend`) — either as issues with structured labels or as Markdown files in `work/` |
+| **Ticket workflow** | Label transitions or Git branch → PR → merge | Governance adapts to backend; status labels replace file status fields |
+| **Board/Kanban** | GitHub Projects or auto-generated views | Native board views with issue backend; generated from files with git-files backend |
 | **Sprint planning** | Mission brief creation | Goal-oriented, not time-boxed |
 | **Sprint review** | PR review with embedded evidence | Continuous, not biweekly |
 | **Daily standup** | Git log + fleet observability dashboards | Always current, no meetings; observability provides real-time fleet health |
@@ -178,34 +178,34 @@ The agentic enterprise model does not require replacing every tool in your organ
                            └──────────────────────────────────┘
 ```
 
-Every arrow in this diagram is a **Git operation** (commit, branch, PR, merge, review comment) — the system of record. In practice, agents also interact with enterprise tools (observability platforms, ITSM, CI/CD, communication channels) through governed integrations. Git remains the canonical record; external tools extend the operating model's reach.
+Every arrow in this diagram is a **governed operation** — a Git commit, PR, issue state change, or label transition — depending on the configured work backend. Git remains the canonical record for governance decisions; the work backend handles operational tracking. In practice, agents also interact with enterprise tools (observability platforms, ITSM, CI/CD, communication channels) through governed integrations.
 
 ---
 
 ## Artifact Flow: The Complete Chain
 
-Every handoff between layers and loops is mediated by a concrete artifact stored in the repository. No implicit handoffs.
+Every handoff between layers and loops is mediated by a concrete artifact. No implicit handoffs. Artifacts are tracked in the configured work backend (see `CONFIG.yaml → work_backend` and [docs/WORK-BACKENDS.md](docs/WORK-BACKENDS.md)).
+
+**Git-files backend:** Artifacts are Markdown files in `work/` as shown below.
+**Issue backend:** Artifacts are issues with `artifact:*` labels. The same logical flow applies — just the medium changes.
 
 ```
-Signal (work/signals/)
+Signal (work/signals/ or issue with artifact:signal)
   │
-  ├─ Steering: Signal Digest (work/signals/digests/)
+  ├─ Steering: Signal Digest
   │
   ▼
-Mission Brief (work/missions/<name>/BRIEF.md)
-  + Outcome Contract (work/missions/<name>/OUTCOME-CONTRACT.md)
+Mission Brief + Outcome Contract
   │
   ├─ Orchestration: Fleet Config (org/2-orchestration/fleet-configs/<mission>.md)
-  │                  Mission Status (work/missions/<name>/STATUS.md)
+  │                  Mission Status (append-only updates)
   │                  Fleet Performance Report
   │
-  ├─ Technical Design (work/missions/<name>/TECHNICAL-DESIGN.md)
-  │  (for design-required missions: API contracts, data models,
-  │   interface specs, behavioral specs, threat model, perf budgets)
+  ├─ Technical Design (always in Git — code-review-adjacent)
   │
   ▼
 Execution Outputs (code PRs, docs, content, assets)
-  + Asset Registry (work/assets/<asset>.md)
+  + Asset Registry (always in Git — persistent documentation)
   + Runbooks (per service)
   │
   ├─ Quality: Evaluation Reports (work/missions/<name>/evaluations/)
@@ -247,14 +247,15 @@ See [org/agents/README.md](org/agents/README.md) for the full lifecycle document
 
 ### Layer 1: Git + PR Interface (The Foundation)
 
-Every human interaction ultimately maps to a Git operation. But the *surface* varies by role:
+Every human interaction ultimately maps to a governed operation — a Git commit, issue state change, or label transition. The *surface* varies by role:
 
 | Interaction Surface | Who Uses It | What They Do |
 |---|---|---|
-| **{{GIT_HOST}} Web UI** | Everyone | Review PRs, approve merges, browse structure |
+| **{{GIT_HOST}} Web UI** | Everyone | Review PRs, approve merges, browse structure, triage issues |
 | **IDE (VS Code + Copilot)** | Tech Leads, Policy Authors | Edit policies, review code, write decision records |
 | **Git CLI** | Agent Fleet Managers, advanced users | Scripted operations, bulk changes |
-| **Chat / Messaging Interface** | Outcome Owners, Executives, all layers | Natural-language commands → agent actions → PRs |
+| **Issue Tracker** | Everyone | Triage signals, track missions, assign tasks, comment on progress |
+| **Chat / Messaging Interface** | Outcome Owners, Executives, all layers | Natural-language commands → agent actions → PRs/issues |
 | **Dashboard / Web App** | Executives, Mission Leads, Fleet Managers | Real-time mission status, fleet health, quality metrics |
 | **Mobile notifications** | Outcome Owners, on-call | Approve/reject decisions, escalation alerts |
 
@@ -273,14 +274,14 @@ Agent:            [merges PR #247, creates enablement branch, notifies
                   "Done. PR #247 merged. Enablement stream initiated."
 ```
 
-**Key design principle:** Every chat action that changes state produces a Git commit. Chat is the *input surface*, Git is the *state machine*. Conversations are ephemeral; Git is permanent.
+**Key design principle:** Every chat action that changes state produces a governed record — a Git commit, issue update, or label change. Chat is the *input surface*, the work backend is the *state machine*. Conversations are ephemeral; the audit trail is permanent.
 
 ### Layer 3: Web UIs & Dashboards (The Visual Layer)
 
 | UI | Purpose | Data Source |
 |---|---|---|
-| **Mission Control Dashboard** | Kanban-style view of all active missions | `work/missions/` + Git activity |
-| **Signal Triage Board** | Incoming signals ranked by urgency/impact | `work/signals/` + agent analysis |
+| **Mission Control Dashboard** | Kanban-style view of all active missions | Work backend (issues or `work/missions/`) |
+| **Signal Triage Board** | Incoming signals ranked by urgency/impact | Work backend (issues or `work/signals/`) |
 | **Fleet Performance Dashboard** | Agent throughput, error rates, cost per task | {{OBSERVABILITY_TOOL}} metrics |
 | **Quality Scorecard** | Per-division quality grades, compliance rates | `org/4-quality/` evaluation results |
 | **Org Health Visualizer** | Interactive 5-layer org chart | `org/` folder structure |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <img src="https://img.shields.io/badge/model-Agentic%20Enterprise-blueviolet" alt="Agentic Enterprise">
-  <img src="https://img.shields.io/badge/version-1.0.0-brightgreen" alt="Version">
+  <img src="https://img.shields.io/badge/version-3.0.0-brightgreen" alt="Version">
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License">
   <img src="https://img.shields.io/badge/runtime-bring%20your%20own-orange" alt="Runtime">
   <a href="https://github.com/wlfghdr/agentic-enterprise/actions/workflows/validate.yml">
@@ -91,7 +91,7 @@ Loop 4 feeds signals back into Loop 1 via two channels: telemetry from the obser
 
 | Legacy | Agentic Enterprise | Why Better |
 |--------|-------------------|------------|
-| Ticket system | Markdown in `work/` | Version-controlled, diffable, agent-readable |
+| Ticket system | Work artifacts in `work/` or issue tracker | Version-controlled, diffable, agent-readable; or native issue UI for human triage |
 | Sprint planning | Mission briefs | Goal-oriented, not time-boxed |
 | Daily standup | `git log` + dashboards | Always current, no meetings |
 | Wiki / knowledge base | This repository | Single source of truth |
@@ -183,11 +183,12 @@ Before doing anything, read these files in order:
 
 Key principles:
 - Two native communication channels: the **repo** (natural language files — read instructions, produce artifacts, file signals) and the **observability platform** (real-time telemetry — emit spans as you act, consume operational data before deciding).
-- Everything is in Git. PRs = decisions. CODEOWNERS = RACI.
-- You recommend; humans decide (via PR merge).
+- Git is the governance backbone. PRs = decisions. CODEOWNERS = RACI.
+- Work tracking is configurable: Markdown files in work/ or issues in an issue tracker (see CONFIG.yaml → work_backend).
+- You recommend; humans decide (via PR merge or label transition).
 - Every claim must be grounded in evidence.
 - Stay in your lane — read your layer's boundaries.
-- Surface improvement signals to work/signals/ when you spot issues.
+- Surface improvement signals (to work/signals/ or as issues with artifact:signal label).
 
 Repository structure:
 - org/ — Organizational structure (5 layers)

--- a/docs/ARCHIVE-POLICY.md
+++ b/docs/ARCHIVE-POLICY.md
@@ -1,10 +1,16 @@
 # Archive Policy (Work Artifact Lifecycle)
 
-All `work/` directories follow the same lifecycle: **active → done → archived**.
+> **Version:** 1.1 | **Last updated:** 2026-03-07
 
-Archiving keeps active directories clean and scannable while preserving full history in git.
+All work artifacts follow the same lifecycle: **active → done → archived**.
 
-## Archive Mechanics
+Archiving keeps active views clean and scannable while preserving full history. The mechanics depend on your configured work backend (see `CONFIG.yaml → work_backend` and [WORK-BACKENDS.md](WORK-BACKENDS.md)).
+
+---
+
+## Git-Files Backend
+
+### Archive Mechanics
 
 Every `work/<area>/` directory may contain an `archive/` subfolder. When items reach a terminal state, they move there.
 
@@ -28,7 +34,7 @@ work/
     archive/          ← superseded design docs
 ```
 
-## When to Archive
+### When to Archive
 
 | Area | Archive trigger |
 |------|----------------|
@@ -41,7 +47,7 @@ work/
 | **decisions** | Decision implemented + referenced in mission/PR |
 | **designs** | Design superseded by newer version or implementation complete |
 
-## How to Archive
+### How to Archive
 
 **Option A: git mv** (preferred — preserves blame)
 ```bash
@@ -55,7 +61,7 @@ git mv work/missions/old-mission/ work/missions/archive/
 ./scripts/archive_work.sh --dry-run  # preview only
 ```
 
-## Rules
+### Rules
 
 1. **Never delete** work artifacts from the repo — always archive (git history = audit trail)
 2. **Archive entire mission folders** (not individual files inside a mission)
@@ -64,9 +70,47 @@ git mv work/missions/old-mission/ work/missions/archive/
 5. **README.md** files in each directory stay (never archived)
 6. **Agents ignore `archive/`** — when scanning active work, skip the archive subfolder
 
+---
+
+## Issue Backend (GitHub Issues)
+
+When `work_backend.type` is `"github-issues"`, archiving is equivalent to **closing** issues. Closed issues remain searchable and serve as the historical record — no data is lost.
+
+### When to Close
+
+The same triggers from the git-files table apply. When an artifact reaches a terminal state, close its corresponding issue.
+
+### How to Close
+
+1. **Apply final status label** before closing — e.g., `status:completed`, `status:done`, `status:upstream-issued`, `status:superseded`
+2. **Add a closing comment** summarizing the outcome or linking to the follow-up work
+3. **Close the issue** (not delete)
+
+For missions tracked as issue hierarchies:
+- Close child task issues first
+- Close the parent mission issue last
+- The parent issue's closing comment should summarize the mission outcome
+
+### Rules
+
+1. **Never delete** issues — close them with a resolution note
+2. **Always apply final status labels** before closing (enables filtering and reporting)
+3. **Closed issues remain searchable** — they are the audit trail equivalent of `archive/` subfolders
+4. **Templates** (issues with `template:*` labels, if any) are not closed
+5. **Agents filter by open status** — when scanning active work, query only open issues
+
+---
+
 ## Agent Integration
 
 This policy is referenced in AGENTS.md Rule 14. All agents should:
+
+**Git-files backend:**
 - Archive items they close (in the same commit/PR)
 - Orchestration agents: periodically scan for archivable items
 - Never scan `archive/` subfolders when looking for active work
+
+**Issue backend:**
+- Close issues they complete (apply final status label + closing comment)
+- Orchestration agents: periodically scan for closable issues
+- Filter by open status when looking for active work

--- a/docs/FILE-GUIDE.md
+++ b/docs/FILE-GUIDE.md
@@ -38,15 +38,16 @@ The `.github/` folder mixes OSS infrastructure with governance tooling that's ge
 **Quick summary:**
 - **Keep:** `workflows/validate.yml`, `PULL_REQUEST_TEMPLATE.md`, `copilot-instructions.md`
 - **Keep if using the CI feature:** `workflows/policy.yml`, `workflows/security.yml`
-- **Delete:** `workflows/stale.yml`, `ISSUE_TEMPLATE/`
+- **Keep if using issue backend:** `workflows/stale.yml`, `ISSUE_TEMPLATE/`
+- **Delete if using git-files backend:** `workflows/stale.yml`, `ISSUE_TEMPLATE/`
 
 | File / Folder | OSS purpose | Company fork action |
 |---|---|---|
 | `workflows/validate.yml` | Core CI: validates operating model docs, schemas, locks, placeholders | **Keep** — these gates enforce governance in your fork too. They check that your config, policies, and artifacts stay consistent. |
 | `workflows/policy.yml` | OPA/Conftest policy enforcement (workflow permissions, pinned actions) | **Keep** if using the Policy-as-Code gate (see `docs/POLICY-AS-CODE.md`); delete if not |
 | `workflows/security.yml` | Gitleaks secret scanning + GitHub Dependency Review | **Keep** if using security scanning (see `docs/SECURITY-SCANNING.md`); delete if not |
-| `workflows/stale.yml` | Marks and closes stale GitHub Issues/PRs (OSS housekeeping) | **Delete** — irrelevant in a private fork. Your work flows through `work/signals/` and `work/missions/`, not GitHub Issues. |
-| `ISSUE_TEMPLATE/` | Bug report and config forms for OSS contributors | **Delete** — your fork uses `work/signals/` for signal intake, not GitHub Issues for internal triage |
+| `workflows/stale.yml` | Marks and closes stale GitHub Issues/PRs (OSS housekeeping) | **Keep if using issue backend** (`work_backend.type: github-issues`) for housekeeping stale issues. **Delete if using git-files backend.** |
+| `ISSUE_TEMPLATE/` | Bug report and config forms for OSS contributors | **Template repo:** keep for OSS contributor workflows. **Company fork with issue backend:** replace/adapt using the samples in `docs/github-issues/`. **Company fork with git-files backend:** delete if not needed. |
 | `PULL_REQUEST_TEMPLATE.md` | PR checklist reminding contributors to cite policies and evidence | **Keep and adapt** — update checklist items to match your fork's governance conventions |
 | `copilot-instructions.md` | GitHub Copilot agent instructions for working in this repo | **Keep and update** — edit after customization to reference your company name, divisions, and active missions |
 | `prompts/` | Agent skill prompts (e.g., `/deploy` workflow) | **Keep and adapt** — update prompts to reference your company's structure and toolchain |
@@ -65,7 +66,7 @@ The `.github/` folder mixes OSS infrastructure with governance tooling that's ge
 | `CODEOWNERS` | RACI map — who approves what. Replace placeholder role names with real GitHub team names. | Populate with actual `@org/team-name` handles |
 | `org/` | Org structure: 5 layers, agent type registry, integration registry, quality policies. | Customise divisions, add ventures, fill in integration configs |
 | `process/` | 4-loop lifecycle guides (Discover → Build → Ship → Operate). | Adjust to your actual delivery workflow |
-| `work/` | Active work artifacts — signals, missions, decisions, releases, retrospectives. | Use daily. File signals, open missions, record decisions. |
+| `work/` | Active work artifacts — signals, missions, decisions, releases, retrospectives. When using issue backend, contains only templates and persistent artifacts (technical designs, asset registry, governance exceptions). | Use daily. File signals, open missions, record decisions — in git files or in the configured issue tracker. |
 
 ---
 
@@ -132,7 +133,8 @@ concept-visualization.html
 
 # .github/ — keep selectively (see per-file table above)
 # Keep: validate.yml, PULL_REQUEST_TEMPLATE.md, copilot-instructions.md
-# Delete: stale.yml, ISSUE_TEMPLATE/
+# Keep if using issue backend: stale.yml, ISSUE_TEMPLATE/
+# Delete if using git-files backend: stale.yml, ISSUE_TEMPLATE/
 ```
 
 ---

--- a/docs/GITHUB-ISSUES.md
+++ b/docs/GITHUB-ISSUES.md
@@ -1,0 +1,290 @@
+# GitHub Issues Backend Guide
+
+> **Version:** 1.0 | **Last updated:** 2026-03-07
+
+> **What this document is:** The concrete implementation guide for running operational work artifacts in GitHub Issues. Use this when `CONFIG.yaml → work_backend.type` is `github-issues`.
+
+---
+
+## Goal
+
+This guide makes the GitHub issue backend operational without implicit knowledge.
+
+If a human needs to approve something, the required label change is written out explicitly.
+If GitHub needs configuration, the exact repo settings, labels, and issue forms are listed here.
+
+Use this guide together with [WORK-BACKENDS.md](WORK-BACKENDS.md) and [REQUIRED-GITHUB-SETTINGS.md](REQUIRED-GITHUB-SETTINGS.md).
+
+---
+
+## Minimum Setup Checklist
+
+Complete these steps before using the issue backend in a real fork:
+
+1. Set `work_backend.type: "github-issues"` in `CONFIG.yaml`.
+2. Enable GitHub Issues and Issue Forms in the repository settings.
+3. Copy the sample forms from `docs/github-issues/forms/` into `.github/ISSUE_TEMPLATE/` in your instance repository.
+4. Copy `docs/github-issues/config.sample.yml` to `.github/ISSUE_TEMPLATE/config.yml` in your instance repository and customize the links.
+5. Create the required labels listed below.
+6. Tell humans who approve work to use the approval transitions exactly as written in the approval table.
+7. Keep Git-backed companion artifacts in the repository: signal digests, technical designs, quality evaluations, fleet reports, outcome reports, asset registry entries, governance exceptions, and locks.
+
+---
+
+## CONFIG.yaml Sample
+
+Use this as the minimal GitHub-backed configuration:
+
+```yaml
+work_backend:
+  type: "github-issues"
+
+  github_issues:
+    repo: ""                    # empty = same repo
+    use_projects: true
+    use_label_prefixes: true
+
+  overrides:
+    technical-design: "git-files"
+    governance-exception: "git-files"
+    asset-registry: "git-files"
+```
+
+Example for a dedicated issue repository:
+
+```yaml
+work_backend:
+  type: "github-issues"
+
+  github_issues:
+    repo: "acme/operating-work"
+    use_projects: true
+    use_label_prefixes: true
+
+  overrides:
+    technical-design: "git-files"
+    governance-exception: "git-files"
+    asset-registry: "git-files"
+```
+
+---
+
+## Required Labels
+
+These labels are the minimum viable set for the issue backend.
+
+### Artifact Labels
+
+- `artifact:signal`
+- `artifact:mission`
+- `artifact:task`
+- `artifact:decision`
+- `artifact:release`
+- `artifact:retrospective`
+
+### Status Labels
+
+- `status:new`
+- `status:proposed`
+- `status:approved`
+- `status:planning`
+- `status:active`
+- `status:paused`
+- `status:completed`
+- `status:cancelled`
+- `status:pending`
+- `status:in-progress`
+- `status:blocked`
+- `status:proceed`
+- `status:defer`
+- `status:monitor`
+- `status:done`
+- `status:accepted`
+- `status:superseded`
+- `status:deprecated`
+- `status:draft`
+- `status:deploying`
+- `status:deployed`
+- `status:rolled-back`
+
+### Layer Labels
+
+- `layer:steering`
+- `layer:strategy`
+- `layer:orchestration`
+- `layer:execution`
+- `layer:quality`
+
+### Loop Labels
+
+- `loop:discover`
+- `loop:build`
+- `loop:ship`
+- `loop:operate`
+
+### Priority Labels
+
+- `priority:critical`
+- `priority:high`
+- `priority:medium`
+- `priority:low`
+
+### Recommended Additional Labels
+
+- `urgency:immediate`
+- `urgency:next-cycle`
+- `urgency:monitor`
+- `category:market`
+- `category:customer`
+- `category:technical`
+- `category:internal`
+- `category:competitive`
+- `category:financial`
+- `confidence:high`
+- `confidence:medium`
+- `confidence:low`
+
+### Label Rule
+
+Use exactly one `status:` label per issue.
+When the state changes, remove the old `status:*` label and add the new one in the same action.
+
+---
+
+## Label Bootstrap Sample
+
+If you manage labels as code, this YAML structure is a practical starting point:
+
+```yaml
+labels:
+  - name: "artifact:signal"
+    color: "1D76DB"
+    description: "Operational signal"
+  - name: "artifact:mission"
+    color: "5319E7"
+    description: "Mission issue"
+  - name: "artifact:task"
+    color: "0E8A16"
+    description: "Mission task"
+  - name: "artifact:decision"
+    color: "0052CC"
+    description: "Decision record"
+  - name: "artifact:release"
+    color: "FBCA04"
+    description: "Release contract"
+  - name: "artifact:retrospective"
+    color: "B60205"
+    description: "Incident retrospective"
+  - name: "status:new"
+    color: "D4C5F9"
+    description: "Freshly filed"
+  - name: "status:proposed"
+    color: "C2E0C6"
+    description: "Awaiting human approval"
+  - name: "status:approved"
+    color: "0E8A16"
+    description: "Approved by authorized human"
+  - name: "status:active"
+    color: "1D76DB"
+    description: "Work is in flight"
+  - name: "status:completed"
+    color: "5319E7"
+    description: "Work completed"
+  - name: "status:blocked"
+    color: "B60205"
+    description: "Blocked pending action"
+  - name: "status:draft"
+    color: "F9D0C4"
+    description: "Draft awaiting approval"
+```
+
+If you prefer GitHub CLI, create labels with `gh label create` using the same names.
+
+---
+
+## Human Approval Table
+
+Humans should not have to guess what “approve” means.
+
+Use these approval actions exactly:
+
+| Artifact | Human action | Approval result |
+|----------|--------------|-----------------|
+| Signal | Review the issue, leave a short rationale comment, replace `status:new` with one of `status:proceed`, `status:defer`, `status:monitor`, or `status:done` | Signal is triaged |
+| Mission | Review scope and outcome contract, leave a short approval comment, replace `status:proposed` with `status:approved` | Mission may move to planning |
+| Decision | Review context and tradeoffs, leave a short approval comment, replace `status:proposed` with `status:accepted` | Decision is accepted |
+| Release | Review rollout and rollback plan, leave a short approval comment, replace `status:draft` with `status:approved` | Deployment may begin |
+| Retrospective | Review findings and follow-ups, leave a short approval comment, replace `status:draft` with `status:accepted` | Postmortem is closed |
+
+Do not use issue closure as the approval signal.
+Closure archives completed work. The label transition is the approval event.
+
+---
+
+## Human Operating Rules
+
+These rules keep the issue backend consistent:
+
+1. Never leave multiple `status:` labels on one issue.
+2. Always leave a short comment when approving, rejecting, or cancelling.
+3. Close completed work only after the final status label is applied.
+4. Close child task issues before closing the parent mission issue.
+5. For missions, keep the issue body as the current mission brief and use comments for running status updates.
+6. For tasks, put acceptance criteria directly in the task issue body so execution and quality agents can evaluate against them.
+
+---
+
+## Sample Files To Copy Into An Instance Repo
+
+This template repository keeps the operational GitHub issue forms as documentation samples so the framework repo itself does not behave like an instance repo.
+
+Copy these into `.github/ISSUE_TEMPLATE/` in your company fork when you enable the issue backend:
+
+- `docs/github-issues/config.sample.yml`
+- `docs/github-issues/forms/signal.sample.yml`
+- `docs/github-issues/forms/mission.sample.yml`
+- `docs/github-issues/forms/task.sample.yml`
+- `docs/github-issues/forms/decision.sample.yml`
+- `docs/github-issues/forms/release.sample.yml`
+- `docs/github-issues/forms/retrospective.sample.yml`
+
+These samples pre-apply the base artifact labels and ask for the fields humans typically forget.
+
+---
+
+## GitHub Projects Recommendation
+
+If `use_projects: true`, create these minimum views:
+
+| Project View | Filter |
+|--------------|--------|
+| Signal Triage | `label:artifact:signal is:open` |
+| Active Missions | `label:artifact:mission is:open` |
+| Mission Tasks | `label:artifact:task is:open` |
+| Release Pipeline | `label:artifact:release is:open` |
+
+---
+
+## Companion Git Artifacts That Still Matter
+
+Even with GitHub Issues enabled, these stay in Git:
+
+- `work/signals/digests/`
+- `work/missions/<name>/TECHNICAL-DESIGN.md`
+- `work/missions/<name>/evaluations/`
+- `work/missions/<name>/FLEET-REPORT.md`
+- `work/missions/<name>/OUTCOME-REPORT.md`
+- `work/assets/`
+- `work/decisions/EXC-*.md`
+- `work/locks/`
+
+The issue backend is for operational coordination.
+Git still holds the durable review-heavy artifacts.
+
+---
+
+## Changelog
+
+| Version | Date | Change |
+|---|---|---|
+| 1.0 | 2026-03-07 | Initial version — concrete GitHub issue-backend implementation guide |

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,8 @@ Each document falls into one of three categories:
 | [`PLACEHOLDER-CHECK.md`](PLACEHOLDER-CHECK.md) | CI feature | ✅ Template CI gate | **Keep** if using placeholder CI gate; delete otherwise |
 | [`SCHEMA-GUIDE.md`](SCHEMA-GUIDE.md) | CI feature | ✅ Template CI gate | **Keep** if using schema validation; delete otherwise |
 | [`mission-lifecycle.md`](mission-lifecycle.md) | Process reference | ✅ Framework doc | **Keep** — mission lifecycle, status transitions, Divide & Conquer pattern |
+| [`GITHUB-ISSUES.md`](GITHUB-ISSUES.md) | Setup reference | ✅ Framework doc | **Keep** — concrete GitHub issue-backend implementation guide |
+| [`WORK-BACKENDS.md`](WORK-BACKENDS.md) | Setup reference | ✅ Framework doc | **Keep** — guide to work backend choice (git-files vs. issue tracker) |
 
 ---
 
@@ -33,7 +35,9 @@ Guides that help you bootstrap a new fork or understand the framework structure.
 | Guide | Purpose |
 |---|---|
 | [`FILE-GUIDE.md`](FILE-GUIDE.md) | Maps every root file to a category (OSS infrastructure, company content, or agent bootstrap). Answers "what do I keep, what do I delete?" for every file including `.github/` configs. |
+| [`GITHUB-ISSUES.md`](GITHUB-ISSUES.md) | Concrete GitHub issue-backend implementation guide: setup checklist, labels, issue forms, approval steps, and config samples. |
 | [`REQUIRED-GITHUB-SETTINGS.md`](REQUIRED-GITHUB-SETTINGS.md) | Checklist for GitHub branch protection, CODEOWNERS enforcement, and required status checks. Without this, PRs are advisory — not binding. |
+| [`WORK-BACKENDS.md`](WORK-BACKENDS.md) | Comprehensive guide to work artifact tracking backends: git-files vs. issue trackers. Label taxonomy, structural conventions, agent behavior differences, migration paths. |
 | [`mission-lifecycle.md`](mission-lifecycle.md) | End-to-end mission lifecycle: status transitions, Divide & Conquer decomposition, gate requirements, anti-patterns. Required reading for Orchestration and Execution agents. |
 
 ---

--- a/docs/REQUIRED-GITHUB-SETTINGS.md
+++ b/docs/REQUIRED-GITHUB-SETTINGS.md
@@ -11,16 +11,35 @@ Use this checklist when you fork/customize the framework.
 
 ---
 
-## 1) Enable Issues (recommended)
+## 1) Enable Issues
 
 Repo → **Settings → General → Features**
 - ✅ Issues
 
-> **Company fork note:** If your fork is private and uses `work/signals/` for signal intake rather than GitHub Issues for internal triage, you may disable Issues. The signals workflow is the native intake mechanism. GitHub Issues remain useful for external contributors or public-facing bug reports.
+> **Company fork note:** If `CONFIG.yaml → work_backend.type` is `github-issues`, this is required, not optional. If you stay on `git-files`, Issues can remain disabled for internal operations.
 
 ---
 
-## 2) Protect the default branch (`main`)
+## 2) If using the issue backend, enable issue forms and labels before going live
+
+Repo → **Settings → General → Features**
+- ✅ Issues
+- ✅ Issue forms
+
+Then copy the sample files from `docs/github-issues/` into `.github/ISSUE_TEMPLATE/` in your instance repository and customize them.
+
+Minimum required label families for a usable GitHub issue backend:
+- `artifact:` labels for each issue-backed artifact type
+- `status:` labels for each governed state transition
+- `layer:` labels for ownership
+- `loop:` labels for lifecycle stage
+- `priority:` labels for triage
+
+Use [docs/GITHUB-ISSUES.md](GITHUB-ISSUES.md) for the exact label set, human approval transitions, and setup checklist.
+
+---
+
+## 3) Protect the default branch (`main`)
 
 Repo → **Settings → Branches → Branch protection rules**
 
@@ -45,14 +64,14 @@ Recommended minimum rule for `main`:
 
 ---
 
-## 3) CODEOWNERS must exist and be meaningful
+## 4) CODEOWNERS must exist and be meaningful
 
 - Keep `CODEOWNERS` current.
 - Treat it as **executable RACI**: sensitive paths (policies, operating model, agent instructions) must have explicit owners.
 
 ---
 
-## 4) Required checks: keep the gate list small and non-controversial
+## 5) Required checks: keep the gate list small and non-controversial
 
 Start with the repo’s built-in validation workflow:
 - YAML parse checks
@@ -64,7 +83,7 @@ Then add stronger gates (security scans, policy-as-code) as you adopt them.
 
 ---
 
-## 5) Operating model note
+## 6) Operating model note
 
 The model’s rule of thumb:
 - **PRs = decisions**
@@ -72,3 +91,11 @@ The model’s rule of thumb:
 - **CI = quality gates**
 
 Without branch protection, these become advisory.
+
+If you use the issue backend, add one more operating rule for humans:
+- **Approval = explicit status label transition by an authorized human**
+
+Examples:
+- Mission approval: replace `status:proposed` with `status:approved`
+- Release approval: replace `status:draft` with `status:approved`
+- Signal triage: replace `status:new` with one of `status:proceed`, `status:defer`, `status:monitor`, or `status:done`

--- a/docs/WORK-BACKENDS.md
+++ b/docs/WORK-BACKENDS.md
@@ -1,0 +1,389 @@
+# Work Backends — Git Files vs. Issue Tracker
+
+> **Version:** 1.1 | **Last updated:** 2026-03-07
+
+> **What this document is:** A comprehensive guide to how work artifacts can be tracked using different backends — either as Markdown files in Git (the original model) or as issues in an issue tracker (GitHub Issues, Jira, Linear, etc.).
+
+---
+
+## Why Two Backends?
+
+The operating model defines **what artifacts exist** and **how they flow** between layers and loops. The original framework tracked everything as Markdown files in `work/`. This is fully self-contained and auditable, but creates friction for human collaboration:
+
+- **Visibility:** Scanning 20+ Markdown files to understand mission status is harder than glancing at a labeled issue board.
+- **Interaction:** Commenting, assigning, re-labeling, and triaging are native to issue trackers — and clunky via file edits + PRs.
+- **Notifications:** Issue trackers have built-in notification, mention, and subscription systems.
+- **Mobile:** Issue trackers work well on mobile. Editing Markdown in a repo does not.
+- **Collaboration:** Discussion threads, reactions, and cross-references are first-class in issue trackers.
+
+The framework now supports **both backends**. The choice is made at instance configuration time via `CONFIG.yaml → work_backend`.
+
+---
+
+## The Three File Categories
+
+Not everything moves. The framework distinguishes three categories:
+
+### 1. Governance Backbone — Always in Git
+
+These define the **structure, rules, and shape** of the organization. They change slowly and deliberately. They are **never** tracked in an issue system.
+
+| What | Location | Why Git |
+|------|----------|---------|
+| Org structure | `org/` | Defines layers, divisions, agent types |
+| Quality policies | `org/4-quality/policies/` | Law — changes need PR review |
+| Agent instructions | `org/*/AGENT.md` | Agent behavior boundary — needs version control |
+| Agent type registry | `org/agents/` | Governed lifecycle (proposed → active → deprecated) |
+| Process definitions | `process/` | Loop-by-loop guides |
+| Integration registry | `org/integrations/` | Governed connections to external tools |
+| Configuration | `CONFIG.yaml` | Source of truth for everything configurable |
+| Global rules | `AGENTS.md`, `CLAUDE.md` | Non-negotiable agent rules |
+| Templates | `_TEMPLATE-*.md` everywhere | Schema definitions — stay in Git as references |
+
+### 2. Persistent Documentation Artifacts — Always in Git
+
+These are **long-lived deliverables** that benefit from version control, code review, and diff history.
+
+| Artifact | Why Git |
+|----------|---------|
+| **Technical Designs** | Architecture decisions tightly coupled to code — need PR-based review |
+| **Asset Registry Entries** | Persistent documentation references — part of the knowledge base |
+| **Governance Exceptions** | Audit-critical — time-bounded policy overrides need full traceability |
+| **Runbooks** | Operational procedures co-located with service definitions |
+| **Signal Digests** | Weekly synthesis artifacts consumed across layers — diffable history matters more than issue interaction |
+| **Quality Evaluation Reports** | Immutable evidence artifacts that should not be edited through issue comments |
+| **Outcome Reports** | Measured results against the outcome contract — stored as durable mission evidence |
+| **Fleet Performance Reports** | Periodic fleet analysis that benefits from file-based version history |
+
+### 3. Operational Work Artifacts — Configurable Backend
+
+These are the **dynamic, frequently-changing** artifacts that track active work. They can live in Git files OR in an issue tracker.
+
+| Artifact | Git Files | Issue Tracker |
+|----------|-----------|--------------|
+| **Signals** | `work/signals/YYYY-MM-DD-name.md` | Issue with `artifact:signal` label |
+| **Missions** | `work/missions/<name>/BRIEF.md` | Issue with `artifact:mission` label |
+| **Outcome Contracts** | `work/missions/<name>/OUTCOME-CONTRACT.md` | Section in mission issue body or linked issue |
+| **Mission Status** | `work/missions/<name>/STATUS.md` (append-only) | Comments on mission issue |
+| **Tasks** | `work/missions/<name>/TASKS.md` | Sub-issues linked to mission issue |
+| **Decision Records** | `work/decisions/YYYY-MM-DD-name.md` | Issue with `artifact:decision` label |
+| **Release Contracts** | `work/releases/YYYY-MM-DD-name.md` | Issue with `artifact:release` label |
+| **Retrospectives** | `work/retrospectives/YYYY-MM-DD-name.md` | Issue with `artifact:retrospective` label |
+| **Locks** | `work/locks/<lock-id>.md` | Not applicable — locks stay in Git (concurrency mechanism) |
+
+---
+
+## Configuring the Work Backend
+
+Set the backend in `CONFIG.yaml`:
+
+```yaml
+work_backend:
+  type: "github-issues"    # "git-files" | "github-issues"
+
+  github_issues:
+    repo: ""                # empty = same repo; or "org/repo" for separate issue repo
+    use_projects: true      # use GitHub Projects for Kanban board views
+    use_label_prefixes: true # use artifact:, status:, layer: prefixes
+
+  overrides:
+    # Force specific artifacts to a backend regardless of the global type.
+    # Useful when most work is in issues but some artifacts must stay in Git.
+    technical-design: "git-files"
+    governance-exception: "git-files"
+    asset-registry: "git-files"
+    # lock: "git-files"  ← always git, not configurable
+```
+
+When `work_backend.type` is `"git-files"` (the default), the framework behaves exactly as before — all work artifacts are Markdown files in `work/`.
+
+---
+
+## Issue Backend: Label Taxonomy
+
+When using an issue tracker, **labels replace file paths and YAML frontmatter** as the primary metadata mechanism. The following label taxonomy provides the same structural information that the Markdown templates encode.
+
+### Artifact Type Labels (`artifact:`)
+
+| Label | Maps to Template |
+|-------|-----------------|
+| `artifact:signal` | `_TEMPLATE-signal.md` |
+| `artifact:mission` | `_TEMPLATE-mission-brief.md` |
+| `artifact:task` | `_TEMPLATE-tasks.md` (individual task) |
+| `artifact:decision` | `_TEMPLATE-decision-record.md` |
+| `artifact:release` | `_TEMPLATE-release-contract.md` |
+| `artifact:retrospective` | `_TEMPLATE-postmortem.md` |
+| `artifact:governance-exception` | `_TEMPLATE-governance-exception.md` |
+
+### Status Labels (`status:`)
+
+Status labels are shared across artifact types. Apply the relevant ones:
+
+| Label | Used By |
+|-------|---------|
+| `status:new` | Signals (freshly filed) |
+| `status:proposed` | Missions, Decisions, Governance Exceptions |
+| `status:approved` | Missions, Decisions, Releases, Governance Exceptions |
+| `status:planning` | Missions |
+| `status:active` | Missions |
+| `status:paused` | Missions |
+| `status:completed` | Missions, Tasks |
+| `status:cancelled` | Missions, Tasks |
+| `status:pending` | Tasks |
+| `status:in-progress` | Tasks |
+| `status:blocked` | Tasks |
+| `status:proceed` | Signals (disposition: proceed to mission) |
+| `status:defer` | Signals |
+| `status:monitor` | Signals |
+| `status:done` | Signals |
+| `status:accepted` | Decisions, Retrospectives |
+| `status:deprecated` | Decisions |
+| `status:superseded` | Decisions |
+| `status:draft` | Releases, Retrospectives |
+| `status:deploying` | Releases |
+| `status:deployed` | Releases |
+| `status:rolled-back` | Releases |
+| `status:pass` | Quality Evaluations |
+| `status:fail` | Quality Evaluations |
+| `status:escalate` | Quality Evaluations |
+
+**Status label rule:** Use exactly one `status:` label per issue. When the artifact advances, remove the old `status:*` label and add the new one in the same action.
+
+### Layer Labels (`layer:`)
+
+Which organizational layer owns or originated this artifact.
+
+| Label | Layer |
+|-------|-------|
+| `layer:steering` | Layer 0 — Steering |
+| `layer:strategy` | Layer 1 — Strategy |
+| `layer:orchestration` | Layer 2 — Orchestration |
+| `layer:execution` | Layer 3 — Execution |
+| `layer:quality` | Layer 4 — Quality |
+
+### Loop Labels (`loop:`)
+
+Which process loop this artifact belongs to.
+
+| Label | Loop |
+|-------|------|
+| `loop:discover` | Discover & Decide |
+| `loop:build` | Design & Build |
+| `loop:ship` | Validate & Ship |
+| `loop:operate` | Operate & Evolve |
+
+### Priority Labels (`priority:`)
+
+| Label | Meaning |
+|-------|---------|
+| `priority:critical` | Blocking — immediate action required |
+| `priority:high` | Important — next cycle |
+| `priority:medium` | Normal priority |
+| `priority:low` | Nice to have |
+
+### Signal-Specific Labels
+
+| Label | Meaning |
+|-------|---------|
+| `urgency:immediate` | Needs action now |
+| `urgency:next-cycle` | Next triage cycle |
+| `urgency:monitor` | Watch and wait |
+| `category:market` | Market signal |
+| `category:customer` | Customer signal |
+| `category:technical` | Technical signal |
+| `category:internal` | Internal signal |
+| `category:competitive` | Competitive signal |
+| `category:financial` | Financial signal |
+| `confidence:high` | High confidence in signal |
+| `confidence:medium` | Medium confidence |
+| `confidence:low` | Low confidence |
+
+### Division Labels (`division:`)
+
+Created dynamically based on configured divisions in `CONFIG.yaml`. Examples:
+
+- `division:data-foundation`
+- `division:core-services`
+- `division:customer-experience`
+- `division:engineering-foundation`
+
+### Quality Verdict Labels (`verdict:`)
+
+| Label | Meaning |
+|-------|---------|
+| `verdict:pass` | Quality evaluation passed |
+| `verdict:pass-with-notes` | Passed with observations |
+| `verdict:fail` | Failed — blocking issues found |
+| `verdict:escalate` | Needs human judgment |
+
+### Severity Labels (for retrospectives)
+
+| Label | Meaning |
+|-------|---------|
+| `severity:sev1` | Critical outage |
+| `severity:sev2` | Major impact |
+| `severity:sev3` | Moderate impact |
+| `severity:sev4` | Minor impact |
+
+---
+
+## Issue Backend: Structural Conventions
+
+For an operational GitHub implementation, including issue forms, human approval steps, and label bootstrap samples, see [docs/GITHUB-ISSUES.md](GITHUB-ISSUES.md).
+
+### Missions as Issue Hierarchies
+
+A **mission** in the issue backend is an issue with `artifact:mission` label. Its structure:
+
+```
+Mission Issue (#42)
+  ├── artifact:mission, status:active, layer:strategy, loop:build
+  ├── Body: Mission brief content (from template structure)
+  ├── Comment: Outcome Contract (or linked issue)
+  ├── Comment: Status Update 1 (newest first)
+  ├── Comment: Status Update 2
+  │
+  ├── Sub-Issue: Task 1 (#43) — artifact:task, status:in-progress, division:core-services
+  ├── Sub-Issue: Task 2 (#44) — artifact:task, status:pending, division:data-foundation
+  └── Sub-Issue: Task 3 (#45) — artifact:task, status:blocked, division:engineering-foundation
+```
+
+Git-backed companion artifacts still exist alongside the issue hierarchy where required:
+
+- `work/signals/digests/YYYY-WXX-digest.md`
+- `work/missions/<name>/evaluations/*.md`
+- `work/missions/<name>/OUTCOME-REPORT.md`
+- `work/missions/<name>/FLEET-REPORT.md`
+- `work/missions/<name>/TECHNICAL-DESIGN.md` (when required)
+
+### Cross-References
+
+- **Signal → Mission:** Mission issue body references signal issue: "Origin: #31"
+- **Mission → Tasks:** Tasks are sub-issues of the mission issue
+- **Task → PR:** Task issue links to implementing PR(s)
+- **Quality Eval → Mission:** Git evaluation report references the mission issue and task issue
+- **Retrospective → Signal:** Retro issue references generated signal issues
+- **Decision → Mission:** Decision issue references the mission it supports
+
+### Issue Templates
+
+GitHub Issue Templates (`.github/ISSUE_TEMPLATE/`) can mirror the Markdown templates. In this template repository, the operational forms are stored as docs-only samples under `docs/github-issues/forms/` so the framework repo itself does not behave like an instance repo.
+
+- `signal.sample.yml` — maps to `_TEMPLATE-signal.md`
+- `mission.sample.yml` — maps to `_TEMPLATE-mission-brief.md`
+- `task.sample.yml` — maps to `_TEMPLATE-tasks.md`
+- `decision.sample.yml` — maps to `_TEMPLATE-decision-record.md`
+- `release.sample.yml` — maps to `_TEMPLATE-release-contract.md`
+- `retrospective.sample.yml` — maps to `_TEMPLATE-postmortem.md`
+
+Instance repos should copy these samples into `.github/ISSUE_TEMPLATE/` when enabling the issue backend. Agents can still create issues with structured body text directly.
+
+### GitHub Projects Integration
+
+When `use_projects: true`, create GitHub Projects boards for visual tracking:
+
+| Board | View | Filter |
+|-------|------|--------|
+| **Signal Triage** | Board (Kanban) | `label:artifact:signal` |
+| **Active Missions** | Board (Kanban) | `label:artifact:mission` |
+| **Mission Tasks** | Board per mission | `label:artifact:task` + mission reference |
+| **Release Pipeline** | Board (Kanban) | `label:artifact:release` |
+| **Quality Dashboard** | Table | Mission-linked Git reports + evaluation references |
+
+---
+
+## Agent Behavior Differences by Backend
+
+### Creating Artifacts
+
+| Action | Git Files Backend | Issue Backend |
+|--------|-------------------|---------------|
+| File a signal | Create `work/signals/YYYY-MM-DD-name.md`, commit, open PR | Create issue with `artifact:signal` + metadata labels |
+| Create a mission | Create `work/missions/<name>/BRIEF.md`, commit, open PR | Create issue with `artifact:mission` label, body from template |
+| Decompose tasks | Edit `TASKS.md`, commit | Create sub-issues with `artifact:task` labels |
+| Update status | Append to `STATUS.md`, commit | Add comment to mission issue, update status labels |
+| Quality evaluation | Create `evaluations/*.md`, commit | Create `evaluations/*.md`, commit, and reference the mission/task issues |
+| Decision record | Create `work/decisions/*.md`, commit, open PR | Create issue with `artifact:decision` label |
+| Close mission | Update status in files, archive folder | Close issue, update labels to `status:completed` |
+
+### Approval Mechanisms
+
+| Mechanism | Git Files Backend | Issue Backend |
+|-----------|-------------------|---------------|
+| Signal triage | PR merge = approval | Authorized human removes `status:new` and applies exactly one of `status:proceed`, `status:defer`, `status:monitor`, or `status:done` |
+| Mission approval | PR merge = approval | Label change (`status:proposed` → `status:approved`) by authorized human |
+| Decision approval | PR merge = approval | Label change (`status:proposed` → `status:accepted`) by authorized human |
+| Quality gate | Evaluation file with PASS verdict | Evaluation file in Git references the issue-backed mission/task |
+| Release go/no-go | PR merge = approval | Label change (`status:draft` → `status:approved`) by authorized human |
+
+### Human Approval Cheat Sheet
+
+When humans are the approval gate in the issue backend, the action should be explicit and mechanical:
+
+| Artifact | Human does this | Approval result |
+|----------|-----------------|-----------------|
+| Signal | Review the issue, leave a short rationale comment, replace `status:new` with one terminal triage label | Signal is triaged |
+| Mission | Confirm scope/outcomes, leave a short approval comment, replace `status:proposed` with `status:approved` | Mission can move to planning |
+| Decision | Review context and tradeoffs, leave a short approval comment, replace `status:proposed` with `status:accepted` | Decision becomes active |
+| Release | Review rollout and rollback plan, leave a short approval comment, replace `status:draft` with `status:approved` | Deployment may begin |
+| Retrospective | Review findings and follow-ups, leave a short approval comment, replace `status:draft` with `status:accepted` | Postmortem is closed |
+
+Do not rely on issue closure alone as approval. Closure archives work; the `status:` label change is the approval event.
+
+### Audit Trail
+
+| Aspect | Git Files Backend | Issue Backend |
+|--------|-------------------|---------------|
+| Who changed what | Git blame + commit history | Issue activity log + label change history |
+| When | Commit timestamps | Issue event timestamps |
+| Why | Commit messages + PR descriptions | Issue comments + label change context |
+| Completeness | Full — Git captures everything | Full — issue trackers log all events |
+
+---
+
+## Migration Between Backends
+
+### Git Files → Issue Backend
+
+1. Set `work_backend.type: "github-issues"` in `CONFIG.yaml`
+2. For each active artifact in `work/`, create a corresponding issue with appropriate labels
+3. Keep Git-only artifacts in place (`TECHNICAL-DESIGN.md`, evaluation reports, fleet reports, outcome reports, signal digests, asset registry, governance exceptions, locks)
+4. Archive (don't delete) only the Git-file operational artifacts that moved to issues — they remain as historical record
+5. Going forward, agents create issues instead of files for configurable artifacts
+
+### Issue Backend → Git Files
+
+1. Set `work_backend.type: "git-files"` in `CONFIG.yaml`
+2. For each open issue with `artifact:*` labels, create corresponding files in `work/`
+3. Close the issues with a note linking to the Git artifact
+4. Going forward, agents create files instead of issues
+
+### Hybrid Operation
+
+Using `overrides` in CONFIG.yaml, you can run both backends simultaneously for different artifact types. For example:
+- Signals, Missions, Tasks → issues (high human interaction)
+- Technical Designs, Governance Exceptions → git files (need code review)
+- Decisions → issues (discussion-heavy)
+- Asset Registry → git files (persistent documentation)
+
+---
+
+## Templates as Schema Definitions
+
+Regardless of backend, the `_TEMPLATE-*.md` files in `work/` remain in the repository. They serve as:
+
+1. **Schema definitions** — what fields/sections an artifact must contain
+2. **Reference documentation** — what each field means and what values are valid
+3. **Fallback** — if no issue backend is configured, they're used directly
+4. **Issue template source** — GitHub Issue Templates can be generated from them
+
+Templates are **never** tracked in the issue system. They are framework files, governed by the template lifecycle (Rule 11 in AGENTS.md).
+
+---
+
+## Changelog
+
+| Version | Date | Change |
+|---------|------|--------|
+| 1.1 | 2026-03-07 | Clarified Git-only companion artifacts, added human approval cheat sheet, removed issue-only claims for digests/evaluations/outcome reports/fleet reports, linked GitHub implementation guide |
+| 1.0 | 2026-03-07 | Initial version — introduced work backend abstraction concept |

--- a/docs/github-issues/config.sample.yml
+++ b/docs/github-issues/config.sample.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: "Operating Model Guide"
+    url: https://github.com/OWNER/REPO/blob/main/docs/GITHUB-ISSUES.md
+    about: "Setup checklist, required labels, and exact approval steps for the issue backend"
+  - name: "Discussions"
+    url: https://github.com/OWNER/REPO/discussions
+    about: "Questions, ideas, and open-ended conversations"

--- a/docs/github-issues/forms/decision.sample.yml
+++ b/docs/github-issues/forms/decision.sample.yml
@@ -1,0 +1,58 @@
+name: "Decision"
+description: "Create a decision record issue when using the GitHub issue backend"
+title: "[Decision] "
+labels: ["artifact:decision", "status:proposed", "loop:build"]
+body:
+  - type: input
+    id: decision-id
+    attributes:
+      label: "Decision ID"
+      placeholder: "DR-2026-001"
+    validations:
+      required: true
+
+  - type: input
+    id: related-mission
+    attributes:
+      label: "Related mission or context"
+      placeholder: "#123 or mission name"
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: "Context"
+    validations:
+      required: true
+
+  - type: textarea
+    id: decision
+    attributes:
+      label: "Decision"
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: "Alternatives considered"
+      placeholder: "Alternative 1 ...\nAlternative 2 ..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: consequences
+    attributes:
+      label: "Consequences"
+      description: "Positive, negative, and neutral effects"
+    validations:
+      required: true
+
+  - type: input
+    id: review-schedule
+    attributes:
+      label: "Review schedule"
+      placeholder: "never / quarterly / annually / trigger condition"
+    validations:
+      required: true

--- a/docs/github-issues/forms/mission.sample.yml
+++ b/docs/github-issues/forms/mission.sample.yml
@@ -1,0 +1,107 @@
+name: "Mission"
+description: "Create a mission issue when using the GitHub issue backend"
+title: "[Mission] "
+labels: ["artifact:mission", "status:proposed", "layer:strategy", "loop:build"]
+body:
+  - type: input
+    id: mission-id
+    attributes:
+      label: "Mission ID"
+      placeholder: "MISSION-2026-001"
+    validations:
+      required: true
+
+  - type: input
+    id: origin-signal
+    attributes:
+      label: "Origin signal"
+      description: "Link the originating signal issue(s)"
+      placeholder: "#123"
+    validations:
+      required: true
+
+  - type: input
+    id: sponsor
+    attributes:
+      label: "Sponsor"
+      placeholder: "Outcome Owner / Venture Lead"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: design-required
+    attributes:
+      label: "Design required?"
+      options:
+        - "true"
+        - "false"
+    validations:
+      required: true
+
+  - type: textarea
+    id: objective
+    attributes:
+      label: "Objective"
+      description: "What does this mission accomplish and why does it matter?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: in-scope
+    attributes:
+      label: "In scope"
+      placeholder: "- Deliverable 1\n- Deliverable 2"
+    validations:
+      required: true
+
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: "Out of scope"
+      placeholder: "- Explicitly excluded item"
+    validations:
+      required: true
+
+  - type: textarea
+    id: divisions-involved
+    attributes:
+      label: "Divisions involved"
+      description: "List primary and supporting divisions"
+      placeholder: "Primary: core-services\nSupporting: engineering-foundation"
+    validations:
+      required: true
+
+  - type: textarea
+    id: outcome-contract
+    attributes:
+      label: "Outcome contract summary"
+      description: "List the measurable outcomes and deadlines"
+      placeholder: "Metric | Target | Measurement method | Deadline"
+    validations:
+      required: true
+
+  - type: textarea
+    id: human-checkpoints
+    attributes:
+      label: "Human checkpoints"
+      description: "List the review/approval moments explicitly"
+      placeholder: "1. Architecture review ...\n2. Release approval ..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: observability-requirements
+    attributes:
+      label: "Observability requirements"
+      description: "Key metrics, baselines at risk, and monitoring dependencies"
+    validations:
+      required: true
+
+  - type: textarea
+    id: blockers
+    attributes:
+      label: "Blocked by / blocks"
+      description: "List mission dependencies if any"
+      placeholder: "Blocked by: ...\nBlocks: ..."
+    validations:
+      required: false

--- a/docs/github-issues/forms/release.sample.yml
+++ b/docs/github-issues/forms/release.sample.yml
@@ -1,0 +1,57 @@
+name: "Release"
+description: "Create a release contract issue when using the GitHub issue backend"
+title: "[Release] "
+labels: ["artifact:release", "status:draft", "loop:ship", "layer:orchestration"]
+body:
+  - type: input
+    id: release-id
+    attributes:
+      label: "Release ID"
+      placeholder: "REL-2026-001"
+    validations:
+      required: true
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: "Release summary"
+    validations:
+      required: true
+
+  - type: textarea
+    id: changes
+    attributes:
+      label: "Changes included"
+      description: "List changes, missions, and quality verdicts"
+    validations:
+      required: true
+
+  - type: textarea
+    id: rollout
+    attributes:
+      label: "Progressive rollout plan"
+      placeholder: "Canary ...\nEarly adopters ...\nGeneral ...\nFull ..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: rollback
+    attributes:
+      label: "Rollback plan"
+    validations:
+      required: true
+
+  - type: textarea
+    id: predeploy
+    attributes:
+      label: "Pre-deployment checklist"
+      description: "Call out production readiness, rollback readiness, and on-call notification"
+    validations:
+      required: true
+
+  - type: textarea
+    id: release-notes
+    attributes:
+      label: "Release notes"
+    validations:
+      required: true

--- a/docs/github-issues/forms/retrospective.sample.yml
+++ b/docs/github-issues/forms/retrospective.sample.yml
@@ -1,0 +1,76 @@
+name: "Retrospective"
+description: "Create a postmortem issue when using the GitHub issue backend"
+title: "[Retrospective] "
+labels: ["artifact:retrospective", "status:draft", "loop:operate", "layer:execution"]
+body:
+  - type: input
+    id: incident-id
+    attributes:
+      label: "Incident ID"
+      placeholder: "INC-2026-001"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: "Severity"
+      options:
+        - SEV1
+        - SEV2
+        - SEV3
+        - SEV4
+    validations:
+      required: true
+
+  - type: input
+    id: incident-date
+    attributes:
+      label: "Date of incident"
+      placeholder: "YYYY-MM-DD HH:MM UTC"
+    validations:
+      required: true
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: "Incident summary"
+    validations:
+      required: true
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: "Impact"
+      description: "Services, customers, duration, and business impact"
+    validations:
+      required: true
+
+  - type: textarea
+    id: detection
+    attributes:
+      label: "Detection"
+    validations:
+      required: true
+
+  - type: textarea
+    id: root-cause
+    attributes:
+      label: "Root cause analysis"
+    validations:
+      required: true
+
+  - type: textarea
+    id: remediation
+    attributes:
+      label: "Remediation and follow-up items"
+    validations:
+      required: true
+
+  - type: textarea
+    id: signals-filed
+    attributes:
+      label: "Signals filed"
+      description: "List the signal issues or files created from this retrospective"
+    validations:
+      required: true

--- a/docs/github-issues/forms/signal.sample.yml
+++ b/docs/github-issues/forms/signal.sample.yml
@@ -1,0 +1,93 @@
+name: "Signal"
+description: "File a new operational signal when using the GitHub issue backend"
+title: "[Signal] "
+labels: ["artifact:signal", "status:new", "loop:discover"]
+body:
+  - type: input
+    id: source-system
+    attributes:
+      label: "Source system"
+      description: "Where did this signal come from?"
+      placeholder: "e.g., customer interview, observability platform, sales call"
+    validations:
+      required: true
+
+  - type: input
+    id: source-reference
+    attributes:
+      label: "Source URL or reference"
+      description: "Link to dashboard, document, thread, or data source if available"
+      placeholder: "https://... or internal reference"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: "Category"
+      options:
+        - market
+        - customer
+        - technical
+        - internal
+        - competitive
+        - financial
+    validations:
+      required: true
+
+  - type: dropdown
+    id: confidence
+    attributes:
+      label: "Confidence"
+      options:
+        - high
+        - medium
+        - low
+    validations:
+      required: true
+
+  - type: dropdown
+    id: urgency
+    attributes:
+      label: "Urgency"
+      options:
+        - immediate
+        - next-cycle
+        - monitor
+    validations:
+      required: true
+
+  - type: textarea
+    id: observation
+    attributes:
+      label: "Observation"
+      description: "Describe what was observed. Use facts, metrics, or quotes rather than opinion."
+      placeholder: "Describe the signal clearly and concretely."
+    validations:
+      required: true
+
+  - type: textarea
+    id: alignment-impact
+    attributes:
+      label: "Strategic alignment and potential impact"
+      description: "Which strategic beliefs does this affect, and how large is the impact?"
+      placeholder: "Belief: ... Impact: high/medium/low ..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: divisions
+    attributes:
+      label: "Affected divisions"
+      description: "List the divisions likely to be involved if this becomes a mission"
+      placeholder: "core-services, engineering-foundation"
+    validations:
+      required: false
+
+  - type: textarea
+    id: related-signals
+    attributes:
+      label: "Related signals or prior context"
+      description: "Link related issues or files if this adds to existing evidence"
+    validations:
+      required: false

--- a/docs/github-issues/forms/task.sample.yml
+++ b/docs/github-issues/forms/task.sample.yml
@@ -1,0 +1,85 @@
+name: "Task"
+description: "Create a mission task issue when using the GitHub issue backend"
+title: "[Task] "
+labels: ["artifact:task", "status:pending", "layer:execution", "loop:build"]
+body:
+  - type: input
+    id: mission-reference
+    attributes:
+      label: "Parent mission"
+      description: "Link the mission issue this task belongs to"
+      placeholder: "#123"
+    validations:
+      required: true
+
+  - type: input
+    id: task-id
+    attributes:
+      label: "Task ID"
+      placeholder: "TASK-001"
+    validations:
+      required: true
+
+  - type: input
+    id: assigned-to
+    attributes:
+      label: "Assigned to"
+      description: "Division and agent type or human role"
+      placeholder: "core-services — builder agent"
+    validations:
+      required: true
+
+  - type: input
+    id: depends-on
+    attributes:
+      label: "Depends on"
+      description: "Use task IDs or issue references"
+      placeholder: "None or TASK-002 / #456"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: "Priority"
+      options:
+        - critical
+        - high
+        - medium
+        - low
+    validations:
+      required: true
+
+  - type: input
+    id: target-date
+    attributes:
+      label: "Target date"
+      placeholder: "YYYY-MM-DD"
+    validations:
+      required: false
+
+  - type: textarea
+    id: description
+    attributes:
+      label: "Description"
+      description: "Write the task so the assigned agent can start without more clarification"
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: "Acceptance criteria"
+      description: "Use checkboxes or one item per line"
+      placeholder: "- Criterion 1\n- Criterion 2"
+    validations:
+      required: true
+
+  - type: textarea
+    id: linked-work
+    attributes:
+      label: "Linked PRs or issues"
+      description: "Fill this as soon as work starts to avoid duplicate work"
+      placeholder: "PR #789"
+    validations:
+      required: false

--- a/docs/mission-lifecycle.md
+++ b/docs/mission-lifecycle.md
@@ -27,15 +27,15 @@ ASSETS (commits, PRs, files)    Delivered artifacts with registry entries
 OUTCOME REPORT                  Targets vs. actuals measurement
 ```
 
-Each arrow represents a **Git PR** with **CODEOWNERS-enforced approval**. The Git history is the audit trail.
+In the git-files backend, these artifacts are files and the approvals are PR-based. In the issue backend, the mission brief and tasks move to issues, and approvals are explicit `status:` label transitions by authorized humans. Git remains the audit trail for governance and Git-backed companion artifacts; issue history is the audit trail for issue-backed work artifacts.
 
 ### Who Does What
 
 | Role | Responsibility |
 |------|---------------|
-| **Strategy Layer** | Defines the mission brief and outcome contract. Approves mission scope. |
-| **Orchestrator** | Decomposes BRIEF.md into Fleet Config and TASKS.md. Monitors progress. |
-| **Execution Agents** | Pick up tasks from TASKS.md, execute, update status, generate assets. |
+| **Strategy Layer** | Defines the mission brief and outcome contract. Approves mission scope via PR merge or issue label transition. |
+| **Orchestrator** | Decomposes the mission into Fleet Config and TASKS.md or task issues. Monitors progress. |
+| **Execution Agents** | Pick up tasks from TASKS.md or task issues, execute, update status, generate assets. |
 | **Quality Layer** | Evaluates outputs against policies AND task acceptance criteria. Traces each output to its originating task. Issues verdicts. |
 | **Steering Layer** | Aggregates signals, approves structural changes, owns company evolution. |
 
@@ -69,19 +69,21 @@ proposed ──→ approved ──→ planning ──→ active ──→ comple
 
 | From | To | Gate | Who |
 |------|----|------|-----|
-| `proposed` | `approved` | Strategy Layer human approves Mission Brief via PR merge | Strategy Layer human |
+| `proposed` | `approved` | Strategy Layer human approves Mission Brief via PR merge (git-files) or label transition (`status:proposed` → `status:approved`) in the mission issue | Strategy Layer human |
 | `approved` | `planning` | Orchestrator creates Fleet Config; Technical Design initiated if `design-required: true` | Orchestrator |
-| `planning` | `active` | **TASKS.md exists with at least one task.** Technical Design approved (if required). | Orchestrator (gate checked by Orchestrator and CI) |
+| `planning` | `active` | **TASKS.md exists with at least one task** (git-files) or **at least one child issue exists with `artifact:task` label** (issue backend). Technical Design approved (if required). | Orchestrator (gate checked by Orchestrator and CI where applicable) |
 | `active` | `paused` | Human decision — resource conflict, external blocker, reprioritization | Human (any layer) |
 | `paused` | `active` | Human decision; original gate conditions still satisfied | Human (any layer) |
 | `active` | `completed` | Outcome Report produced; outcomes measured against contract | Strategy Layer + Orchestrator |
-| _any_ | `cancelled` | Human decision with documented rationale in STATUS.md | Human (Strategy or Steering) |
+| _any_ | `cancelled` | Human decision with documented rationale in STATUS.md (git-files) or mission issue comment (issue backend) | Human (Strategy or Steering) |
 
 ### The Critical Gate: `planning` → `active`
 
 This is the gate that Issue #56 identified as the most failure-prone transition. The invariant is:
 
 > **A mission cannot transition to `active` without a TASKS.md file containing at least one decomposed task.**
+
+> **Issue backend equivalent:** A mission cannot transition to `active` without at least one child issue labeled `artifact:task`.
 
 Without this gate, execution agents have nothing to pick up. The mission appears active but is effectively dead — a silent failure that is hard to diagnose.
 
@@ -177,6 +179,8 @@ work/missions/<mission-name>/
 └── evaluations/             # Quality evaluation reports
     └── YYYY-MM-DD-<eval>.md # Individual quality evaluations
 ```
+
+  When using the issue backend, `BRIEF.md`, `OUTCOME-CONTRACT.md`, `TASKS.md`, and `STATUS.md` are replaced by issue-backed artifacts. The Git-backed companions in this folder still remain: `TECHNICAL-DESIGN.md` when required, `FLEET-REPORT.md`, `OUTCOME-REPORT.md`, and `evaluations/`.
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -698,8 +698,8 @@ footer{border-top:1px solid var(--border);padding:40px 24px;text-align:center;co
       <table class="replace-table">
         <thead><tr><th>Traditional Approach</th><th>Agentic Enterprise</th><th>What changes</th></tr></thead>
         <tbody>
-          <tr><td class="old">Ticket system</td><td class="new">Markdown file in <code style="color:var(--cyan);font-size:0.82rem">work/</code></td><td class="why">System of record in Git; existing tools sync via integrations</td></tr>
-          <tr><td class="old">Ticket workflow</td><td class="new">Git branch → PR → merge</td><td class="why">Governance is Git-native; status projects to dashboards</td></tr>
+          <tr><td class="old">Ticket system</td><td class="new">Work artifacts in <code style="color:var(--cyan);font-size:0.82rem">work/</code> or issue tracker</td><td class="why">Git files or native issues; configurable per team</td></tr>
+          <tr><td class="old">Ticket workflow</td><td class="new">PR merge or label transitions</td><td class="why">Governance adapts to backend; Git stays system of record</td></tr>
           <tr><td class="old">Sprint planning</td><td class="new">Mission brief creation</td><td class="why">Goal-oriented, not time-boxed</td></tr>
           <tr><td class="old">Daily standup</td><td class="new">Git log + observability dashboards</td><td class="why">Always current, real-time fleet health</td></tr>
           <tr><td class="old">Enterprise wiki</td><td class="new">The repository itself</td><td class="why">Single source of truth, versioned</td></tr>

--- a/org/0-steering/AGENT.md
+++ b/org/0-steering/AGENT.md
@@ -3,7 +3,7 @@
 > **Role:** You are a Steering Layer agent. You assist CxO executives, Board Advisors, and Organization Architects in evolving the company itself — its structure, operating model, processes, venture portfolio, division map, and strategic direction.
 > **Layer:** Steering (Layer 0 — above Strategy, governs the system itself)
 > **Authority:** You analyze, model, propose, and draft. Humans at the executive level decide.
-> **Version:** 1.2 | **Last updated:** 2026-02-25
+> **Version:** 1.3 | **Last updated:** 2026-03-07
 
 ---
 
@@ -21,7 +21,7 @@ Help the executive leadership continuously evolve {{COMPANY_SHORT}} as a company
 6. **All quality policies:** [../4-quality/policies/](../4-quality/policies/) — the current guardrails
 7. **Process model:** [../../process/README.md](../../process/README.md) — how work currently flows
 8. **Active work:** [../../work/](../../work/) — what's in flight
-9. **Improvement signals:** [../../work/signals/](../../work/signals/) — incoming evolution signals from all layers; **include observability-sourced signals** (marked `source: observability-platform`)
+9. **Improvement signals:** [../../work/signals/](../../work/signals/) (git-files) or issues with `artifact:signal` label (issue backend) — incoming evolution signals from all layers; **include observability-sourced signals** (marked `source: observability-platform`)
 10. **Agent type registry:** [../agents/](../agents/) — the governed registry of all agent types
 11. **Venture health reports:** [../1-strategy/ventures/](../1-strategy/ventures/) — venture-level health assessments
 12. **Observability platform** (via MCP) — **query before producing any digest or evolution proposal:**
@@ -72,7 +72,7 @@ Help the executive leadership continuously evolve {{COMPANY_SHORT}} as a company
 The Steering Layer runs a weekly sensing loop that aggregates signals, detects patterns, and produces digests for the Strategy Layer. This is the nervous system of the organization.
 
 **Input:**
-- `work/signals/` — all signals filed during the current week (from any layer, any source)
+- `work/signals/` (git-files) or issues with `artifact:signal` label (issue backend) — all signals filed during the current week (from any layer, any source)
 - Observability platform (via MCP) — fleet health, process efficiency, anomaly alerts
 
 **Process:**
@@ -90,7 +90,7 @@ The Steering Layer runs a weekly sensing loop that aggregates signals, detects p
 6. **Query observability platform** — before finalizing, cross-reference signal themes against live fleet metrics, error rates, and cycle times; add data-grounded annotations where telemetry supports or contradicts signal claims
 
 **Output:**
-- `work/signals/digests/YYYY-WXX-digest.md` — weekly digest using `work/signals/digests/_TEMPLATE-signal-digest.md`
+- `work/signals/digests/YYYY-WXX-digest.md` — weekly digest using `work/signals/digests/_TEMPLATE-signal-digest.md` (always produced as a git file regardless of work backend)
 - Pattern alerts embedded in the digest (section per detected pattern)
 - Evolution proposals (`org/0-steering/_TEMPLATE-evolution-proposal.md`) when patterns indicate structural change is needed
 
@@ -157,7 +157,7 @@ The Steering Layer runs a weekly sensing loop that aggregates signals, detects p
 │    → Present board-level governance materials                       │
 │                                                                     │
 │  INWARD (from all layers):                                          │
-│    → Receive improvement signals from work/signals/                 │
+│    → Receive improvement signals from all layers                   │
 │    → Receive quality data, fleet performance, market signals        │
 └─────────────────────────────────────────────────────────────────────┘
 ```
@@ -200,6 +200,7 @@ When you create or modify artifacts, apply **Rule 10** from `AGENTS.md`. For Ste
 
 | Version | Date | Change |
 |---|---|---|
+| 1.3 | 2026-03-07 | Updated for dual work backend support (git-files and issue tracker) |
 | 1.2 | 2026-02-25 | Expanded Signal Aggregation & Digests into full Continuous Sensing Loop with input/process/output, pattern detection criteria (3+ signals), anomaly flagging, and weekly cadence |
 | 1.1 | 2026-02-19 | Added Versioning Your Outputs section |
 | 1.0 | 2026-02-19 | Initial version |

--- a/org/1-strategy/AGENT.md
+++ b/org/1-strategy/AGENT.md
@@ -3,7 +3,7 @@
 > **Role:** You are a Strategy Layer agent. You assist Outcome Owners, Venture Leads, Experience Directors, Architecture Governors, Growth Analysts, Market Strategists, and Customer Strategy Leads.
 > **Layer:** Strategy (second layer of the 5-layer model, below Steering)
 > **Authority:** You draft, analyze, and recommend. Humans decide.
-> **Version:** 1.2 | **Last updated:** 2026-02-25
+> **Version:** 1.3 | **Last updated:** 2026-03-07
 
 ---
 
@@ -17,8 +17,8 @@ Help the Strategy Layer define **what** {{COMPANY_SHORT}} does and **why** — a
 2. **Organizational model:** [../README.md](../README.md)
 3. **Venture charter** for the relevant venture (in `ventures/`)
 4. **Venture health reports** (in `ventures/<venture>-health.md`) — current venture metric status
-5. **Active missions:** [../../work/missions/](../../work/missions/)
-6. **Signal digests:** [../../work/signals/digests/](../../work/signals/digests/) — curated weekly signal summaries (prefer over raw signal scanning); includes observability-sourced signals
+5. **Active missions:** [../../work/missions/](../../work/missions/) (git-files) or issues with `artifact:mission` label (issue backend)
+6. **Signal digests:** [../../work/signals/digests/](../../work/signals/digests/) — curated weekly signal summaries (always in Git regardless of work backend); includes observability-sourced signals
 7. **Process lifecycle:** [../../process/README.md](../../process/README.md)
 8. **Observability platform** (via MCP) — **query when you need grounded data, not estimates:**
    - Product adoption telemetry: feature usage rates, workflow completion rates, unique active users — ground all "market fit" and "growth" claims in real usage data
@@ -41,7 +41,7 @@ Help the Strategy Layer define **what** {{COMPANY_SHORT}} does and **why** — a
 - Missions can span any function: product build, delivery, GTM launch, sales play, CS program
 
 ### Outcome Management & Venture Health
-- **Consume outcome reports** (`work/missions/<name>/OUTCOME-REPORT.md`) to track mission impact on venture metrics
+- **Consume outcome reports** (`work/missions/<name>/OUTCOME-REPORT.md` for git-files, or linked from mission issues for issue backend) to track mission impact on venture metrics
 - **Consume observability platform data** (via MCP) to ground outcome reports in real telemetry — usage metrics, error rates, latency trends — rather than estimates. Where an outcome contract defines measurable success criteria, verify them against live observability data before declaring success.
 - **Produce venture health reports** (`org/1-strategy/ventures/_TEMPLATE-venture-health-report.md`) monthly or quarterly, stored at `org/1-strategy/ventures/<venture>-health.md`
 - **Trigger outcome report creation** when outcome contract `measurement_schedule` dates arrive (initial check, follow-up, final evaluation)
@@ -54,7 +54,7 @@ The Strategy Layer owns the Signal → Mission Brief flow. This is the primary i
 
 **Input:**
 - `work/signals/digests/` — weekly signal digests produced by the Steering Layer (primary input; prefer digests over raw signals)
-- `work/signals/` — raw signals (use when digests haven't covered a specific area or for urgent signals filed between digest cycles)
+- `work/signals/` (git-files) or issues with `artifact:signal` label (issue backend) — raw signals (use when digests haven't covered a specific area or for urgent signals filed between digest cycles)
 
 **Process:**
 1. **Read the latest digest** — start with the most recent `work/signals/digests/YYYY-WXX-digest.md`
@@ -72,9 +72,9 @@ The Strategy Layer owns the Signal → Mission Brief flow. This is the primary i
 4. **Observability-sourced signals** (marked `source: observability-platform`) are high-confidence and data-grounded — treat them as prioritized inputs; they represent patterns the platform detected automatically, not anecdotal reports
 
 **Output:**
-- `work/missions/<name>/BRIEF.md` — created from `work/missions/_TEMPLATE-mission-brief.md`
-- `work/missions/<name>/OUTCOME-CONTRACT.md` — created from `work/missions/_TEMPLATE-outcome-contract.md` (with `measurement_schedule` dates filled in)
-- Updated signal dispositions in the originating signal files
+- Mission brief — `work/missions/<name>/BRIEF.md` (git-files) or issue with `artifact:mission` label (issue backend), created from `work/missions/_TEMPLATE-mission-brief.md`
+- Outcome contract — `work/missions/<name>/OUTCOME-CONTRACT.md` (git-files) or linked issue (issue backend), created from `work/missions/_TEMPLATE-outcome-contract.md` (with `measurement_schedule` dates filled in)
+- Updated signal dispositions in the originating signal artifacts
 
 ### GTM & Growth Analysis
 - Draft competitive positioning (grounded in evidence, not speculation)
@@ -97,8 +97,8 @@ When you create or modify artifacts, apply **Rule 10** from `AGENTS.md`. For Str
 
 | Artifact | Versioning approach |
 |---|---|
-| Mission briefs (`work/missions/*/BRIEF.md`) | Increment `Revision` + update `Last updated` each time the brief is meaningfully updated |
-| Signals (`work/signals/*.md`) | **Immutable once filed.** If new information arrives, file a supplemental signal with a `supersedes:` reference to the original |
+| Mission briefs | Increment `Revision` + update `Last updated` each time the brief is meaningfully updated (git-files: `work/missions/*/BRIEF.md`; issue backend: edit mission issue body) |
+| Signals | **Immutable once filed.** If new information arrives, file a supplemental signal with a `supersedes:` reference to the original (git-files: `work/signals/*.md`; issue backend: cross-reference original issue) |
 | Venture charters | Increment `Revision` + update `Last updated` when strategy changes |
 | Venture health reports | Date-stamped per period (e.g., `2026-Q1-health.md`) — each period is a new file; no revision counter |
 | Outcome contracts | Increment `Revision` if outcome targets or metrics are renegotiated |
@@ -113,11 +113,11 @@ When you create or modify artifacts, apply **Rule 10** from `AGENTS.md`. For Str
 - **Never commit** scope, timelines, or resources
 - **Never fabricate** data, metrics, or competitive claims
 - **Never bypass** the Process Organization lifecycle
-- **Never approve** your own outputs — they always go through human review via PR
+- **Never approve** your own outputs — they always go through human review (PR for git-files backend, approval label for issue backend)
 
 ## Continuous Improvement Responsibility
 
-Surface improvement signals to `work/signals/` when you observe:
+Surface improvement signals (to `work/signals/` for git-files backend, or as an issue with `artifact:signal` label for issue backend) when you observe:
 - A venture charter that no longer aligns with market reality
 - Overlap between venture scopes
 - Gaps in the venture portfolio
@@ -130,6 +130,7 @@ Surface improvement signals to `work/signals/` when you observe:
 
 | Version | Date | Change |
 |---|---|---|
+| 1.3 | 2026-03-07 | Updated for dual work backend support (git-files and issue tracker) |
 | 1.2 | 2026-02-25 | Expanded Signal Triage into full workflow section with input/process/output and prioritization criteria |
 | 1.1 | 2026-02-19 | Added Versioning Your Outputs section |
 | 1.0 | 2026-02-19 | Initial version |

--- a/org/2-orchestration/AGENT.md
+++ b/org/2-orchestration/AGENT.md
@@ -3,7 +3,7 @@
 > **Role:** You are an Orchestration Layer agent. You assist Mission Leads, Agent Fleet Managers, Cross-Mission Coordinators, Release Coordinators, and Campaign Orchestrators.
 > **Layer:** Orchestration (translates strategy into executable work)
 > **Authority:** You configure, monitor, and optimize agent fleets. Humans approve mission briefs and resolve escalations.
-> **Version:** 1.5 | **Last updated:** 2026-03-05
+> **Version:** 1.6 | **Last updated:** 2026-03-07
 
 ---
 
@@ -15,12 +15,12 @@ Translate mission briefs from the Strategy Layer into executable agent fleet con
 
 1. **Company vision & mission:** [../../COMPANY.md](../../COMPANY.md)
 2. **Organizational model:** [../README.md](../README.md)
-3. **Active missions:** [../../work/missions/](../../work/missions/)
+3. **Active missions:** [../../work/missions/](../../work/missions/) (git-files) or issues with `artifact:mission` label (issue backend)
 4. **Fleet config template:** [fleet-configs/_TEMPLATE-fleet-config.md](fleet-configs/_TEMPLATE-fleet-config.md)
 5. **Quality policies:** [../4-quality/policies/](../4-quality/policies/)
 6. **Process lifecycle:** [../../process/README.md](../../process/README.md)
 7. **Agent type registry:** [../agents/](../agents/) — available agent types and their capabilities
-8. **Quality evaluation reports:** `work/missions/<name>/evaluations/` — fleet quality tracking input
+8. **Quality evaluation reports:** `work/missions/<name>/evaluations/` (always in Git) — fleet quality tracking input
 
 ## What You Do
 
@@ -32,14 +32,14 @@ Translate mission briefs from the Strategy Layer into executable agent fleet con
 
 ### Work Deduplication (AGENTS.md Rule 12)
 Before decomposing a mission or dispatching work:
-- **Scan active missions** for overlapping scope — check `work/missions/*/BRIEF.md` for missions targeting the same deliverables, components, or objectives
+- **Scan active missions** for overlapping scope — check `work/missions/*/BRIEF.md` (git-files) or search issues with `artifact:mission` label (issue backend) for missions targeting the same deliverables, components, or objectives
 - **Scan open PRs and issues** for existing work addressing the same problem — use Git branch names, PR titles, and linked task IDs as search criteria
 - **Scan TASKS.md** across active missions for tasks with similar descriptions or targeting the same files/components
 - If overlap is found: **link rather than duplicate** — reference the existing mission/task/PR in the new mission's brief or TASKS.md, and coordinate sequencing
 - If a new mission fully overlaps with existing active work, **escalate to Strategy Layer** rather than creating parallel missions
 
 ### Task Decomposition (Divide & Conquer)
-- **Produce TASKS.md** (`work/missions/_TEMPLATE-tasks.md`) for every mission that involves Execution Layer work — this is **required** before a mission can transition to `active` status
+- **Produce TASKS.md** (`work/missions/_TEMPLATE-tasks.md`) for every mission that involves Execution Layer work (git-files backend), or create child issues with `artifact:task` label (issue backend) — this is **required** before a mission can transition to `active` status
 - Decompose mission outcomes into concrete, assignable tasks with: assigned division, agent type, acceptance criteria, dependencies, and priority
 - Ensure tasks are granular enough to be independently deliverable by a single agent or agent pool
 - Verify the dependency graph has no circular dependencies before setting status to `active`
@@ -70,7 +70,7 @@ Before decomposing a mission or dispatching work:
 
 ### Mission Status Tracking
 - **Produce mission status updates** (`work/missions/_TEMPLATE-mission-status.md`) weekly during active missions
-- Store status updates in `work/missions/<name>/STATUS.md` — this is a **running log** (append-only, latest entry first); it is exempt from Revision tracking (see Versioning section below)
+- Store status updates in `work/missions/<name>/STATUS.md` (git-files) or as comments/field updates on the mission issue (issue backend) — this is a **running log** (append-only, latest entry first); it is exempt from Revision tracking (see Versioning section below)
 - Trigger status transitions with evidence (proposed → approved → planning → active → paused → completed → cancelled) — each transition has a gate; see [docs/mission-lifecycle.md](../../docs/mission-lifecycle.md)
 
 ### Release Preparation (Ship Loop)
@@ -90,10 +90,10 @@ The Orchestration Layer owns release preparation — the bridge between quality-
    - Customer-facing release notes
 3. **Define rollout strategy** — specify stages, percentages, durations, and health check criteria for each stage
 4. **Coordinate deployment** — hand off to Execution Layer agents for deployment execution; ensure on-call team is notified
-5. **Submit for human approval** — release contract goes through PR review before deployment begins
+5. **Submit for human approval** — release contract goes through PR review (git-files) or issue approval (issue backend) before deployment begins
 
 **Output:**
-- `work/releases/YYYY-MM-DD-<release>.md` — release contract with rollout strategy and rollback plan
+- Release contract: `work/releases/YYYY-MM-DD-<release>.md` (git-files) or issue with `artifact:release` label (issue backend) — with rollout strategy and rollback plan
 
 **Handoff:**
 - To **Execution Layer** — for deployment execution (staging → production)
@@ -111,7 +111,7 @@ The Orchestration Layer owns release preparation — the bridge between quality-
 - Monitor quality scores
 - Detect bottlenecks and suggest reconfigurations
 - **Produce fleet performance reports** (`work/missions/_TEMPLATE-fleet-performance-report.md`) per mission or monthly
-- Store fleet reports in `work/missions/<name>/FLEET-REPORT.md`
+- Store fleet reports in `work/missions/<name>/FLEET-REPORT.md` (always in Git)
 - **Consume quality evaluation reports** from `work/missions/<name>/evaluations/` for fleet quality trend analysis
 
 ### Cross-Mission Coordination
@@ -163,7 +163,7 @@ When you create or modify artifacts, apply **Rule 10** from `AGENTS.md`. For Orc
 
 ## Continuous Improvement Responsibility
 
-Surface improvement signals to `work/signals/` when you observe:
+Surface improvement signals (to `work/signals/` for git-files backend, or as an issue with `artifact:signal` label for issue backend) when you observe:
 - Fleet configurations that consistently produce suboptimal outcomes
 - Division contention that suggests divisions may need splitting
 - Cross-mission coordination overhead that suggests process improvement
@@ -175,6 +175,7 @@ Surface improvement signals to `work/signals/` when you observe:
 
 | Version | Date | Change |
 |---|---|---|
+| 1.6 | 2026-03-07 | Updated for dual work backend support (git-files and issue tracker) |
 | 1.5 | 2026-03-05 | Added Work Deduplication section (AGENTS.md Rule 12) — mandatory overlap scan before mission decomposition and work dispatch |
 | 1.4 | 2026-02-25 | Added observability design verification to Technical Design Gate; added observability policy assignment to Fleet Configuration |
 | 1.3 | 2026-02-25 | Added Release Preparation (Ship Loop) section with input/process/output/handoff; added Dependency Management section with deadlock detection and escalation path |

--- a/org/3-execution/AGENT.md
+++ b/org/3-execution/AGENT.md
@@ -3,7 +3,7 @@
 > **Role:** You are an Execution Layer agent. You produce work — code, tests, docs, content, proposals, analyses, customer deliverables — under the direction of division leads across all company functions.
 > **Layer:** Execution (where work gets done)
 > **Authority:** You implement within defined constraints. Humans own architecture decisions, key relationships, novel patterns, and critical path resolution.
-> **Version:** 1.4 | **Last updated:** 2026-03-05
+> **Version:** 1.5 | **Last updated:** 2026-03-07
 
 ---
 
@@ -13,13 +13,13 @@ Execute the work defined in mission briefs and fleet configurations. This spans 
 
 ## Context You Must Read Before Every Task
 
-1. **Mission tasks:** `work/missions/<name>/TASKS.md` — **your primary work intake**. Find the task(s) assigned to your division and agent type. Read the task description, acceptance criteria, and dependencies before starting.
+1. **Mission tasks:** `work/missions/<name>/TASKS.md` (git-files) or child issues with `artifact:task` label on the mission issue (issue backend) — **your primary work intake**. Find the task(s) assigned to your division and agent type. Read the task description, acceptance criteria, and dependencies before starting.
 2. **Quality policies:** [../4-quality/policies/](../4-quality/policies/) — **read ALL relevant policies before producing any output** (especially delivery, architecture, and observability)
 3. **Division charter** for your division (in `divisions/<your-division>/`)
 4. **Fleet configuration** for your mission (from `../2-orchestration/fleet-configs/`)
-5. **Mission brief:** the active mission in [../../work/missions/](../../work/missions/)
-6. **Architecture decisions:** [../../work/decisions/](../../work/decisions/)
-7. **Quality evaluation reports:** `work/missions/<name>/evaluations/` — previous evaluations for your mission (learn from prior findings)
+5. **Mission brief:** the active mission in [../../work/missions/](../../work/missions/) (git-files) or issues with `artifact:mission` label (issue backend)
+6. **Architecture decisions:** [../../work/decisions/](../../work/decisions/) (git-files) or issues with `artifact:decision` label (issue backend)
+7. **Quality evaluation reports:** `work/missions/<name>/evaluations/` — previous evaluations for your mission (always in Git regardless of work backend)
 8. **Agent type registry:** [../agents/](../agents/) — know your own agent type definition and capabilities
 
 ## What You Do
@@ -28,16 +28,16 @@ Execute the work defined in mission briefs and fleet configurations. This spans 
 - **Read TASKS.md** in the active mission folder — this is the Orchestrator's decomposition of the mission into concrete work items
 - Identify tasks assigned to your division and agent type
 - Verify that task dependencies (`Depends on` field) are satisfied — if a blocking task is not yet `completed`, do not start the dependent task
-- Set the task status to `in-progress` when you begin work (via PR)
+- Set the task status to `in-progress` when you begin work (via PR for git-files, or by updating the task issue status/label for issue backend)
 - Upon completion, set the task status to `completed`, link the generated assets, and check off acceptance criteria
 - If you cannot complete a task, set it to `blocked` and surface a blocker in STATUS.md — do not silently stall
-- If TASKS.md does not exist for an active mission, **file an improvement signal** — this indicates an orchestration gap (see [docs/mission-lifecycle.md](../../docs/mission-lifecycle.md))
+- If task tracking does not exist for an active mission (no TASKS.md for git-files, or no child task issues for issue backend), **file an improvement signal** — this indicates an orchestration gap (see [docs/mission-lifecycle.md](../../docs/mission-lifecycle.md))
 
 ### Work Deduplication (AGENTS.md Rule 12)
 Before creating any PR, issue, or branch:
 - **Search open PRs** for existing work on the same topic — check branch names, PR titles, changed files, and linked task IDs
 - **Search open issues** for duplicates — check titles, labels, and linked missions/tasks
-- **Check TASKS.md** to verify the task is not already `in-progress` by another agent
+- **Check TASKS.md** (git-files) or **check the child task issue status** (issue backend) to verify the task is not already `in-progress` by another agent
 - **Check the `Linked PRs/Issues` field** on your task — if a PR already exists, contribute to it rather than opening a new one
 - If you discover you've created a duplicate: close it immediately with a note linking to the original, and update TASKS.md accordingly
 
@@ -122,12 +122,12 @@ When you create or modify artifacts, apply **Rule 10** from `AGENTS.md`. For Exe
 
 - **Never make architecture decisions** — escalate novel patterns to Tech Leads
 - **Never bypass quality policies** — escalate if a policy seems wrong
-- **Never merge your own PRs** — all outputs go through eval agents + human review
+- **Never merge your own PRs** — all code outputs go through eval agents + human review
 - **Never make customer commitments** — proposals are always "pending human review"
 
 ## Continuous Improvement Responsibility
 
-Surface improvement signals to `work/signals/` when you observe:
+Surface improvement signals (to `work/signals/` for git-files backend, or as an issue with `artifact:signal` label for issue backend) when you observe:
 - Agent instructions that are unclear, contradictory, or missing for common scenarios
 - Division boundaries that cause confusion
 - Common patterns that should be codified as architecture decisions
@@ -146,6 +146,7 @@ Surface improvement signals to `work/signals/` when you observe:
 
 | Version | Date | Change |
 |---|---|---|
+| 1.5 | 2026-03-07 | Updated for dual work backend support (git-files and issue tracker) |
 | 1.4 | 2026-03-05 | Added Work Deduplication section (AGENTS.md Rule 12) — mandatory duplicate check before creating PRs, issues, or branches |
 | 1.3 | 2026-02-25 | Added observability design to Technical Design Production (instrumentation, metrics, SLOs, dashboards, alerting); added production baseline consultation and impact assessment for modified components |
 | 1.2 | 2026-02-24 | Added Task Pickup section (TASKS.md as primary work intake); added TASKS.md as first item in Context You Must Read |

--- a/org/4-quality/AGENT.md
+++ b/org/4-quality/AGENT.md
@@ -3,7 +3,7 @@
 > **Role:** You are a Quality Layer agent (eval agent, policy guardian, compliance checker). You evaluate ALL outputs before they are merged, published, shipped, or sent externally.
 > **Layer:** Quality (the immune system of the organization)
 > **Authority:** You enforce quality policies. You can BLOCK any output. Humans set policies and resolve disputes.
-> **Version:** 1.5 | **Last updated:** 2026-02-25
+> **Version:** 1.6 | **Last updated:** 2026-03-07
 
 ---
 
@@ -14,8 +14,8 @@ Protect organizational quality across every dimension: code, security, architect
 ## Context You Must Read Before Every Evaluation
 
 1. **All quality policies:** [policies/](policies/) — **read EVERY applicable policy before evaluating**
-2. **Mission tasks:** `work/missions/<name>/TASKS.md` — **identify which task produced the output being evaluated**. Read the task's acceptance criteria — these are part of your evaluation scope alongside policies.
-3. **Architecture decisions:** [../../work/decisions/](../../work/decisions/) — patterns and constraints to enforce
+2. **Mission tasks:** `work/missions/<name>/TASKS.md` (git-files) or child issues with `artifact:task` label (issue backend) — **identify which task produced the output being evaluated**. Read the task's acceptance criteria — these are part of your evaluation scope alongside policies.
+3. **Architecture decisions:** [../../work/decisions/](../../work/decisions/) (git-files) or issues with `artifact:decision` label (issue backend) — patterns and constraints to enforce
 4. **Company values:** [../../COMPANY.md](../../COMPANY.md) — brand voice, strategic alignment
 5. **Agent type registry:** [../agents/](../agents/) — when reviewing agent type proposals
 6. **Asset registry:** [../../work/assets/](../../work/assets/) — validate completeness of registered assets
@@ -57,7 +57,7 @@ Protect organizational quality across every dimension: code, security, architect
 
 Every evaluation must produce a structured report using the **quality evaluation report template** (`work/missions/_TEMPLATE-quality-evaluation-report.md`).
 
-**Storage:** `work/missions/<mission-name>/evaluations/YYYY-MM-DD-<output-name>.md`
+**Storage:** `work/missions/<mission-name>/evaluations/YYYY-MM-DD-<output-name>.md` (always in Git regardless of work backend)
 
 The template includes:
 
@@ -90,8 +90,8 @@ When you create or modify artifacts, apply **Rule 10** from `AGENTS.md`. For Qua
 
 | Artifact | Versioning approach |
 |---|---|
-| Quality evaluation reports (`work/missions/*/evaluations/*.md`) | **Immutable once filed.** Date-stamped filenames. If re-evaluation is needed, file a new report — do not edit a submitted report |
-| Quality trend signals (`work/signals/*.md`) | **Immutable once filed.** File a new signal if findings are updated |
+| Quality evaluation reports (`work/missions/*/evaluations/*.md`) | **Immutable once filed.** Date-stamped filenames. Always stored in Git regardless of work backend. If re-evaluation is needed, file a new report — do not edit a submitted report |
+| Quality trend signals | **Immutable once filed.** File a new signal if findings are updated. (Git-files: `work/signals/*.md`; issue backend: issue with `artifact:signal` label) |
 | Policy files (`org/4-quality/policies/*.md`) | Bump `Version` (minor or major) + update `Last updated` + add row to the file's `## Changelog` section |
 | Agent Type Proposal evaluations | Filed as evaluation reports — immutable once the PR is submitted |
 
@@ -121,7 +121,7 @@ When an **Agent Type Proposal** (`org/agents/_TEMPLATE-agent-type-proposal.md`) 
 ## Quality Trend Analysis
 
 - Track evaluation verdicts over time per mission, per division, and per policy domain
-- When a policy domain shows **≥3 consecutive FAILs** across different outputs, surface a **quality trend signal** to `work/signals/`
+- When a policy domain shows **≥3 consecutive FAILs** across different outputs, surface a **quality trend signal** (to `work/signals/` for git-files, or as an issue with `artifact:signal` label for issue backend)
 - When Execution agents consistently fail on the same finding, recommend upstream instruction improvements
 - **Consume asset registry** (`work/assets/`) — validate that registered assets have complete metadata and meet documentation policies
 - **Consume observability platform trend data** (via MCP) — quality patterns are visible in telemetry long before they surface as evaluation verdicts. Proactively query:
@@ -135,12 +135,12 @@ When an **Agent Type Proposal** (`org/agents/_TEMPLATE-agent-type-proposal.md`) 
 The Quality Layer owns the Operate loop feedback cycle — closing the loop between shipped outputs and the Discover loop by filing production signals, triggering outcome reports, and detecting stalled missions.
 
 ### Outcome Measurement
-- **Monitor `measurement_schedule` dates** in outcome contracts (`work/missions/<name>/OUTCOME-CONTRACT.md`)
+- **Monitor `measurement_schedule` dates** in outcome contracts (`work/missions/<name>/OUTCOME-CONTRACT.md` for git-files, or on the mission issue for issue backend)
 - When a measurement checkpoint date arrives (initial check, follow-up, or final evaluation):
   1. Query the observability platform for actual metrics defined in the outcome contract
   2. Compare actuals vs. targets
-  3. Produce an outcome report (`work/missions/<name>/OUTCOME-REPORT.md`) from `work/missions/_TEMPLATE-outcome-report.md`
-  4. File the outcome report as a PR for human review
+  3. Produce an outcome report (`work/missions/<name>/OUTCOME-REPORT.md`) from `work/missions/_TEMPLATE-outcome-report.md` (always in Git)
+  4. File the outcome report for human review (as a PR for git-files backend, or link it from the mission issue for issue backend)
 - For the **final evaluation** checkpoint: recommend whether the outcome contract is `met` or `not-met` based on measured data
 
 ### Production Signaling
@@ -148,20 +148,20 @@ The Quality Layer owns the Operate loop feedback cycle — closing the loop betw
   - Reliability anomalies: error rate spikes, SLA breaches, availability drops
   - Adoption anomalies: feature usage significantly below or above projections
   - Performance anomalies: latency degradation, resource consumption drift
-- Signals are filed to `work/signals/` with `category: technical` and `source system: observability-platform` or `quality-evaluation`
+- Signals are filed to `work/signals/` (git-files) or as issues with `artifact:signal` label (issue backend), with `category: technical` and `source system: observability-platform` or `quality-evaluation`
 - These signals feed back into the Discover loop via the Steering Layer's weekly digest
 
 ### Stall Detection
 - **Flag missions with no status update** for more than 7 calendar days as potentially stalled
 - Detection process:
-  1. Scan `work/missions/*/STATUS.md` for the most recent entry date
-  2. If the latest entry is older than 7 days and mission status is `active`, file a stall signal
-  3. Stall signals are filed to `work/signals/` with `category: internal` and `urgency: next-cycle`
+  1. Git-files: Scan `work/missions/*/STATUS.md` for the most recent entry date. Issue backend: Check last update timestamp on mission issues with `status:active` label.
+  2. If the latest update is older than 7 days and mission status is `active`, file a stall signal
+  3. Stall signals are filed (to `work/signals/` for git-files, or as issues with `artifact:signal` label for issue backend) with `category: internal` and `urgency: next-cycle`
 - Stall signals are consumed by the Orchestration Layer for mission re-prioritization or escalation
 
 ## Continuous Improvement Responsibility
 
-Surface improvement signals to `work/signals/` when you observe:
+Surface improvement signals (to `work/signals/` for git-files backend, or as an issue with `artifact:signal` label for issue backend) when you observe:
 - Policies that are unclear, contradictory, or have gaps
 - Outputs that consistently fail the same policy (upstream problem)
 - New output types that have no applicable policy (coverage gap)
@@ -173,6 +173,7 @@ Surface improvement signals to `work/signals/` when you observe:
 
 | Version | Date | Change |
 |---|---|---|
+| 1.6 | 2026-03-07 | Updated for dual work backend support (git-files and issue tracker) |
 | 1.5 | 2026-02-25 | Added design-time observability evaluation to Evaluation Protocol (step 6): Quality agents verify Observability Design section completeness in Technical Designs before build |
 | 1.4 | 2026-02-25 | Added Operate Loop section with outcome measurement (measurement_schedule monitoring), production signaling, and stall detection (7-day threshold) |
 | 1.3 | 2026-02-24 | Added TASKS.md to evaluation context; added task traceability and acceptance criteria verification to Evaluation Protocol |

--- a/process/1-discover/AGENT.md
+++ b/process/1-discover/AGENT.md
@@ -4,13 +4,13 @@
 > **Loop:** Discover (the first loop in the process lifecycle)  
 > **Authority:** You detect and draft. Humans validate and approve.
 
-> **Version:** 1.2 | **Last updated:** 2026-02-25
+> **Version:** 1.3 | **Last updated:** 2026-03-07
 
 ---
 
 ## Your Purpose
 
-Monitor signal sources, detect meaningful signals, draft signal files, assist with opportunity validation, and generate mission brief drafts for human review and approval.
+Monitor signal sources, detect meaningful signals, draft signal artifacts, assist with opportunity validation, and generate mission brief drafts for human review and approval.
 
 ## Context You Must Read
 
@@ -25,7 +25,7 @@ Monitor signal sources, detect meaningful signals, draft signal files, assist wi
 
 ### Signal Detection
 - Monitor configured signal sources (see Discover Guide)
-- Draft signal files using `work/signals/_TEMPLATE-signal.md`
+- Draft signals using `work/signals/_TEMPLATE-signal.md` (git-files backend) or by creating an issue with `artifact:signal` label (issue backend)
 - Classify signals: market | customer | technical | internal | competitive
 - Assess initial urgency: immediate | next-cycle | monitor
 - For technical signals sourced from the observability platform, link the specific metrics, dashboards, or queries as evidence — signals grounded in production data are highest confidence
@@ -44,9 +44,9 @@ Monitor signal sources, detect meaningful signals, draft signal files, assist wi
 - Draft opportunity summary for Strategy Layer review
 
 ### Mission Brief Drafting
-- Generate mission brief using `work/missions/_TEMPLATE-mission-brief.md`
+- Generate mission brief using `work/missions/_TEMPLATE-mission-brief.md` (git-files backend) or by creating an issue with `artifact:mission` label (issue backend)
 - Define scope boundaries (in-scope / out-of-scope)
-- Propose outcome contract using `work/missions/_TEMPLATE-outcome-contract.md`
+- Propose outcome contract using `work/missions/_TEMPLATE-outcome-contract.md` (git-files) or as a linked issue (issue backend)
 - Identify dependencies on other missions
 - **Populate the Observability Requirements section** — identify key metrics aligned with the outcome contract, query production baselines for any existing components this mission will modify, and note observability dependencies (new dashboards, SLOs, alerts). This ensures observability is considered from mission inception, not deferred to implementation.
 - **Populate Observability Requirements** — identify key metrics the mission must expose (aligned with outcome contract), query production baselines for existing components affected by the mission, and note observability dependencies (new SLOs, dashboards, alerts). This ensures observability is considered from mission inception, not deferred to implementation.
@@ -55,8 +55,8 @@ Monitor signal sources, detect meaningful signals, draft signal files, assist wi
 
 | Artifact | Versioning approach |
 |---|---|
-| Signals (`work/signals/*.md`) | **Immutable once filed.** If new information arrives, file a supplemental signal. Include a `supersedes:` reference to the original in the new signal's metadata. |
-| Mission briefs (`work/missions/*/BRIEF.md`) | Increment `Revision` + update `Last updated` as the brief evolves. Once approved, a new revision documents any scope changes. |
+| Signals | **Immutable once filed.** If new information arrives, file a supplemental signal. Include a `supersedes:` reference to the original. (Git-files: `work/signals/*.md`; issue backend: cross-reference original issue.) |
+| Mission briefs | Increment `Revision` + update `Last updated` (git-files: `work/missions/*/BRIEF.md`) or edit the mission issue body (issue backend). Once approved, a new revision documents any scope changes. |
 | Outcome contracts | Increment `Revision` if outcome targets change during the Discover loop |
 
 ## What You Never Do
@@ -72,6 +72,7 @@ Monitor signal sources, detect meaningful signals, draft signal files, assist wi
 
 | Version | Date | Change |
 |---|---|---|
+| 1.3 | 2026-03-07 | Updated for dual work backend support (git-files and issue tracker) |
 | 1.2 | 2026-02-25 | Added observability-driven signal detection (link production metrics as evidence); added Observability Requirements to Mission Brief Drafting |
 | 1.1 | 2026-02-19 | Added Versioning Your Outputs section |
 | 1.0 | 2026-02-19 | Initial version |

--- a/process/1-discover/GUIDE.md
+++ b/process/1-discover/GUIDE.md
@@ -23,6 +23,7 @@
 
 Anyone (human or agent) can create a signal:
 
+**Git-files backend:**
 ```bash
 # Create a new signal file
 cp work/signals/_TEMPLATE-signal.md work/signals/YYYY-MM-DD-<descriptive-name>.md
@@ -30,7 +31,10 @@ cp work/signals/_TEMPLATE-signal.md work/signals/YYYY-MM-DD-<descriptive-name>.m
 # Submit as a Pull Request
 ```
 
-**Signal file must include:**
+**Issue backend:**
+Create a new issue with label `artifact:signal`. Use the signal issue template (if configured) or fill in the required fields: source, category, raw data/observation, urgency, and link to source data.
+
+**Signal must include:**
 - Source (where did this signal come from?)
 - Category (market | customer | technical | internal | competitive | financial)
 - Raw data or observation
@@ -56,13 +60,13 @@ For signals that proceed:
 ### Step 4: Mission Brief Creation
 
 If the opportunity is validated:
-1. Use `work/missions/_TEMPLATE-mission-brief.md`
+1. Use `work/missions/_TEMPLATE-mission-brief.md` (git-files) or create a mission issue with `artifact:mission` label (issue backend)
 2. Define scope (in-scope / out-of-scope)
-3. Create outcome contract (`work/missions/_TEMPLATE-outcome-contract.md`)
+3. Create outcome contract (`work/missions/_TEMPLATE-outcome-contract.md` or as a linked issue)
 4. Identify human checkpoint moments
 5. Estimate fleet composition
 6. **Define observability requirements** — identify key metrics aligned with the outcome contract, query production baselines for any existing components affected, and note observability dependencies (new dashboards, SLOs, alerts needed). See the Observability Requirements section in the mission brief template.
-7. Submit as PR for Strategy Layer approval
+7. Submit for Strategy Layer approval (PR for git-files backend, label change for issue backend)
 
 ### Step 5: Mission Approval
 

--- a/process/2-build/AGENT.md
+++ b/process/2-build/AGENT.md
@@ -4,7 +4,7 @@
 > **Loop:** Build (the second loop in the process lifecycle)  
 > **Authority:** You produce work. Quality Layer evaluates. Humans resolve escalations and approve architecture decisions.
 
-> **Version:** 1.3 | **Last updated:** 2026-02-25
+> **Version:** 1.4 | **Last updated:** 2026-03-07
 
 ---
 
@@ -14,7 +14,7 @@ Execute approved mission briefs by producing outputs: code, tests, documentation
 
 ## Context You Must Read
 
-1. **Mission tasks:** `work/missions/<name>/TASKS.md` — **your work intake**. Identify your assigned tasks, check dependencies, and verify acceptance criteria before starting.
+1. **Mission tasks:** `work/missions/<name>/TASKS.md` (git-files) or mission issue with `artifact:task` child issues (issue backend) — **your work intake**. Identify your assigned tasks, check dependencies, and verify acceptance criteria before starting.
 2. **Process overview:** [../README.md](../README.md)
 3. **Quality policies:** [../../org/4-quality/policies/](../../org/4-quality/policies/) — ALL of them
 4. **Decision record template:** [../../work/decisions/_TEMPLATE-decision-record.md](../../work/decisions/_TEMPLATE-decision-record.md)
@@ -36,13 +36,13 @@ For all missions:
 - If the Technical Design is absent for a multi-stream mission, raise a blocker to the Orchestration Layer
 
 ### Execute Work Streams
-- Pick up tasks from `TASKS.md` that are assigned to your division and agent type
+- Pick up tasks from `TASKS.md` (git-files) or from child task issues on the mission issue (issue backend) that are assigned to your division and agent type
 - Follow the fleet configuration for your assigned stream
-- Update task status in TASKS.md as you progress (`pending` → `in-progress` → `completed` or `blocked`)
+- Update task status as you progress (`pending` → `in-progress` → `completed` or `blocked`) — in TASKS.md (git-files) or via issue label transition (issue backend)
 - Produce outputs within the defined working paths
 - Respect exclusive path ownership (don't touch other streams' files)
-- Submit outputs as Pull Requests
-- Link generated assets back to the task in TASKS.md upon completion
+- Submit outputs as Pull Requests (code changes always go through PRs regardless of work backend)
+- Link generated assets back to the task upon completion
 
 ### Maintain Quality
 - Self-evaluate against all applicable quality policies BEFORE submitting
@@ -58,10 +58,10 @@ For all missions:
 - Submit for Architecture Governor review
 
 ### Track Progress
-- Update task status in TASKS.md — this is the primary progress indicator
+- Update task status — in TASKS.md (git-files) or via issue label transition (issue backend) — this is the primary progress indicator
 - Surface blockers immediately (set task to `blocked`, document in STATUS.md)
 - Log dependencies discovered during execution
-- If TASKS.md does not exist for an active mission, file an improvement signal — do not guess at work items
+- If task tracking does not exist for an active mission (no TASKS.md for git-files, or no child task issues for issue backend), file an improvement signal — do not guess at work items
 
 ## Versioning Your Outputs
 
@@ -69,7 +69,7 @@ For all missions:
 |---|---|
 | Code | Conventional Commits drive versioning: `feat:` → MINOR, `fix:` → PATCH, `BREAKING CHANGE:` → MAJOR |
 | Technical Design (`work/missions/*/TECHNICAL-DESIGN.md`) | Increment `Revision` + update `Last updated` on each iteration before review |
-| Decision records (`work/decisions/*.md`) | Increment `Revision` when status changes or context is updated. Decision records are **never deleted** — they are superseded by newer decisions. |
+| Decision records | Increment `Revision` when status changes or context is updated (git-files: `work/decisions/*.md`; issue backend: edit the decision issue body). Decision records are **never deleted** — they are superseded by newer decisions. |
 | Documentation | Follow the same Conventional Commits convention as code when committed together |
 
 ## What You Never Do
@@ -86,6 +86,7 @@ For all missions:
 
 | Version | Date | Change |
 |---|---|---|
+| 1.4 | 2026-03-07 | Updated for dual work backend support (git-files and issue tracker) |
 | 1.3 | 2026-02-25 | Added observability design to Technical Design production (instrumentation, metrics, SLOs, production baselines); expanded Maintain Quality with observability coverage verification; distinguished design-time vs. implementation-time observability |
 | 1.2 | 2026-02-24 | Added TASKS.md as primary work intake in Context and Execute Work Streams; added task status tracking to Track Progress; added missing TASKS.md signal guidance |
 | 1.1 | 2026-02-19 | Added Versioning Your Outputs section |

--- a/process/2-build/GUIDE.md
+++ b/process/2-build/GUIDE.md
@@ -64,7 +64,7 @@ For each submitted output:
 
 Novel patterns, architecture choices, and strategy decisions discovered during Build are captured:
 1. Use `work/decisions/_TEMPLATE-decision-record.md`
-2. Submit as PR to `work/decisions/`
+2. Submit for review (as PR to `work/decisions/` for git-files backend, or create an issue with `artifact:decision` label for issue backend)
 3. Architecture Governor reviews and approves
 
 ---
@@ -98,11 +98,11 @@ Before submitting any output:
 Before a mission's outputs can proceed from Build to Ship, **all** of the following must be true:
 
 ### Required Artifacts
-- [ ] All tasks in `TASKS.md` are marked `done` (or explicitly descoped with rationale)
+- [ ] All tasks are marked `done` (or explicitly descoped with rationale) — verified via TASKS.md (git-files) or task issue status (issue backend)
 - [ ] All PRs for in-scope deliverables are merged to `main`
 - [ ] Quality evaluation reports exist for every output (`work/missions/<name>/evaluations/`)
 - [ ] All evaluation verdicts are **PASS** or **PASS WITH NOTES** — no open FAILs or ESCALATEs
-- [ ] Decision records filed for all novel patterns or architecture choices (`work/decisions/`)
+- [ ] Decision records filed for all novel patterns or architecture choices
 
 ### Quality Gates Passed
 - [ ] All applicable quality policies evaluated (security, architecture, performance, observability)
@@ -113,7 +113,7 @@ Before a mission's outputs can proceed from Build to Ship, **all** of the follow
 - [ ] **Build owner:** Execution Layer agents (mission complete from their perspective)
 - [ ] **Ship owner:** Orchestration Layer (takes over for release preparation)
 - [ ] Orchestration Layer notified that Build is complete and release preparation can begin
-- [ ] `STATUS.md` updated to reflect readiness for Ship loop
+- [ ] Mission status updated to reflect readiness for Ship loop
 
 > **Gate enforcer:** The Quality Layer verifies this checklist before approving the Build→Ship transition. The Orchestration Layer cannot create a release contract until all items are checked.
 

--- a/process/3-ship/AGENT.md
+++ b/process/3-ship/AGENT.md
@@ -4,7 +4,7 @@
 > **Loop:** Ship (the third loop in the process lifecycle)  
 > **Authority:** You prepare and execute. Humans approve production deployments.
 
-> **Version:** 1.2 | **Last updated:** 2026-02-24
+> **Version:** 1.3 | **Last updated:** 2026-03-07
 
 ---
 
@@ -19,7 +19,7 @@ Take quality-approved outputs and ship them to production safely, measurably, an
 3. **Delivery policy:** [../../org/4-quality/policies/delivery.md](../../org/4-quality/policies/delivery.md)
 4. **Observability policy:** [../../org/4-quality/policies/observability.md](../../org/4-quality/policies/observability.md)
 5. **Outcome contract** for the mission
-6. **Mission tasks:** `work/missions/<name>/TASKS.md` — verify task completion before release
+6. **Mission tasks:** `work/missions/<name>/TASKS.md` (git-files) or child issues with `artifact:task` label (issue backend) — verify task completion before release
 7. **Outcome report template:** [../../work/missions/_TEMPLATE-outcome-report.md](../../work/missions/_TEMPLATE-outcome-report.md)
 8. **Asset registry:** [../../work/assets/](../../work/assets/) — verify all ship artifacts are registered
 
@@ -27,8 +27,8 @@ Take quality-approved outputs and ship them to production safely, measurably, an
 
 ### Release Preparation
 - Compile release contract from quality-approved outputs
-- **Store release contract** in `work/releases/YYYY-MM-DD-<release-name>.md` (template: `work/releases/_TEMPLATE-release-contract.md`)
-- **Verify task completion** — read `TASKS.md` for the mission and confirm all tasks are `completed` or explicitly `descoped` with documented rationale. **Block the release if tasks remain in-progress or pending without descope justification.**
+- **Store release contract** in `work/releases/YYYY-MM-DD-<release-name>.md` (git-files, template: `work/releases/_TEMPLATE-release-contract.md`) or create an issue with `artifact:release` label (issue backend)
+- **Verify task completion** — read `TASKS.md` (git-files) or child task issues (issue backend) for the mission and confirm all tasks are `completed` or explicitly `descoped` with documented rationale. **Block the release if tasks remain in-progress or pending without descope justification.**
 - **Verify asset registry completeness** — every deliverable in the release must have an entry in `work/assets/`; create missing entries using `work/assets/_TEMPLATE-asset-registry-entry.md`
 - **Verify production readiness** — check against `org/4-quality/policies/observability.md`: instrumentation active, telemetry flowing, health dashboard created, alerting configured with runbooks. **Block the release if production readiness is not verified.**
 - Define progressive rollout plan
@@ -51,31 +51,31 @@ Take quality-approved outputs and ship them to production safely, measurably, an
 ### Outcome Measurement
 - Collect outcome metrics defined in the outcome contract
 - Compare actuals vs. targets
-- **Produce an outcome report** (`work/missions/_TEMPLATE-outcome-report.md`) — store in `work/missions/<name>/OUTCOME-REPORT.md`
+- **Produce an outcome report** (`work/missions/_TEMPLATE-outcome-report.md`) — store in `work/missions/<name>/OUTCOME-REPORT.md` (always in Git regardless of work backend)
 - The outcome report triggers:
   - Strategy Layer to update **venture health reports**
   - Steering Layer to consume for **Loop 3 recalibration**
 - Identify learnings and improvement opportunities
 
 ### Feedback Loop
-- Create new signals in `work/signals/` based on production observations
+- Create new signals based on production observations (to `work/signals/` for git-files, or as issues with `artifact:signal` label for issue backend)
 - Surface process improvements to Steering Layer
 - Document lessons learned
-- When incidents occur post-ship, produce a **postmortem** (`work/retrospectives/_TEMPLATE-postmortem.md`) — store in `work/retrospectives/YYYY-MM-DD-<incident-name>.md`
+- When incidents occur post-ship, produce a **postmortem** (`work/retrospectives/_TEMPLATE-postmortem.md`) — store in `work/retrospectives/YYYY-MM-DD-<incident-name>.md` (git-files) or create an issue with `artifact:retrospective` label (issue backend)
 
 ## Versioning Your Outputs
 
 | Artifact | Versioning approach |
 |---|---|
-| Release contracts (`work/releases/*.md`) | **Immutable once merged.** Date-stamped filenames. A hotfix or re-release gets a new release contract file. |
-| Outcome reports (`work/missions/*/OUTCOME-REPORT.md`) | Increment `Revision` if updated post-filing (e.g., final metrics confirmed after initial estimate) |
-| Postmortems (`work/retrospectives/*.md`) | **Append-only.** Once a postmortem PR is merged, add new findings as dated addendum entries — do not re-edit earlier sections |
+| Release contracts | **Immutable once approved.** Date-stamped. A hotfix or re-release gets a new release contract. (Git-files: `work/releases/*.md`; issue backend: new issue with `artifact:release` label.) |
+| Outcome reports (`work/missions/*/OUTCOME-REPORT.md`) | Increment `Revision` if updated post-filing (e.g., final metrics confirmed after initial estimate). Always in Git. |
+| Postmortems | **Append-only.** Once approved, add new findings as dated addendum entries — do not re-edit earlier sections. (Git-files: `work/retrospectives/*.md`; issue backend: issue comments for addenda.) |
 | Asset registry entries (`work/assets/*.md`) | Increment `Revision` + update `Last updated` when ownership or metadata changes at ship time |
 
 ## What You Never Do
 
 - **Never deploy** without a release contract
-- **Never ship** with open tasks — all tasks in TASKS.md must be `completed` or explicitly `descoped` before release
+- **Never ship** with open tasks — all tasks must be `completed` or explicitly `descoped` before release (verified via TASKS.md for git-files, or task issue status for issue backend)
 - **Never skip** progressive rollout (unless emergency hotfix)
 - **Never disable** automatic rollback triggers
 - **Never ignore** post-deployment health alerts
@@ -87,6 +87,7 @@ Take quality-approved outputs and ship them to production safely, measurably, an
 
 | Version | Date | Change |
 |---|---|---|
+| 1.3 | 2026-03-07 | Updated for dual work backend support (git-files and issue tracker) |
 | 1.2 | 2026-02-24 | Added TASKS.md to context; added task completion verification to Release Preparation; added "Never ship with open tasks" rule |
 | 1.1 | 2026-02-19 | Added Versioning Your Outputs section |
 | 1.0 | 2026-02-19 | Initial version |

--- a/process/3-ship/GUIDE.md
+++ b/process/3-ship/GUIDE.md
@@ -71,9 +71,9 @@ After the defined measurement period:
 ### Step 6: Feedback Loop
 
 Production observations become new signals:
-1. Performance improvements needed → signal to `work/signals/`
-2. Customer feedback patterns → signal to `work/signals/`
-3. Process friction points → signal to `work/signals/`
+1. Performance improvements needed → new signal
+2. Customer feedback patterns → new signal
+3. Process friction points → new signal
 4. Unexpected behavior → incident signal
 
 ---
@@ -100,14 +100,14 @@ For critical production issues:
 3. **Test** — Abbreviated testing (security checks still mandatory)
 4. **Deploy** — Expedited deployment (skip non-essential stages)
 5. **Validate** — Post-deployment health check (15 min window)
-6. **Document** — Post-incident signal in `work/signals/`
+6. **Document** — Post-incident signal filed
 
 ## Exit Criteria / Handoff to Operate
 
 Before a release transitions from Ship to Operate, **all** of the following must be true:
 
 ### Required Artifacts
-- [ ] Release contract exists and is approved (`work/releases/YYYY-MM-DD-<release>.md`)
+- [ ] Release contract exists and is approved (git-files: `work/releases/YYYY-MM-DD-<release>.md`; issue backend: approved issue with `artifact:release` label)
 - [ ] Progressive deployment completed through all stages (canary → GA → full rollout)
 - [ ] Post-deployment validation passed (error rates, latency, smoke tests)
 - [ ] Outcome contract has `measurement_schedule` dates filled in (`work/missions/<name>/OUTCOME-CONTRACT.md`)
@@ -124,7 +124,7 @@ Before a release transitions from Ship to Operate, **all** of the following must
 - [ ] **Operate owner:** Quality Layer (takes over for outcome measurement, production signaling, and stall detection)
 - [ ] Quality Layer has the `measurement_schedule` dates and will trigger outcome reports at each checkpoint
 - [ ] On-call team is aware of the new deployment and has access to rollback procedures
-- [ ] `STATUS.md` updated to reflect that the mission is in the Operate/measurement phase
+- [ ] Mission status updated to reflect that the mission is in the Operate/measurement phase
 
 > **Gate enforcer:** The Orchestration Layer verifies this checklist before declaring the release complete. The Quality Layer begins the Operate loop once the handoff is confirmed.
 

--- a/process/4-operate/AGENT.md
+++ b/process/4-operate/AGENT.md
@@ -4,7 +4,7 @@
 > **Loop:** Operate & Evolve (fourth loop — the continuous post-GA lifecycle)  
 > **Key difference from Loops 1–3:** Loops 1–3 are mission-driven (time-bounded, goal-oriented). This loop is **continuous and event-driven** — it runs 24/7, governed by operational policies and health targets, not by mission briefs.
 
-> **Version:** 1.1 | **Last updated:** 2026-02-19
+> **Version:** 1.2 | **Last updated:** 2026-03-07
 
 ---
 
@@ -19,7 +19,7 @@ You primarily operate within the **Execution Layer**, but Loop 4 spans all 5 lay
 | Layer | Their Role | Your Interaction |
 |-------|-----------|------------------|
 | **Quality** | Operations Policy Authors define the health targets, remediation boundaries, and alerting standards you enforce | You execute within their policies. When policies are insufficient, you escalate to them |
-| **Strategy** | Outcome Owners interpret your production signals and decide what warrants new missions | You file signals to `work/signals/`. They triage and prioritize |
+| **Strategy** | Outcome Owners interpret your production signals and decide what warrants new missions | You file signals (to `work/signals/` or as issues with `artifact:signal` label). They triage and prioritize |
 | **Orchestration** | Agent Fleet Managers coordinate your fleet. Mission Leads create missions from your signals | They configure your fleet parameters. You report fleet health |
 | **Execution** | On-call engineers handle your escalations. Tech Leads own service architecture | You escalate novel failures. They resolve and update runbooks |
 | **Steering** | Executives receive systemic operational trends (cost, maturity, production health posture) | You surface aggregated trends. They inform company evolution |
@@ -32,7 +32,7 @@ You primarily operate within the **Execution Layer**, but Loop 4 spans all 5 lay
 4. **Health targets:** Declarative health target configs for the service you're operating
 5. **Runbooks:** Executable runbooks for the service (template: `org/3-execution/divisions/_TEMPLATE/_TEMPLATE-runbook.md`)
 6. **Incident response framework:** Escalation paths, severity definitions, communication templates
-7. **Architecture decisions:** [../../work/decisions/](../../work/decisions/) — relevant patterns and constraints
+7. **Architecture decisions:** [../../work/decisions/](../../work/decisions/) (git-files) or issues with `artifact:decision` label (issue backend) — relevant patterns and constraints
 8. **Postmortem template:** [../../work/retrospectives/_TEMPLATE-postmortem.md](../../work/retrospectives/_TEMPLATE-postmortem.md) — for incident retrospectives
 9. **Signal digest template:** [../../work/signals/digests/_TEMPLATE-signal-digest.md](../../work/signals/digests/_TEMPLATE-signal-digest.md) — signals surface through digests into Loop 1
 
@@ -46,7 +46,7 @@ You primarily operate within the **Execution Layer**, but Loop 4 spans all 5 lay
 - **Track error budgets** — alert when error rates exceed safe thresholds
 - **Watch deployment health** — monitor post-deployment metrics for every new release
 - **Detect anomalies** — use baseline comparison and anomaly detection
-- **Surface degradation signals** — file improvement signals to `work/signals/` when sustained degradation is detected
+- **Surface degradation signals** — file improvement signals (to `work/signals/` for git-files, or as issues with `artifact:signal` label for issue backend) when sustained degradation is detected
 
 ### Automated Remediation (Remediation Agents)
 
@@ -76,14 +76,14 @@ You primarily operate within the **Execution Layer**, but Loop 4 spans all 5 lay
   - **SEV4 (Low):** Informational signal → log + surface as improvement signal
 - **Diagnose** — Correlate signals across production systems
 - **Coordinate** — During SEV1/SEV2: notify on-call, assemble context package, draft customer communication
-- **Postmortem** — After resolution: generate blameless postmortem draft using **postmortem template** (`work/retrospectives/_TEMPLATE-postmortem.md`), store in `work/retrospectives/YYYY-MM-DD-<incident-name>.md`, identify systemic improvements, file signals
-  - **Policy gap analysis** — if the incident reveals a quality policy gap, include it in the postmortem and surface a signal to `work/signals/` for the Quality Layer
+- **Postmortem** — After resolution: generate blameless postmortem draft using **postmortem template** (`work/retrospectives/_TEMPLATE-postmortem.md`), store in `work/retrospectives/YYYY-MM-DD-<incident-name>.md` (git-files) or create an issue with `artifact:retrospective` label (issue backend), identify systemic improvements, file signals
+  - **Policy gap analysis** — if the incident reveals a quality policy gap, include it in the postmortem and surface a signal for the Quality Layer
 
 ### Chaos Engineering & Resilience Testing (Resilience Agents)
 
 - **Scheduled failure injection** — Run pre-approved chaos experiments in staging environments
 - **Continuous resilience validation** — Low-impact resilience checks in production (with approval)
-- **Surface resilience gaps** — File signals in `work/signals/` when chaos experiments reveal weaknesses
+- **Surface resilience gaps** — File signals (to `work/signals/` for git-files, or as issues with `artifact:signal` label for issue backend) when chaos experiments reveal weaknesses
 
 ### Capacity Management & Cost Optimization (Capacity Agents)
 
@@ -102,7 +102,7 @@ You primarily operate within the **Execution Layer**, but Loop 4 spans all 5 lay
 
 This is the critical connection that makes the entire model **circular**:
 
-- **Production signals → Loop 1** — Every operational observation that suggests a product change should be filed as a signal in `work/signals/`
+- **Production signals → Loop 1** — Every operational observation that suggests a product change should be filed as a signal (to `work/signals/` for git-files, or as an issue with `artifact:signal` label for issue backend)
 - **Signals are aggregated into digests** — The Steering Layer produces weekly **signal digests** (`work/signals/digests/_TEMPLATE-signal-digest.md`, stored in `work/signals/digests/`) that compile operational signals with strategic and quality signals for Loop 1 triage
 - **Health target compliance → Quality feedback** — When health target violations correlate with specific quality policy domains (e.g., persistent performance regressions), surface a signal recommending policy tightening or upstream instruction improvement
 - **Signal types from operations:**
@@ -131,8 +131,8 @@ This is the critical connection that makes the entire model **circular**:
 
 | Artifact | Versioning approach |
 |---|---|
-| Signals (`work/signals/*.md`) | **Immutable once filed.** Production observations, anomalies, and capacity signals are new files — not revisions to old ones |
-| Postmortems (`work/retrospectives/*.md`) | **Append-only.** Add dated addenda for new findings. Do not edit previously published sections. |
+| Signals | **Immutable once filed.** Production observations, anomalies, and capacity signals are new artifacts — not revisions to old ones. (Git-files: `work/signals/*.md`; issue backend: new issue with `artifact:signal` label.) |
+| Postmortems | **Append-only.** Add dated addenda for new findings. Do not edit previously published sections. (Git-files: `work/retrospectives/*.md`; issue backend: issue comments for addenda.) |
 | Runbook updates | Runbooks are owned by Execution Layer. File a mission or signal to request a change — don't edit directly unless you have authorized access. When authorized, increment `Revision` + update `Last updated`. |
 
 ## What You Never Do
@@ -148,7 +148,7 @@ This is the critical connection that makes the entire model **circular**:
 
 ## Continuous Improvement Responsibility
 
-Surface improvement signals to `work/signals/` when you observe:
+Surface improvement signals (to `work/signals/` for git-files backend, or as an issue with `artifact:signal` label for issue backend) when you observe:
 - Runbooks that are incomplete or don't match current system behavior
 - Alert rules with high false-positive rates
 - Health targets that are too tight or too loose
@@ -164,5 +164,6 @@ Surface improvement signals to `work/signals/` when you observe:
 
 | Version | Date | Change |
 |---|---|---|
+| 1.2 | 2026-03-07 | Updated for dual work backend support (git-files and issue tracker) |
 | 1.1 | 2026-02-19 | Added Versioning Your Outputs section |
 | 1.0 | 2026-02-19 | Initial version |

--- a/process/4-operate/GUIDE.md
+++ b/process/4-operate/GUIDE.md
@@ -55,7 +55,7 @@ Loop 3 (Ship) completes → Feature is GA → Loop 4 begins (and never ends)
   │           └────────┴────────┘                                      │
   │                    │                                                │
   │                    ▼                                                │
-  │        File improvement signal → work/signals/ → Loop 1 (Discover)│
+  │        File improvement signal → Loop 1 (Discover)               │
   │                                                                    │
   │  In parallel (always running):                                     │
   │  • Feature flag agents manage progressive rollouts                 │
@@ -86,7 +86,7 @@ You author the policies that operations agents enforce autonomously:
 
 ### 2. Respond to Escalations (On-Call Engineers)
 
-When operations agents escalate, you investigate and resolve:
+When operations agents escalate, you investigate and resolve. Escalations appear as notifications on issues (issue backend) or as updates in `work/signals/` and `STATUS.md` (git-files backend):
 
 | Escalation Type | Your Response |
 |---|---|
@@ -112,7 +112,7 @@ Feature flag agents manage ongoing rollouts, but key decisions are yours:
 
 The most valuable output of Loop 4 is the **feedback loop to Loop 1**:
 
-- Operations agents file signals in `work/signals/` based on production observations
+- Operations agents file signals based on production observations (to `work/signals/` for git-files, or as issues with `artifact:signal` label for issue backend)
 - You interpret whether these signals warrant new missions
 - **This is the loop that closes the entire model.** Without Operate → Discover feedback, the model is linear. With it, the model is circular.
 
@@ -150,7 +150,7 @@ The most valuable output of Loop 4 is the **feedback loop to Loop 1**:
    "Query Z degrades 5% per month at current data growth"
          │
          ▼
- Signals filed in work/signals/
+ Signals filed as work artifacts
          │
          ▼
  Loop 1 (Discover) picks them up:

--- a/process/README.md
+++ b/process/README.md
@@ -33,7 +33,7 @@
 │              Feedback loops (continuous)                   │
 └──────────────────────────┼────────────────────────────────┘
                            │
-                    work/signals/ ← new signals from production
+                    signals ← new signals from production
 ```
 
 ## The Three Loops in Detail
@@ -43,10 +43,10 @@
 
 | Phase | Input | Output | Owner |
 |-------|-------|--------|-------|
-| Signal capture | Raw signal | `work/signals/<signal>.md` | Anyone (human or agent) |
-| Signal triage | Signal file | Prioritized, categorized signal | Strategy Layer |
+| Signal capture | Raw signal | Signal artifact (file in `work/signals/` or issue with `artifact:signal` label) | Anyone (human or agent) |
+| Signal triage | Signal file / issue | Prioritized, categorized signal | Strategy Layer |
 | Opportunity validation | Prioritized signal | Validated opportunity | Strategy Layer + Steering Layer |
-| Mission brief | Validated opportunity | `work/missions/<name>/BRIEF.md` | Strategy Layer |
+| Mission brief | Validated opportunity | Mission brief (file in `work/missions/` or issue with `artifact:mission` label) | Strategy Layer |
 
 **Loop details:** [1-discover/GUIDE.md](1-discover/GUIDE.md)  
 **Agent instructions:** [1-discover/AGENT.md](1-discover/AGENT.md)
@@ -93,7 +93,7 @@ Like Loops 1–3, the Operate loop **spans all 5 layers** — it is not confined
 | Incident response | SEV1-4 alerts | Resolution, postmortem, policy updates | Incident agents + on-call engineers (**Execution**) |
 | Capacity & performance | Resource metrics, traffic patterns | Optimization actions, forecasts | Capacity agents (**Execution**) |
 | Signal interpretation | Production observations | New missions, strategic pivots | Outcome Owners (**Strategy**) |
-| Signal generation | All production observations | `work/signals/` entries → Loop 1 | All operations agents (**Execution → Strategy**) |
+| Signal generation | All production observations | Signal artifacts → Loop 1 | All operations agents (**Execution → Strategy**) |
 | Systemic signal aggregation | Operational trends, maturity metrics | Company-level evolution proposals | Steering agents (**Steering**) |
 
 **Key distinction:** Loops 1–3 are mission-driven (time-bounded). Loop 4 is continuous (event-driven, 24/7).
@@ -103,19 +103,19 @@ Like Loops 1–3, the Operate loop **spans all 5 layers** — it is not confined
 
 ---
 
-## Process Governance: Git-Native
+## Process Governance
 
-This is a **Git-native** company. Git is the system of record, not a side channel.
+Git is the **governance backbone** — organizational structure, policies, agent instructions, and templates always live in Git and are governed via PRs. Operational work artifacts (signals, missions, decisions, releases) can be tracked in either Git files or an issue tracker, depending on your configured work backend (see `CONFIG.yaml → work_backend` and [../docs/WORK-BACKENDS.md](../docs/WORK-BACKENDS.md)).
 
-| Concept | Git Mechanism |
-|---------|---------------|
-| **Decision** | Pull Request merged to `work/decisions/` |
-| **Approval** | PR review approval |
-| **RACI** | CODEOWNERS file — see [../CODEOWNERS](../CODEOWNERS) |
-| **Audit trail** | Git history |
-| **Policy change** | PR to `org/4-quality/policies/` |
-| **Strategy change** | PR to `org/1-strategy/` |
-| **Escalation** | PR with `escalation` label |
+| Concept | Git-Files Backend | Issue Backend |
+|---------|-------------------|---------------|
+| **Decision** | PR merged to `work/decisions/` | Issue with `artifact:decision` label, approved via label change |
+| **Approval** | PR review approval | Label change by authorized human (e.g., `status:proposed` → `status:approved`) |
+| **RACI** | CODEOWNERS file — see [../CODEOWNERS](../CODEOWNERS) | CODEOWNERS (for governance) + issue assignment (for work artifacts) |
+| **Audit trail** | Git history | Git history (governance) + issue activity log (work artifacts) |
+| **Policy change** | PR to `org/4-quality/policies/` | PR to `org/4-quality/policies/` (always Git) |
+| **Strategy change** | PR to `org/1-strategy/` | PR to `org/1-strategy/` (always Git) |
+| **Escalation** | PR with `escalation` label | Issue with `escalation` label |
 
 ### CODEOWNERS Structure
 

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -122,6 +122,35 @@
     "product_name": {
       "type": "string",
       "description": "Primary product or offering name."
+    },
+    "work_backend": {
+      "type": "object",
+      "description": "Where operational work artifacts are tracked. See docs/WORK-BACKENDS.md.",
+      "additionalProperties": true,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["git-files", "github-issues"],
+          "description": "Work tracking backend: git-files (Markdown in work/) or github-issues."
+        },
+        "github_issues": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "repo": { "type": "string", "description": "Issue repo (empty = same repo)." },
+            "use_projects": { "type": "boolean", "description": "Use GitHub Projects for board views." },
+            "use_label_prefixes": { "type": "boolean", "description": "Use artifact:, status:, layer: label prefixes." }
+          }
+        },
+        "overrides": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "enum": ["git-files", "github-issues"]
+          },
+          "description": "Per-artifact backend overrides."
+        }
+      }
     }
   }
 }

--- a/work/README.md
+++ b/work/README.md
@@ -1,11 +1,15 @@
 # Work — Active Work Tracking
 
-> **What this is:** The living workspace where signals, missions, and decisions are tracked.  
-> **Convention:** This is the only folder that changes frequently. Everything else (`org/`, `process/`) changes slowly and deliberately.
+> **What this is:** The artifact definitions and templates for tracking operational work.
+> **Backend:** Where these artifacts live depends on `CONFIG.yaml → work_backend`. See [docs/WORK-BACKENDS.md](../docs/WORK-BACKENDS.md).
+> - **Git-files backend** (default): Artifacts are Markdown files in this folder. This is the only folder that changes frequently.
+> - **Issue backend** (e.g., GitHub Issues): Artifacts are tracked as issues with structured labels. This folder contains only templates (as schema definitions) and persistent documentation artifacts.
 
 ---
 
 ## Structure
+
+**Git-files backend** — all artifacts live here:
 
 ```
 work/
@@ -26,7 +30,28 @@ work/
     └── README.md
 ```
 
+**Issue backend** — only these remain in Git:
+
+```
+work/
+├── assets/               # Asset registry entries (always in Git)
+├── missions/             # Git-backed mission evidence and design artifacts
+│   └── <name>/
+│       ├── TECHNICAL-DESIGN.md
+│       ├── FLEET-REPORT.md
+│       ├── OUTCOME-REPORT.md
+│       └── evaluations/
+├── decisions/            # Governance exceptions (always in Git)
+│   └── EXC-*.md
+├── signals/
+│   └── digests/          # Weekly signal digests (always in Git)
+├── locks/                # Concurrency locks (always in Git)
+└── _TEMPLATE-*.md        # Schema definitions (always in Git)
+```
+
 ## How It Works
+
+### Git-Files Backend
 
 | Folder | What Goes Here | Template | Who Creates |
 |--------|---------------|----------|-------------|
@@ -39,6 +64,21 @@ work/
 | `assets/` | Non-code deliverable registry entries | `work/assets/_TEMPLATE-asset-registry-entry.md` | Execution Layer |
 | `retrospectives/` | Postmortems and incident reports | `work/retrospectives/_TEMPLATE-postmortem.md` | Operate Loop agents |
 | `locks/` | Concurrency locks for critical shared files | `work/locks/_TEMPLATE-lock.md` | Any agent or human editing a protected file |
+
+### Issue Backend (e.g., GitHub Issues)
+
+| Artifact | Label | Who Creates | Approval |
+|----------|-------|-------------|----------|
+| Signal | `artifact:signal` + `status:new` | Anyone | Label change by Steering |
+| Mission | `artifact:mission` + `status:proposed` | Strategy Layer | Label → `status:approved` |
+| Task | `artifact:task` (sub-issue of mission) | Orchestration Layer | Label transitions |
+| Decision | `artifact:decision` + `status:proposed` | Any Layer | Label → `status:accepted` |
+| Release | `artifact:release` + `status:draft` | Orchestration Layer | Label → `status:approved` |
+| Retrospective | `artifact:retrospective` + `status:draft` | Operate Loop | Label → `status:accepted` |
+
+Git-only companion artifacts still apply in issue backend: signal digests, technical designs, evaluation reports, fleet reports, outcome reports, asset registry entries, governance exceptions, and locks.
+
+See [docs/WORK-BACKENDS.md](../docs/WORK-BACKENDS.md) for the full label taxonomy and [docs/GITHUB-ISSUES.md](../docs/GITHUB-ISSUES.md) for the GitHub setup guide.
 
 ## Naming Conventions
 


### PR DESCRIPTION
## Release v3.0.0 - Work Backend Abstraction

### TL;DR
The framework no longer assumes Git-only work tracking. Choose **Git files** or **GitHub Issues** as your work backend. All 5 layers, all 4 process loops, and 38 files updated for dual-backend support.

### What changed
- **Multi-backend work tracking** (BREAKING) - `CONFIG.yaml` now has a `work_backend` section
- **GitHub Issues integration** - issue forms, label taxonomy, approval flows
- **All layer AGENT.md files** updated for backend-aware behavior
- **Framework taxonomy cleanup** - cleaner division defaults
- **Connector pattern** - MCP/A2A reference architecture
- **Rule 12** (Deduplicate before acting) + **Rule 13a** (upstream-first)

### 38 files changed | 1,677 insertions | 222 deletions

Full details in the release notes.
