### PR TITLE
docs: OTel GenAI semantic conventions for agent observability

### DIFF
--- a/docs/observability-genai.md
+++ b/docs/observability-genai.md
@@ -2,7 +2,7 @@
 
 > **Version:** 1.0 | **Last updated:** 2026-03-08
 > **Spec reference:** [OTel GenAI Semantic Conventions (Development)](https://opentelemetry.io/docs/specs/semconv/gen-ai/) — verify currency before use
-> **Related:** `work/missions/_TEMPLATE-observability-design.md` (full instrumentation design template)
+> **Related:** `work/missions/_TEMPLATE-technical-design.md` (Observability Design section — full instrumentation design template)
 
 ---
 
@@ -18,7 +18,7 @@ The OpenTelemetry GenAI Semantic Conventions Working Group has standardized this
 2. **Cross-team comparability** — Teams adopting this template produce comparable traces. Benchmarking, shared dashboards, and fleet-level cost analysis become trivially achievable.
 3. **Ecosystem longevity** — The GenAI conventions are on the standards track. Aligning now avoids a painful migration later.
 
-This file is a **quick-reference** for agents and developers. For the full instrumentation design template (span hierarchy, metrics design, SLOs, alerting, dashboard spec), see [`work/missions/_TEMPLATE-observability-design.md`](../work/missions/_TEMPLATE-observability-design.md).
+This file is a **quick-reference** for agents and developers. For the full instrumentation design template (span hierarchy, metrics design, SLOs, alerting, dashboard spec), see the Observability Design section in [`work/missions/_TEMPLATE-technical-design.md`](../work/missions/_TEMPLATE-technical-design.md).
 
 ---
 
@@ -244,7 +244,7 @@ Use this as a PR-level quality gate when adding or modifying agent LLM calls:
 |------|---------|
 | `AGENTS.md Rule 9` | Mandate: all agents MUST emit OTel spans (what to do) |
 | **This file** | Standard: which span names and attributes to use (how to do it) |
-| `work/missions/_TEMPLATE-observability-design.md` | Full design template: span hierarchy, metrics, SLOs, dashboards, alerting for a complete mission |
+| `work/missions/_TEMPLATE-technical-design.md` (Observability Design section) | Full design template: span hierarchy, metrics, SLOs, dashboards, alerting for a complete mission |
 | `org/integrations/` | Integration Registry: where spans are exported (OTLP endpoint config) |
 
 ---


### PR DESCRIPTION
## What this PR does

Adds `docs/observability-genai.md` — a concise, agent-facing reference for the [OTel GenAI Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) that specifies *which* span names and attributes agents should use when instrumenting LLM calls and agent workflows.

## Why this matters

AGENTS.md Rule 9a mandates that every agent emits OTel spans. What it does **not** specify is the naming and attribute convention for GenAI-specific spans. Without a standard, teams produce incompatible traces (`llm.call`, `model_request`, `ai_inference` — all describing the same operation) and no standard tooling can aggregate across them.

By adopting the OTel GenAI Semantic Conventions, teams using this template get:

- **Automatic tooling compatibility** — OTel-native backends (Dynatrace, Grafana, Honeycomb, etc.) with GenAI support will auto-parse token cost dashboards, latency histograms, and error rate panels without custom configuration
- **Cross-team comparability** — All template adopters produce comparable traces, enabling fleet-level cost analysis and shared dashboards
- **Ecosystem longevity** — Conventions are on the standards track; aligning now avoids a migration later

## Key attributes documented

| Attribute | Purpose |
|-----------|---------|
| `gen_ai.operation.name` | Operation type: `chat`, `invoke_agent`, `execute_tool`, `retrieval` |
| `gen_ai.provider.name` | LLM provider: `openai`, `anthropic`, `aws.bedrock` |
| `gen_ai.request.model` | Model name as requested: `gpt-4o` |
| `gen_ai.usage.input_tokens` | Prompt tokens (cost tracking) |
| `gen_ai.usage.output_tokens` | Completion tokens (cost tracking) |
| `gen_ai.response.finish_reasons` | Why the model stopped: `["stop"]` |
| `gen_ai.agent.name` / `gen_ai.agent.id` | Agent identity on invoke/create spans |
| `gen_ai.conversation.id` | Session correlation across spans |

## What's included

- Span type reference: agent spans (`invoke_agent`), inference spans (`chat`), tool spans (`execute_tool`), retrieval spans
- Full attribute table with requirement levels and concrete examples
- Trace hierarchy example showing a real orchestrator → agent → model → tool call
- Standard metrics: `gen_ai.client.token.usage`, `gen_ai.client.operation.duration`
- PR-level instrumentation checklist
- Cross-reference to `work/missions/_TEMPLATE-observability-design.md` for the full design template

## Relationship to existing content

| File | Role |
|------|------|
| `AGENTS.md Rule 9` | Mandate — agents MUST emit telemetry |
| `docs/observability-genai.md` (this PR) | Standard — which span names and attributes to use |
| `work/missions/_TEMPLATE-observability-design.md` | Full design template for a complete mission |

## Signal origin

This PR was motivated by internal signal `upstream-otel-genai-observability-expansion` (triage outcome: proceed, urgency: next-cycle, potential impact: high). The template can differentiate itself in the market by codifying standard OTel GenAI spans — most teams in the ecosystem still instrument ad-hoc.

---

**Spec reference:** [OTel GenAI Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) — status: Development as of 2026-03-08. Attribute availability should be verified against the spec before use in production.