### PR TITLE
feat: compliance reference docs, honest coverage reassessment, validation issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@
     <img src="https://github.com/wlfghdr/agentic-enterprise/actions/workflows/validate.yml/badge.svg" alt="Validate Framework">
   </a>
   <br>
-  <img src="https://img.shields.io/badge/ISO_27001-~90%25_covered-0e8a16" alt="ISO 27001">
-  <img src="https://img.shields.io/badge/SOC_2-~95%25_covered-1d76db" alt="SOC 2">
+  <img src="https://img.shields.io/badge/ISO_27001-~85%25_covered-0e8a16" alt="ISO 27001">
+  <img src="https://img.shields.io/badge/SOC_2-~85%25_covered-1d76db" alt="SOC 2">
   <img src="https://img.shields.io/badge/GDPR-~75%25_covered-d93f0b" alt="GDPR">
-  <img src="https://img.shields.io/badge/ISO_42001-~90%25_covered-5319e7" alt="ISO 42001">
-  <img src="https://img.shields.io/badge/NIST_AI_RMF-~95%25_covered-fbca04" alt="NIST AI RMF">
-  <img src="https://img.shields.io/badge/EU_AI_Act-~85%25_covered-c5def5" alt="EU AI Act">
+  <img src="https://img.shields.io/badge/ISO_42001-~80%25_covered-5319e7" alt="ISO 42001">
+  <img src="https://img.shields.io/badge/NIST_AI_RMF-~85%25_covered-fbca04" alt="NIST AI RMF">
+  <img src="https://img.shields.io/badge/EU_AI_Act-~75%25_covered-c5def5" alt="EU AI Act">
 </p>
 
 <h1 align="center">Agentic Enterprise</h1>
@@ -507,7 +507,8 @@ See `org/integrations/categories/observability.md` for detailed patterns.
 | **Data classification** | Public / Internal / Confidential / Secret scheme with handling rules | [Issue #93](https://github.com/wlfghdr/agentic-enterprise/issues/93) |
 | **Log retention & immutability** | Retention periods, tamper-evidence, compliance archival | [Issue #94](https://github.com/wlfghdr/agentic-enterprise/issues/94) |
 | **Agent behavioral eval** | Eval-driven development, behavioral quality policy | [Issue #74](https://github.com/wlfghdr/agentic-enterprise/issues/74) |
-| **Policy cross-references** | Consistent external standard mapping across all policies | [Issue #104](https://github.com/wlfghdr/agentic-enterprise/issues/104) |
+| **Policy cross-references** | Consistent external standard mapping across all policies | [Issue #104](https://github.com/wlfghdr/agentic-enterprise/issues/104) — addressed in [`docs/compliance/`](docs/compliance/) |
+| **Deterministic validation scripts** | CI/cron scripts for policy structure, agent instructions, OTel contract, compliance mapping, cross-references | [#111](https://github.com/wlfghdr/agentic-enterprise/issues/111)–[#117](https://github.com/wlfghdr/agentic-enterprise/issues/117) |
 
 > **Inherent limitation:** This repository is a governance framework, not a deployed product. It provides the organizational model, policy structure, and integration patterns — but formal certification, runtime enforcement, and production evidence depend on your specific deployment. That's by design: the framework is vendor-neutral and runtime-agnostic.
 
@@ -521,14 +522,16 @@ This framework provides **built-in governance controls** that map directly to en
 
 | Framework | Coverage | What's In Place | Remaining Gaps |
 |-----------|----------|----------------|----------------|
-| **ISO 27001** | ~90% | RBAC (CODEOWNERS), change management (PRs), operations security, CI/CD gates, asset registry, cryptography policy, risk management framework, data classification, log retention & immutability (A.12.4), vendor & supplier risk management (A.5.19–A.5.23) | — |
-| **SOC 2 Type II** | ~95% | Control environment, availability (SLOs + continuity), processing integrity, confidentiality (encryption + data classification), OTel audit trail, incident response SLAs, DR/BCP, log retention & WORM (CC7), vendor risk mitigation (CC9) | — |
-| **GDPR** | ~80% | Privacy policy with lawful basis, DPA/DSAR, breach notification, encryption, transfer controls, DPIA touchpoints, data classification & PII inventory, log retention & storage limitation | Consent management nuances |
-| **ISO 42001** | ~90% | AI governance (5-layer model), agent accountability (OTel spans), human oversight, decision audit trail, risk classification, model cards, fairness audit, explainability | Conformity assessment |
-| **NIST AI RMF** | ~95% | Governance structure, continuous monitoring, risk mitigation (rollback), transparency, risk management framework, AI risk tiers, MEASURE function (fairness metrics) | — |
-| **EU AI Act** | ~85% | Transparency (versioned agent instructions), human oversight, risk management foundations, AI risk classification, model cards, adversarial testing, explainability, record-keeping (log retention) | Conformity assessment |
+| **ISO 27001** | ~85% | RBAC (CODEOWNERS), change management (PRs), operations security, CI/CD gates, asset registry, cryptography policy, risk management framework, data classification, log retention & immutability (A.12.4), vendor & supplier risk management (A.5.19–A.5.23) | Formal ISMS scope statement, Statement of Applicability, internal audit programme, management review records |
+| **SOC 2 Type II** | ~85% | Control environment, availability (SLOs + continuity), processing integrity, confidentiality (encryption + data classification), OTel audit trail, incident response SLAs, DR/BCP, log retention & WORM (CC7), vendor risk mitigation (CC9) | Operating effectiveness evidence (requires deployed runtime), formal control testing, independent audit |
+| **GDPR** | ~75% | Privacy policy with lawful basis, DPA/DSAR, breach notification, encryption, transfer controls, DPIA touchpoints, data classification & PII inventory, log retention & storage limitation | Consent management UX, DPO appointment, supervisory authority registration, populated RoPA |
+| **ISO 42001** | ~80% | AI governance (5-layer model), agent accountability (OTel spans), human oversight, decision audit trail, risk classification, model cards, fairness audit, explainability | Formal AIMS scope, conformity assessment, AI system inventory, internal audit programme |
+| **NIST AI RMF** | ~85% | Governance structure, continuous monitoring, risk mitigation (rollback), transparency, risk management framework, AI risk tiers, MEASURE function (fairness metrics) | MEASURE function quantitative metrics (requires runtime data), organizational AI risk profile document, third-party evaluation |
+| **EU AI Act** | ~75% | Transparency (versioned agent instructions), human oversight, risk management foundations, AI risk classification, model cards, adversarial testing, explainability, record-keeping (log retention) | Conformity assessment, CE marking, EU database registration, post-market monitoring system, serious incident reporting |
 
 > **What the percentages mean:** Each number estimates how many of the framework's relevant controls are _modeled as policy or governance structure_ in this repository. It does **not** mean your deployment is that percentage compliant. Certification requires an independent audit of your running system — the runtime you operate, the integrations you configure, the records you keep, and the evidence you produce in the real environment. This repo gives you the **governance scaffolding and policy surfaces** to get there faster. Gaps are tracked as [open issues](https://github.com/wlfghdr/agentic-enterprise/issues?q=label%3Agap) with certification labels.
+>
+> **Detailed compliance reference docs** with article-level mappings, observability evidence sources, and external references are available in [`docs/compliance/`](docs/compliance/).
 
 ### What changed recently
 
@@ -544,6 +547,7 @@ Several critical gaps have been closed since the initial compliance assessment:
 - **Log retention & immutability** — 5-category retention schedule, WORM for audit/security logs, legal hold, verified deletion (closes ISO 27001 A.12.4 + SOC 2 CC7)
 - **Vendor & third-party risk management** — 4-tier vendor criticality model, security assessment framework with AI-specific questions, SLA/attestation verification, concentration risk tracking (closes ISO 27001 A.5.19–A.5.23 + SOC 2 CC9)
 - **Observability as proof** — dashboards, traces, events, and audit evidence are part of the model so teams can verify what actually happened at runtime
+- **Compliance reference docs** — per-standard reference documents ([`docs/compliance/`](docs/compliance/)) with article-level mappings, observability evidence sources, external references, and honest gap assessments for ISO 27001, SOC 2, GDPR, ISO 42001, NIST AI RMF, and EU AI Act
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -93,6 +93,22 @@ Reference documentation for the CI/automation gates that ship with the template.
 
 ---
 
+## Compliance Reference Docs
+
+Per-standard compliance reference documents with article-level mappings, observability evidence sources, and external references.
+
+| Guide | Standard |
+|---|---|
+| [`compliance/README.md`](compliance/README.md) | Index and overview of all compliance references |
+| [`compliance/iso-27001.md`](compliance/iso-27001.md) | ISO/IEC 27001:2022 — Information Security Management |
+| [`compliance/soc2.md`](compliance/soc2.md) | SOC 2 Type II — Trust Service Criteria |
+| [`compliance/gdpr.md`](compliance/gdpr.md) | GDPR — EU Data Protection Regulation |
+| [`compliance/iso-42001.md`](compliance/iso-42001.md) | ISO/IEC 42001:2023 — AI Management Systems |
+| [`compliance/nist-ai-rmf.md`](compliance/nist-ai-rmf.md) | NIST AI RMF — AI Risk Management Framework |
+| [`compliance/eu-ai-act.md`](compliance/eu-ai-act.md) | EU AI Act — European AI Regulation |
+
+---
+
 ## Consistency Rules
 
 The docs folder now follows a simple split:

--- a/docs/compliance/README.md
+++ b/docs/compliance/README.md
@@ -1,0 +1,50 @@
+# Compliance Reference Index
+
+> **Purpose:** Central mapping of external standards to framework policies, controls, and remaining gaps.
+> **Audience:** Auditors, compliance officers, adopters assessing certification readiness.
+
+This directory contains one reference document per external standard or regulation that the Agentic Enterprise framework maps to. Each document explains:
+
+1. **What the standard requires** — key clauses and control objectives
+2. **How this framework addresses it** — specific policies, controls, and mechanisms
+3. **Where observability fits** — how telemetry provides runtime evidence
+4. **What remains open** — honest assessment of gaps that require deployment-specific work
+
+## Standards Covered
+
+| Standard | Document | Framework Coverage | Key Gaps |
+|----------|----------|-------------------|----------|
+| [ISO/IEC 27001:2022](iso-27001.md) | Information Security Management | ~85% | Formal ISMS scope statement, management review records, internal audit programme, Statement of Applicability |
+| [SOC 2 Type II](soc2.md) | Trust Service Criteria | ~85% | Operating effectiveness evidence (runtime logs), formal control testing, independent audit |
+| [GDPR](gdpr.md) | EU Data Protection | ~75% | Consent management UX, DPO appointment, supervisory authority registration, cookie/tracking compliance |
+| [ISO/IEC 42001:2023](iso-42001.md) | AI Management Systems | ~80% | Formal AIMS scope, conformity assessment, management review, internal audit programme |
+| [NIST AI RMF](nist-ai-rmf.md) | AI Risk Management Framework | ~85% | MEASURE function quantitative metrics, third-party evaluation, organizational AI risk profile document |
+| [EU AI Act](eu-ai-act.md) | European AI Regulation | ~75% | Conformity assessment, CE marking, EU database registration, post-market monitoring system |
+
+## Important Disclaimer
+
+**These documents describe governance scaffolding, not certification status.** The framework provides policy surfaces, control structures, and observability patterns. Actual certification requires:
+
+- A running deployment with real operational evidence
+- Independent third-party audit (ISO/SOC 2) or self-assessment with documentation (GDPR/EU AI Act)
+- Deployment-specific configuration (retention periods, encryption keys, access controls, DPO appointment, etc.)
+- Continuous evidence collection via the observability platform
+
+## How Observability Closes the Evidence Gap
+
+A recurring theme across all standards: **governance documents alone are insufficient — auditors need runtime evidence.** The framework's observability architecture (see [OTEL-CONTRACT.md](../OTEL-CONTRACT.md) and [observability policy](../../org/4-quality/policies/observability.md)) is designed to produce this evidence:
+
+- **Audit trails** — Every agent action produces an OpenTelemetry span with governance decision events
+- **Access logs** — Tool calls, data access, and authentication events are traced
+- **Change evidence** — Git history + PR-based governance provides tamper-evident change records
+- **SLA/SLO proof** — Health targets, error budgets, and incident response times are measured and dashboarded
+- **Compliance dashboards** — Observability platform surfaces policy compliance metrics in real time
+
+Without a configured observability platform, the framework's compliance claims remain theoretical. With one, they become provable.
+
+## Related Resources
+
+- [Quality Policies](../../org/4-quality/policies/) — The 18 policy domains that implement these controls
+- [OTEL-CONTRACT.md](../OTEL-CONTRACT.md) — Canonical telemetry contract for agent spans and events
+- [Risk Management Policy](../../org/4-quality/policies/risk-management.md) — Framework crosswalk to all standards
+- [CONFIG.yaml](../../CONFIG.yaml) — Central configuration including observability integration

--- a/docs/compliance/eu-ai-act.md
+++ b/docs/compliance/eu-ai-act.md
@@ -1,0 +1,100 @@
+# EU AI Act — Compliance Reference
+
+> **Regulation:** Regulation (EU) 2024/1689 — Artificial Intelligence Act
+> **Scope:** AI systems placed on the market or put into service in the EU
+> **Official source:** [EUR-Lex — EU AI Act Full Text](https://eur-lex.europa.eu/eli/reg/2024/1689/oj)
+> **Application timeline:** Prohibitions from Feb 2025, high-risk obligations from Aug 2026, full application from Aug 2027
+
+## 1. What the EU AI Act Requires
+
+The EU AI Act establishes a risk-based regulatory framework:
+
+### Risk Categories
+
+| Category | Examples | Key Obligations |
+|----------|----------|-----------------|
+| **Prohibited** (Art. 5) | Social scoring, real-time biometric identification (exceptions), subliminal manipulation, exploitation of vulnerabilities | Must not be developed, placed on market, or used |
+| **High-risk** (Art. 6, Annex III) | Hiring/recruitment, credit scoring, law enforcement, migration, critical infrastructure, education | Full compliance: risk management, data governance, transparency, human oversight, accuracy/robustness, logging, conformity assessment |
+| **Limited-risk** (Art. 50) | Chatbots, deepfakes, emotion recognition | Transparency obligations (disclosure of AI interaction) |
+| **Minimal-risk** (Art. 52) | Spam filters, AI-enabled games | No specific obligations (voluntary codes of conduct encouraged) |
+
+### Key Obligations for High-Risk AI Systems
+
+| Article | Obligation | Detail |
+|---------|-----------|--------|
+| Art. 9 | Risk management system | Continuous, iterative risk management throughout AI lifecycle |
+| Art. 10 | Data governance | Training/validation/test data quality, relevance, representativeness, bias examination |
+| Art. 11 | Technical documentation | Before placing on market — purpose, design, development, testing, performance |
+| Art. 12 | Record-keeping (logging) | Automatic recording of events throughout lifecycle, traceability |
+| Art. 13 | Transparency | Understandable instructions for use, limitations, intended purpose |
+| Art. 14 | Human oversight | Designed for effective human oversight, ability to override/interrupt |
+| Art. 15 | Accuracy, robustness, cybersecurity | Appropriate levels throughout lifecycle, resilience to errors/attacks |
+| Art. 16–22 | Provider obligations | Conformity assessment, CE marking, EU database registration, post-market monitoring |
+| Art. 26–28 | Deployer obligations | Use in accordance with instructions, monitor, inform provider of risks |
+
+### General-Purpose AI (GPAI) Models (Art. 51–56)
+
+| Obligation | Applies to |
+|-----------|-----------|
+| Technical documentation | All GPAI models |
+| Transparency (copyright compliance, model capabilities) | All GPAI models |
+| Systemic risk evaluation | GPAI with systemic risk (>10^25 FLOPs or equivalent) |
+| Adversarial testing | GPAI with systemic risk |
+| Incident reporting | GPAI with systemic risk |
+
+## 2. How This Framework Addresses It
+
+### Article-Level Mapping
+
+| Article | Requirement | Framework Implementation | Evidence Source |
+|---------|-------------|-------------------------|-----------------|
+| **Art. 5** | Prohibited practices | [AI Governance Policy](../../org/4-quality/policies/ai-governance.md) §1 — Tier 0 prohibited (social scoring, real-time biometrics, manipulative AI) | Risk tier assignments in agent type registry |
+| **Art. 6** | High-risk classification | AI Governance Policy §1 — 4-tier risk classification aligned to EU AI Act, every agent type documents risk tier | Agent type definitions |
+| **Art. 9** | Risk management | [Risk Management Policy](../../org/4-quality/policies/risk-management.md) — continuous risk management, AI risk taxonomy, 7 KRIs, circuit breakers | Risk register, KRI dashboards, `risk.assessment.complete` events |
+| **Art. 10** | Data governance | [Data Classification Policy](../../org/4-quality/policies/data-classification.md), [Privacy Policy](../../org/4-quality/policies/privacy.md), AI vendor assessment — training data provenance | PII inventory, data classification records |
+| **Art. 11** | Technical documentation | Model cards in agent type definitions (purpose, model selection, performance, limitations, fairness, adversarial robustness) | Model card artifacts in `org/agents/` |
+| **Art. 12** | Record-keeping | [Log Retention Policy](../../org/4-quality/policies/log-retention.md), [Observability Policy](../../org/4-quality/policies/observability.md) — all agent actions produce OTel spans, WORM for audit logs | Full OTel telemetry pipeline, WORM verification |
+| **Art. 13** | Transparency | Versioned agent instructions (AGENT.md), explainability levels (Traceable/Justifiable/Auditable), model cards | Agent instruction history, explainability traces |
+| **Art. 14** | Human oversight | AGENTS.md Rule 2 ("Humans decide, agents recommend"), human approval gates, kill switch, escalation mechanisms | `governance.decision` events, human override logs, escalation metrics |
+| **Art. 15** | Accuracy, robustness | AI Governance Policy §4 — adversarial testing (prompt injection, persona manipulation, boundary probing), [Agent Security Policy](../../org/4-quality/policies/agent-security.md) — OWASP LLM Top 10 | Test results, prompt injection rate metrics |
+| **Art. 26–28** | Deployer obligations | [Vendor Risk Management Policy](../../org/4-quality/policies/vendor-risk-management.md) — AI vendor extended assessment, model version tracking, use-in-accordance monitoring | Vendor assessment records, usage monitoring |
+| **Art. 50** | Transparency (limited-risk) | AI Governance §1 Tier 2 — output labeling ("generated by AI"), model card | Disclosure records |
+
+## 3. Where Observability Provides Evidence
+
+The EU AI Act explicitly requires **logging** (Art. 12) and **post-market monitoring** (Art. 72). The observability platform directly fulfills these:
+
+| EU AI Act Requirement | Observability Source | Why It Matters |
+|----------------------|---------------------|----------------|
+| Record-keeping (Art. 12) | All agent actions as OTel spans — `agent.run`, `inference.*`, `tool.execute`, `governance.decision` | Direct fulfillment of automatic logging obligation |
+| Post-market monitoring (Art. 72) | Continuous agent fleet dashboards, SLO monitoring, anomaly detection | Proves ongoing monitoring after deployment |
+| Risk management (Art. 9) | KRI dashboards, `risk.threshold.breach` events, automated risk signals | Proves risk management is continuous, not point-in-time |
+| Human oversight (Art. 14) | Human override rate metrics, escalation frequency dashboards | Proves human oversight is meaningful, not rubber-stamp |
+| Accuracy monitoring (Art. 15) | Error rate metrics, hallucination/correction rate, fairness dashboards | Proves accuracy is maintained post-deployment |
+| Incident detection | Anomaly detection alerts, security test results | Supports incident reporting obligations (Art. 62) |
+
+## 4. Remaining Gaps
+
+| Gap | EU AI Act Requirement | What's Needed | Severity |
+|-----|----------------------|---------------|----------|
+| **Conformity assessment** | Art. 43 | Third-party conformity assessment for high-risk AI in Annex III areas | Critical — legal requirement before placing on EU market |
+| **CE marking** | Art. 48 | Affixed after successful conformity assessment | Critical — cannot market without it |
+| **EU database registration** | Art. 49, 71 | Registration in EU AI database before placing on market | Critical — legal requirement |
+| **Post-market monitoring system** | Art. 72 | Formal, documented system (partially addressed by observability) | High — requires specific procedures beyond monitoring |
+| **Serious incident reporting** | Art. 62 | Reporting to national market surveillance authorities | High — must be operational |
+| **Quality management system** | Art. 17 | Formal QMS documentation (partially addressed by quality policies) | Medium — may need ISO 9001-style documentation |
+| **Instructions for use** | Art. 13(3) | Formal user-facing documentation for deployers | Medium |
+| **Fundamental rights impact assessment** | Art. 27 | Required for deployers of certain high-risk systems (public bodies, private entities in specific sectors) | Medium — deployer obligation |
+| **EU representative** | Art. 22 | If provider is outside EU | Low — context-dependent |
+
+## 5. External References
+
+- [EU AI Act Full Text (EUR-Lex)](https://eur-lex.europa.eu/eli/reg/2024/1689/oj) — Official regulation
+- [EU AI Act Corrigendum](https://eur-lex.europa.eu/eli/reg/2024/1689/corr/2024-08-01) — Corrections
+- [European Commission AI Act Q&A](https://digital-strategy.ec.europa.eu/en/policies/regulatory-framework-ai) — Official guidance
+- [EU AI Act Explorer](https://artificialintelligenceact.eu/) — Navigable text with annotations
+- [EU AI Office](https://digital-strategy.ec.europa.eu/en/policies/ai-office) — Enforcement body
+- [Harmonised Standards under EU AI Act](https://single-market-economy.ec.europa.eu/single-market/european-standards_en) — Technical standards (in development)
+- [NIST AI RMF Crosswalk to EU AI Act](https://airc.nist.gov/Docs/Crosswalks) — Official crosswalk
+- [ISO/IEC 42001 to EU AI Act Mapping](https://www.iso.org/standard/81230.html) — Standard alignment
+- [High-Level Expert Group Ethics Guidelines for Trustworthy AI](https://digital-strategy.ec.europa.eu/en/library/ethics-guidelines-trustworthy-artificial-intelligence) — Foundational principles

--- a/docs/compliance/gdpr.md
+++ b/docs/compliance/gdpr.md
@@ -1,0 +1,83 @@
+# GDPR — Compliance Reference
+
+> **Regulation:** General Data Protection Regulation (EU) 2016/679
+> **Scope:** Processing of personal data of individuals in the EU/EEA
+> **Official source:** [EUR-Lex — GDPR Full Text](https://eur-lex.europa.eu/eli/reg/2016/679/oj)
+> **Supervisory authorities:** National DPAs (e.g., BfDI (DE), CNIL (FR), ICO (UK-equivalent))
+
+## 1. What GDPR Requires
+
+GDPR establishes rights for data subjects and obligations for controllers/processors across these key areas:
+
+| Chapter | Focus | Key Articles |
+|---------|-------|-------------|
+| **Principles** (Art. 5) | Lawfulness, fairness, transparency, purpose limitation, data minimization, accuracy, storage limitation, integrity/confidentiality, accountability | Art. 5(1)(a)–(f), 5(2) |
+| **Lawful basis** (Art. 6) | At least one legal basis required for processing | Art. 6(1)(a)–(f) |
+| **Special categories** (Art. 9) | Stricter rules for health, biometric, political, religious data | Art. 9(1)–(2) |
+| **Data subject rights** (Art. 12–22) | Access, rectification, erasure, portability, objection, automated decision-making | Art. 15–22 |
+| **Controller/processor** (Art. 24–31) | Responsibility, DPA, records of processing | Art. 26, 28, 30 |
+| **Security** (Art. 32) | Appropriate technical and organizational measures | Art. 32(1)(a)–(d) |
+| **Breach notification** (Art. 33–34) | 72-hour notification to authority, communication to data subjects | Art. 33(1), 34(1) |
+| **DPIA** (Art. 35) | Impact assessment before high-risk processing | Art. 35(1), 35(3) |
+| **International transfers** (Art. 44–49) | Adequate safeguards for transfers outside EU/EEA | Art. 46 (SCCs), 47 (BCRs) |
+| **DPO** (Art. 37–39) | Data Protection Officer appointment for certain organizations | Art. 37(1) |
+
+## 2. How This Framework Addresses It
+
+### Article-Level Mapping
+
+| Article | Requirement | Framework Implementation | Evidence Source |
+|---------|-------------|-------------------------|-----------------|
+| **Art. 5(1)(a)** | Lawfulness, fairness, transparency | [Privacy Policy](../../org/4-quality/policies/privacy.md) §1 — lawful basis documentation per feature/workflow | Processing records in Git |
+| **Art. 5(1)(b)** | Purpose limitation | Privacy Policy §1 — purpose documented per data processing activity | Purpose declarations in processing records |
+| **Art. 5(1)(c)** | Data minimization | [Data Classification Policy](../../org/4-quality/policies/data-classification.md) — classification drives handling, least-privilege data access | `data.classification` span attributes |
+| **Art. 5(1)(e)** | Storage limitation | [Log Retention Policy](../../org/4-quality/policies/log-retention.md) — bounded retention, verified deletion | Deletion confirmation audit logs |
+| **Art. 5(1)(f)** | Integrity and confidentiality | [Security Policy](../../org/4-quality/policies/security.md), [Cryptography Policy](../../org/4-quality/policies/cryptography.md) — encryption, access controls | KMS audit trails, access logs |
+| **Art. 5(2)** | Accountability | Git history as audit trail, OTel telemetry, PR-based governance | Full observability pipeline |
+| **Art. 6** | Lawful basis | Privacy Policy §1 — documented per feature, AI features include prompts/outputs/traces | Processing register |
+| **Art. 9** | Special categories | Data Classification — RESTRICTED level for Art. 9 data | Classification enforcement spans |
+| **Art. 12–22** | Data subject rights | Privacy Policy §3 — DSAR runbook with identity verification, search, export, correction, deletion | DSAR OTel events (intake→verification→fulfillment→closure) |
+| **Art. 28** | Processor obligations | Privacy Policy §2 — DPA template, subprocessor controls | DPA artifacts, [Vendor Risk Management](../../org/4-quality/policies/vendor-risk-management.md) records |
+| **Art. 30** | Records of processing | Privacy Policy §1 — RoPA requirement per deployment | Processing register artifacts |
+| **Art. 32** | Security of processing | Security Policy + Cryptography Policy — encryption at rest/transit, access controls, pseudonymization | Security audit trails |
+| **Art. 33** | Breach notification (authority) | Privacy Policy §4 — 72-hour clock, triage process | Breach timeline OTel spans |
+| **Art. 34** | Breach notification (data subjects) | Privacy Policy §4 — communication to affected individuals | Breach notification records |
+| **Art. 35** | DPIA | Privacy Policy §5 — required before high-risk processing, AI profiling requires DPIA | DPIA decision records |
+| **Art. 44–49** | International transfers | Privacy Policy §7 — transfer mapping, SCCs, transfer risk assessment | Transfer mechanism records |
+
+## 3. Where Observability Provides Evidence
+
+GDPR accountability (Art. 5(2)) requires demonstrable compliance — not just policies on paper. The observability platform provides this evidence:
+
+| GDPR Evidence Need | Observability Source | Relevant Article |
+|--------------------|---------------------|------------------|
+| Processing lawfulness proof | Agent spans showing data access with documented purpose | Art. 5(1)(a), 6 |
+| Data minimization verification | `data.classification` attributes on tool calls, access scoping | Art. 5(1)(c) |
+| Storage limitation enforcement | Log retention dashboards, deletion confirmation logs | Art. 5(1)(e) |
+| DSAR response tracking | DSAR workflow OTel events with SLA measurements | Art. 12–22 |
+| Breach response timeline | Breach OTel spans: detection→awareness→triage→notification | Art. 33–34 |
+| Security measure effectiveness | Encryption verification, access control audit trails | Art. 32 |
+| DPIA decision trail | `governance.decision` events for high-risk processing gates | Art. 35 |
+| Transfer mechanism verification | Vendor assessment records, SCC documentation | Art. 44–49 |
+
+## 4. Remaining Gaps
+
+| Gap | GDPR Requirement | What's Needed | Severity |
+|-----|-----------------|---------------|----------|
+| **Consent management UX** | Art. 6(1)(a), 7 | Runtime consent collection, storage, withdrawal UI — deployment-specific | High — if consent is the lawful basis |
+| **DPO appointment** | Art. 37 | Named DPO with independence guarantees — organizational decision | High — if required (public authority, large-scale monitoring, special categories) |
+| **Supervisory authority registration** | Art. 37(7) | DPO contact details communicated to SA | Medium — organizational |
+| **Cookie/tracking compliance** | ePrivacy Directive | Cookie consent, tracking transparency — deployment-specific | Medium — if web-facing |
+| **Records of Processing (RoPA)** | Art. 30 | Populated inventory — framework provides template, deployment must populate | Medium |
+| **Right to explanation** | Art. 22 | Meaningful information about automated decision-making logic | Medium — addressed partially by AI governance explainability |
+| **Age verification** | Art. 8 | Child data protections if processing children's data | Low — context-dependent |
+
+## 5. External References
+
+- [GDPR Full Text (EUR-Lex)](https://eur-lex.europa.eu/eli/reg/2016/679/oj) — Official regulation text
+- [EDPB Guidelines](https://edpb.europa.eu/our-work-tools/general-guidance/guidelines-recommendations-best-practices_en) — European Data Protection Board guidance documents
+- [WP29 Guidelines on DPIAs](https://ec.europa.eu/newsroom/article29/items/611236) — DPIA methodology guidance
+- [SCCs for International Transfers (2021)](https://commission.europa.eu/law/law-topic/data-protection/international-dimension-data-protection/standard-contractual-clauses-scc_en) — Standard Contractual Clauses
+- [ICO Guide to GDPR](https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/) — UK supervisory authority practical guide
+- [BfDI GDPR Guidance](https://www.bfdi.bund.de/EN/Home/home_node.html) — German federal DPA
+- [CNIL GDPR Guidance](https://www.cnil.fr/en/gdpr-developers-guide) — French DPA guide for developers

--- a/docs/compliance/iso-27001.md
+++ b/docs/compliance/iso-27001.md
@@ -1,0 +1,95 @@
+# ISO/IEC 27001:2022 — Compliance Reference
+
+> **Standard:** ISO/IEC 27001:2022 — Information Security Management Systems (ISMS)
+> **Scope:** Requirements for establishing, implementing, maintaining, and continually improving an ISMS
+> **Official source:** [ISO/IEC 27001:2022](https://www.iso.org/standard/27001)
+
+## 1. What ISO 27001 Requires
+
+ISO 27001 defines requirements for an Information Security Management System across two dimensions:
+
+**Management System (Clauses 4–10):**
+- Context of the organization and interested parties (4)
+- Leadership commitment and information security policy (5)
+- Risk assessment and treatment planning (6)
+- Support — resources, competence, awareness, communication, documented information (7)
+- Operational planning, risk assessment execution, risk treatment (8)
+- Performance evaluation — monitoring, measurement, internal audit, management review (9)
+- Continual improvement — nonconformities, corrective actions (10)
+
+**Annex A Controls (93 controls in 4 themes):**
+- A.5 — Organizational controls (37 controls)
+- A.6 — People controls (8 controls)
+- A.7 — Physical controls (14 controls)
+- A.8 — Technological controls (34 controls)
+
+## 2. How This Framework Addresses It
+
+### Clause-Level Mapping
+
+| Clause | Requirement | Framework Implementation | Evidence Source |
+|--------|-------------|-------------------------|-----------------|
+| 4.1–4.2 | Context, interested parties | `COMPANY.md` (vision/mission), `CONFIG.yaml` (org identity) | Git history |
+| 5.1–5.3 | Leadership, policy, roles | 5-layer model with explicit authority, `CODEOWNERS` as RACI | PR approvals, CODEOWNERS |
+| 6.1–6.2 | Risk assessment, objectives | [Risk Management Policy](../../org/4-quality/policies/risk-management.md) — ISO 31000-aligned methodology, risk register | Risk register artifacts, OTel `risk.assessment.complete` events |
+| 7.1–7.5 | Resources, competence, documented info | Agent instructions (`AGENT.md` hierarchy), version-controlled policies | Git history, versioning |
+| 8.1–8.3 | Operational planning, risk treatment | Process loops, mission briefs, quality gates | Mission artifacts, CI/CD checks |
+| 9.1–9.3 | Monitoring, internal audit, management review | Observability platform, quality evaluations | Dashboards, OTel telemetry, eval reports |
+| 10.1–10.2 | Improvement, corrective actions | Signals → missions cycle, retrospectives | `work/signals/`, `work/retrospectives/` |
+
+### Annex A Control Mapping
+
+| Control | Title | Framework Policy/Mechanism | Observability Evidence |
+|---------|-------|---------------------------|----------------------|
+| A.5.1 | Policies for information security | 18 quality policies in `org/4-quality/policies/` | Policy version history in Git |
+| A.5.2 | Information security roles | `CODEOWNERS`, layer-specific `AGENT.md` with explicit boundaries | PR review assignments |
+| A.5.7 | Threat intelligence | Signals system (`work/signals/`), observability anomaly detection | Automated signals from observability platform |
+| A.5.8 | Information security in project management | Technical Design requirement, security threat model | Design review PRs |
+| A.5.15–A.5.18 | Access control | Least-privilege agent tooling, CODEOWNERS, authentication requirements | OTel `tool.execute` spans with access verification |
+| A.5.19–A.5.23 | Supplier relationships | [Vendor Risk Management Policy](../../org/4-quality/policies/vendor-risk-management.md) — 4-tier model, assessment, monitoring, offboarding | Vendor SLA dashboards, assessment records |
+| A.5.24–A.5.28 | Incident management | [Incident Response Policy](../../org/4-quality/policies/incident-response.md) — SEV1-4 targets, auto-escalation | Incident timeline OTel spans, postmortem records |
+| A.5.29–A.5.30 | Business continuity | [Availability Policy](../../org/4-quality/policies/availability.md) — tiered RTO/RPO, DR drills | Drill evidence, recovery dashboards |
+| A.5.31–A.5.36 | Legal, regulatory, compliance | Privacy, data classification, log retention policies | DSAR/breach OTel events, retention dashboards |
+| A.8.1 | User endpoint devices | Out of scope (framework-level, not endpoint management) | — |
+| A.8.2–A.8.4 | Classification, labeling, handling | [Data Classification Policy](../../org/4-quality/policies/data-classification.md) — 4-level scheme | `data.classification` span attributes |
+| A.8.5–A.8.6 | Authentication, capacity | Security policy (mTLS, short-lived tokens), performance policy (resource limits) | Authentication OTel spans, resource metrics |
+| A.8.9 | Configuration management | `CONFIG.yaml`, Git-versioned everything | Git history |
+| A.8.15–A.8.16 | Logging, monitoring | [Observability Policy](../../org/4-quality/policies/observability.md), [Log Retention Policy](../../org/4-quality/policies/log-retention.md) | Full OTel telemetry pipeline |
+| A.8.24 | Use of cryptography | [Cryptography Policy](../../org/4-quality/policies/cryptography.md) — algorithms, KMS, key lifecycle | KMS audit logs, certificate monitoring |
+| A.8.25–A.8.28 | Secure development | Security policy (shift-left), agent security policy (OWASP LLM Top 10) | CI/CD security scan results |
+| A.8.31–A.8.34 | Separation, change, testing, redundancy | Environment progression (dev→staging→prod), progressive rollout | Deployment OTel spans, rollout dashboards |
+
+## 3. Where Observability Provides Evidence
+
+ISO 27001 auditors require **evidence of operating effectiveness**, not just policy documents. The observability platform bridges this gap:
+
+| Evidence Need | Observability Source |
+|---------------|---------------------|
+| Access control effectiveness | `tool.execute` spans showing least-privilege enforcement |
+| Change management process | Git PR history + CI/CD pipeline traces |
+| Incident detection and response | Incident timeline spans with acknowledge/mitigate/resolve timestamps |
+| Risk monitoring | KRI dashboards, `risk.threshold.breach` span events |
+| Log integrity | WORM storage verification, hash chain validation alerts |
+| Supplier performance | Vendor SLA monitoring dashboards |
+| Cryptographic control operation | KMS audit trail, certificate expiry alerts |
+| Business continuity readiness | DR drill evidence dashboards, recovery time measurements |
+
+## 4. Remaining Gaps
+
+| Gap | ISO 27001 Requirement | What's Needed | Severity |
+|-----|----------------------|---------------|----------|
+| **Formal ISMS scope statement** | Clause 4.3 | Deployment must define ISMS boundaries, included/excluded assets | High — required for certification |
+| **Statement of Applicability (SoA)** | Clause 6.1.3d | Formal document listing all 93 controls with justification for inclusion/exclusion | High — required for certification |
+| **Internal audit programme** | Clause 9.2 | Scheduled audit plan, auditor independence, audit reports | High — required for certification |
+| **Management review records** | Clause 9.3 | Documented review meetings with required inputs/outputs | Medium — required for certification |
+| **Competence records** | Clause 7.2 | Evidence of personnel/agent competence for security roles | Medium |
+| **Physical security** | A.7.1–A.7.14 | Out of scope for a framework — deployment-specific | Low — depends on deployment model |
+| **Endpoint management** | A.8.1 | Out of scope for a framework — deployment-specific | Low |
+
+## 5. External References
+
+- [ISO/IEC 27001:2022](https://www.iso.org/standard/27001) — The standard itself (paid)
+- [ISO/IEC 27002:2022](https://www.iso.org/standard/75652.html) — Implementation guidance for Annex A controls (paid)
+- [ISO 27001 Annex A Controls Overview](https://www.iso.org/standard/27001) — Control structure summary
+- [NIST SP 800-53 to ISO 27001 Mapping](https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final) — Cross-framework mapping
+- [BSI IT-Grundschutz to ISO 27001](https://www.bsi.bund.de/EN/Themen/Unternehmen-und-Organisationen/Standards-und-Zertifizierung/IT-Grundschutz/it-grundschutz_node.html) — German federal standard mapping

--- a/docs/compliance/iso-42001.md
+++ b/docs/compliance/iso-42001.md
@@ -1,0 +1,97 @@
+# ISO/IEC 42001:2023 — Compliance Reference
+
+> **Standard:** ISO/IEC 42001:2023 — Artificial Intelligence Management Systems (AIMS)
+> **Scope:** Requirements for establishing, implementing, maintaining, and continually improving an AI management system
+> **Official source:** [ISO/IEC 42001:2023](https://www.iso.org/standard/81230.html)
+
+## 1. What ISO 42001 Requires
+
+ISO 42001 follows the Annex SL high-level management system structure (shared with ISO 27001, ISO 9001, etc.) with AI-specific extensions:
+
+**Management System (Clauses 4–10):**
+- Context of the organization, AI system inventory (4)
+- Leadership, AI policy, roles and responsibilities (5)
+- Risk management for AI systems, AI objectives (6)
+- Support — resources, competence, awareness, communication (7)
+- Operation — AI system lifecycle, data management, impact assessment (8)
+- Performance evaluation — monitoring, internal audit, management review (9)
+- Improvement — nonconformity, corrective action, continual improvement (10)
+
+**Annex A Controls (AI-specific):**
+- A.2 — AI policies and governance
+- A.3 — Internal organization for AI
+- A.4 — Resources for AI
+- A.5 — AI system impact assessment
+- A.6 — AI system lifecycle
+- A.7 — Data for AI systems
+- A.8 — Information for interested parties (transparency)
+- A.9 — Use of AI systems
+- A.10 — Third-party and customer relationships
+
+## 2. How This Framework Addresses It
+
+### Clause-Level Mapping
+
+| Clause | Requirement | Framework Implementation | Evidence Source |
+|--------|-------------|-------------------------|-----------------|
+| 4.1–4.4 | Context, AI system scope | 5-layer model defining AI system boundaries, agent type registry (`org/agents/`) | Git-versioned org structure |
+| 5.1–5.3 | Leadership, AI policy | Steering layer with executive oversight, AI governance policy, CODEOWNERS | PR approvals, governance decisions |
+| 6.1–6.3 | AI risk, objectives | [AI Governance Policy](../../org/4-quality/policies/ai-governance.md) — 4-tier risk classification, [Risk Management Policy](../../org/4-quality/policies/risk-management.md) — AI risk taxonomy (22 canonical risks) | Risk register, OTel `risk.assessment.complete` events |
+| 7.1–7.5 | Resources, competence | Agent type definitions with capabilities, model cards documenting model selection rationale | Agent type registry |
+| 8.2 | AI system lifecycle | 4 process loops (Discover→Build→Ship→Operate), mission-based execution | Mission artifacts, deployment traces |
+| 8.4 | Data for AI | Data Classification Policy, Privacy Policy — training data provenance, PII in prompts/outputs | Classification spans, PII inventory |
+| 8.5 | AI system impact assessment | DPIA template, AI risk tier classification (Tier 0 prohibited → Tier 3 minimal) | DPIA records, risk tier assignments |
+| 9.1 | Monitoring, measurement | [Observability Policy](../../org/4-quality/policies/observability.md) — agent fleet dashboards, token usage tracking, fairness metrics | OTel telemetry, cost attribution dashboards |
+| 9.2–9.3 | Internal audit, management review | Quality Layer evaluations, signal→mission improvement cycle | Eval reports, signals |
+| 10.1–10.2 | Improvement | Retrospectives, improvement signals, upstream contributions | `work/retrospectives/`, `work/signals/` |
+
+### Annex A Control Mapping
+
+| Control | Title | Framework Implementation | Observability Evidence |
+|---------|-------|--------------------------|----------------------|
+| A.2 | AI policies | AI Governance Policy with risk classification, model cards, fairness audit, explainability | Policy version history |
+| A.3 | Internal organization | 5-layer model, agent type registry with declared capabilities and scope | Agent type definitions |
+| A.4 | Resources | Token budget tracking, model selection documentation in model cards | Token consumption dashboards |
+| A.5 | Impact assessment | AI risk tiers, DPIA for high-risk, fairness metrics (four-fifths rule) | Fairness audit results, DPIA records |
+| A.6 | AI lifecycle | Process loops, mission briefs, progressive rollout, adversarial testing | Mission lifecycle spans, test results |
+| A.7 | Data for AI | Data classification, PII inventory, training data provenance (in vendor assessment) | `data.classification` attributes |
+| A.8 | Transparency | Versioned agent instructions (public), explainability levels (Traceable/Justifiable/Auditable), model cards | Explainability traces, model card artifacts |
+| A.9 | Use of AI | Human-in-the-loop governance, agent autonomy tiers, kill switch | `governance.decision` events, human override logs |
+| A.10 | Third-party | Vendor Risk Management Policy with AI-specific extended assessment, model version tracking | Vendor assessment records |
+
+## 3. Where Observability Provides Evidence
+
+ISO 42001 is the first management system standard specifically for AI — it requires **continuous monitoring** of AI system behavior, not just point-in-time assessments:
+
+| Evidence Need | Observability Source | Why It Matters |
+|---------------|---------------------|----------------|
+| AI system behavior monitoring (9.1) | Agent spans (`agent.run`, `inference.*`, `tool.execute`), fleet dashboards | Proves AI systems are continuously monitored |
+| Fairness and bias detection (A.5) | Fairness metric dashboards (demographic parity, equalized odds) | Proves bias is measured, not just promised |
+| Decision accountability (A.9) | `governance.decision` span events with reasoning | Proves every AI decision is traceable |
+| Human oversight effectiveness (A.9) | Human override rate metrics, escalation frequency | Proves humans maintain meaningful control |
+| Resource consumption (A.4) | Token usage per mission/agent/division, cost attribution | Proves AI resource use is governed |
+| Model performance (A.6) | Accuracy/latency/error metrics per model | Proves models perform as documented |
+| Adversarial robustness (A.6) | Security test results, prompt injection rate metrics | Proves systems resist adversarial inputs |
+
+## 4. Remaining Gaps
+
+| Gap | ISO 42001 Requirement | What's Needed | Severity |
+|-----|----------------------|---------------|----------|
+| **Formal AIMS scope statement** | Clause 4.3 | Deployment must define AIMS boundaries and AI system inventory | High — required for certification |
+| **Conformity assessment** | Clause 10, certification | Third-party certification body audit | High — cannot self-certify |
+| **AI system inventory** | Clause 4 | Complete registry of all AI systems with risk classification | Medium — partially addressed by agent type registry |
+| **Management review records** | Clause 9.3 | Documented review with required inputs/outputs | Medium |
+| **Internal audit programme** | Clause 9.2 | Scheduled AI-focused audits | Medium |
+| **Competence evidence** | Clause 7.2 | Records demonstrating AI-specific competence | Medium |
+| **Stakeholder communication plan** | Clause 7.4 | Formal plan for communicating AI decisions to affected parties | Low |
+
+## 5. External References
+
+- [ISO/IEC 42001:2023](https://www.iso.org/standard/81230.html) — The standard itself (paid)
+- [ISO/IEC 23894:2023](https://www.iso.org/standard/77304.html) — AI Risk Management guidance (companion standard)
+- [ISO/IEC TR 24028:2020](https://www.iso.org/standard/77608.html) — Overview of trustworthiness in AI
+- [ISO/IEC 24027:2021](https://www.iso.org/standard/77607.html) — Bias in AI systems
+- [ISO/IEC 38507:2022](https://www.iso.org/standard/56641.html) — Governance implications of use of AI
+- [OECD AI Principles](https://oecd.ai/en/ai-principles) — International AI governance framework
+- [IEEE 7010-2020](https://standards.ieee.org/ieee/7010/7718/) — Wellbeing Impact Assessment for AI
+- [NIST AI 100-1](https://www.nist.gov/artificial-intelligence/ai-risk-management-framework) — Companion framework (see [nist-ai-rmf.md](nist-ai-rmf.md))

--- a/docs/compliance/nist-ai-rmf.md
+++ b/docs/compliance/nist-ai-rmf.md
@@ -1,0 +1,121 @@
+# NIST AI Risk Management Framework — Compliance Reference
+
+> **Framework:** NIST AI 100-1 — Artificial Intelligence Risk Management Framework (AI RMF 1.0)
+> **Companion:** NIST AI 600-1 — Generative AI Profile
+> **Scope:** Voluntary framework for managing risks in AI system design, development, deployment, and use
+> **Official source:** [NIST AI RMF](https://www.nist.gov/artificial-intelligence/ai-risk-management-framework)
+
+## 1. What NIST AI RMF Requires
+
+The AI RMF organizes risk management into four core functions:
+
+### GOVERN — Establish AI governance
+
+| Subcategory | Focus |
+|-------------|-------|
+| GOVERN 1 | Policies, processes, procedures, and practices for AI risk management |
+| GOVERN 2 | Accountability structures and risk management roles |
+| GOVERN 3 | Workforce diversity, equity, inclusion |
+| GOVERN 4 | Organizational risk culture |
+| GOVERN 5 | Stakeholder engagement processes |
+| GOVERN 6 | Policies addressing third-party AI risks |
+
+### MAP — Contextualize AI risks
+
+| Subcategory | Focus |
+|-------------|-------|
+| MAP 1 | Context (intended purpose, users, affected parties) |
+| MAP 2 | Interdependencies and broader context |
+| MAP 3 | AI-specific risks mapped and categorized |
+| MAP 4 | Risks and benefits across affected groups |
+| MAP 5 | AI impacts likelihood and severity |
+
+### MEASURE — Quantify AI risks
+
+| Subcategory | Focus |
+|-------------|-------|
+| MEASURE 1 | Metrics to assess AI risks |
+| MEASURE 2 | AI system evaluated for trustworthiness characteristics |
+| MEASURE 3 | Mechanisms for tracking emergent risks |
+| MEASURE 4 | Feedback mechanisms for continuous evaluation |
+
+### MANAGE — Treat AI risks
+
+| Subcategory | Focus |
+|-------------|-------|
+| MANAGE 1 | AI risks prioritized and responded to |
+| MANAGE 2 | AI risk response strategies implemented |
+| MANAGE 3 | Post-deployment AI risks monitored |
+| MANAGE 4 | Risk management documented and reported |
+
+## 2. How This Framework Addresses It
+
+### Function-Level Mapping
+
+| Function | Subcategory | Framework Implementation | Evidence Source |
+|----------|-------------|-------------------------|-----------------|
+| **GOVERN 1** | Policies | 18 quality policies, AI Governance Policy, agent instruction hierarchy | Policy version history in Git |
+| **GOVERN 1.7** | AI security policies | [Agent Security Policy](../../org/4-quality/policies/agent-security.md) — OWASP LLM Top 10 coverage | Security test results, CI/CD gates |
+| **GOVERN 2** | Accountability | 5-layer model with explicit authority, CODEOWNERS RACI, agent type declarations | PR approvals, `governance.decision` events |
+| **GOVERN 4** | Risk culture | [Risk Management Policy](../../org/4-quality/policies/risk-management.md) — risk appetite statement, escalation culture | Risk register, escalation frequency metrics |
+| **GOVERN 5** | Stakeholder engagement | Human-in-the-loop governance, PR-based review | PR comments, approval records |
+| **GOVERN 6** | Third-party AI risk | [Vendor Risk Management Policy](../../org/4-quality/policies/vendor-risk-management.md) — AI vendor extended assessment | Vendor assessment records |
+| **MAP 1** | Context | Agent type definitions with intended use, model cards | Agent type registry |
+| **MAP 2** | Interdependencies | Architecture policy (dependency mapping), vendor risk (concentration risk tracking) | Dependency diagrams, vendor register |
+| **MAP 3** | AI risk mapping | AI risk taxonomy — 22 canonical risks across 5 dimensions (OP/SE/CO/RE/FI) | Risk register artifacts |
+| **MAP 5** | Impact assessment | [AI Governance Policy](../../org/4-quality/policies/ai-governance.md) — 4-tier risk classification, DPIA template | Risk tier assignments, DPIA records |
+| **MEASURE 1** | Risk metrics | Risk Management Policy — 7 KRIs with thresholds and automated monitoring | KRI dashboards, OTel `risk.threshold.breach` events |
+| **MEASURE 2** | Trustworthiness | Fairness audit (four-fifths rule), adversarial robustness testing, explainability levels | Fairness dashboards, test results |
+| **MEASURE 3** | Emergent risks | Observability anomaly detection, improvement signals, behavioral drift monitoring | Automated signals, anomaly alerts |
+| **MEASURE 4** | Feedback | 4-loop process (Loop 4 feeds signals back to Loop 1), retrospectives | Signal artifacts, retrospective records |
+| **MANAGE 1** | Risk prioritization | Risk scoring (5x5 matrix), risk appetite alignment | Risk register with scores |
+| **MANAGE 2** | Risk response | Treatment strategies (avoid/mitigate/transfer/accept), cascade failure prevention, circuit breakers | Treatment records, `risk.treatment.applied` events |
+| **MANAGE 3** | Post-deployment monitoring | [Observability Policy](../../org/4-quality/policies/observability.md) — continuous agent monitoring, SLO tracking | OTel pipeline, SLO dashboards |
+| **MANAGE 4** | Reporting | Risk register review cadence, monthly posture summaries, annual assessment | Reports, risk register updates |
+
+### NIST AI 600-1 (Generative AI Profile) Additions
+
+| GenAI Risk | Framework Coverage |
+|------------|-------------------|
+| **CBRN information** | Content Policy — accuracy requirements, AI governance — Tier 0 prohibitions |
+| **Confabulation** | AI Governance — RE-1 hallucinated content risk, explainability requirements |
+| **Data privacy** | Privacy Policy — full GDPR coverage, data classification |
+| **Environmental impact** | Token budget tracking (partial — energy consumption not directly measured) |
+| **Homogenization** | Vendor concentration risk tracking, model diversity in fleet configs |
+| **Intellectual property** | Content Policy — license compliance, vendor assessment — training data provenance |
+| **Obscene content** | AI Governance — RE-3 harmful content risk, content filtering |
+| **Value chain risks** | Vendor Risk Management — supply chain assessment, AI vendor extended questions |
+
+## 3. Where Observability Provides Evidence
+
+NIST AI RMF emphasizes **continuous monitoring** (MANAGE 3) and **quantitative measurement** (MEASURE). The observability platform is the implementation mechanism:
+
+| RMF Function | Observability Source | Why It Matters |
+|-------------|---------------------|----------------|
+| GOVERN — Policy enforcement | CI/CD quality gate traces, `governance.decision` events | Proves policies are enforced at runtime, not just documented |
+| MAP — Risk identification | Anomaly detection alerts, automated risk signals | Proves risks are continuously identified, not just mapped once |
+| MEASURE — Risk quantification | KRI dashboards (prompt injection rate, tool call failure rate, escalation frequency, hallucination rate) | Proves risks are measured with real data |
+| MEASURE — Trustworthiness | Fairness metric dashboards, adversarial test results, explainability traces | Proves trustworthiness characteristics are validated |
+| MANAGE — Risk response | `risk.treatment.applied` events, `agent.emergency_halt` events, circuit breaker metrics | Proves risk responses activate when needed |
+| MANAGE — Post-deployment | Agent fleet dashboards, SLO burn rates, behavioral drift alerts | Proves AI systems are monitored after deployment |
+
+## 4. Remaining Gaps
+
+| Gap | NIST AI RMF Requirement | What's Needed | Severity |
+|-----|------------------------|---------------|----------|
+| **MEASURE function quantitative metrics** | MEASURE 1–2 | Populated dashboards with real operational data from a running deployment | High — measurement without data is design, not evidence |
+| **Organizational AI risk profile** | MAP 3 | Formal document consolidating all AI risks with organizational context | Medium |
+| **Third-party evaluation** | MEASURE 2 | Independent evaluation of AI system trustworthiness | Medium |
+| **Stakeholder impact assessment** | MAP 4 | Formal assessment of impacts across affected groups (beyond DPIA) | Medium |
+| **Environmental impact tracking** | GOVERN 1 (GenAI Profile) | Energy consumption metrics for AI workloads | Low |
+| **Workforce AI competence** | GOVERN 3 | Formal AI competence programme and diversity considerations | Low |
+
+## 5. External References
+
+- [NIST AI 100-1 — AI Risk Management Framework](https://www.nist.gov/artificial-intelligence/ai-risk-management-framework) — The framework itself
+- [NIST AI 600-1 — Generative AI Profile](https://airc.nist.gov/Docs/1) — GenAI-specific risks and actions
+- [NIST AI RMF Playbook](https://airc.nist.gov/AI_RMF_Playbook) — Suggested actions for each subcategory
+- [NIST AI 100-2e2023 — Adversarial Machine Learning Taxonomy](https://csrc.nist.gov/pubs/ai/100/2/e2023/final) — Attack taxonomy
+- [NIST SP 800-53 Rev. 5](https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final) — Security and privacy controls (crosswalk)
+- [NIST AI RMF Crosswalk to ISO 42001](https://airc.nist.gov/Docs/Crosswalks) — Official mapping
+- [NIST AI RMF Crosswalk to EU AI Act](https://airc.nist.gov/Docs/Crosswalks) — Official mapping

--- a/docs/compliance/soc2.md
+++ b/docs/compliance/soc2.md
@@ -1,0 +1,71 @@
+# SOC 2 Type II — Compliance Reference
+
+> **Standard:** AICPA SOC 2 — Trust Service Criteria (TSC)
+> **Scope:** Controls relevant to Security, Availability, Processing Integrity, Confidentiality, and Privacy
+> **Official source:** [AICPA SOC 2](https://www.aicpa-cima.com/topic/audit-assurance/audit-and-assurance-greater-than-soc-2)
+
+## 1. What SOC 2 Requires
+
+SOC 2 evaluates an organization's controls against five Trust Service Criteria (TSC):
+
+| Category | Focus | Key Criteria |
+|----------|-------|-------------|
+| **Security** (CC1–CC9) | Protection against unauthorized access | CC1 Control environment, CC2 Communication, CC3 Risk assessment, CC5 Control activities, CC6 Logical/physical access, CC7 System operations, CC8 Change management, CC9 Risk mitigation |
+| **Availability** (A1) | System availability commitments | A1.1 Capacity planning, A1.2 Recovery objectives, A1.3 Backup/recovery testing |
+| **Processing Integrity** (PI1) | System processing accuracy | PI1.1–PI1.5 Completeness, accuracy, timeliness |
+| **Confidentiality** (C1) | Protection of confidential information | C1.1–C1.2 Identification, protection, disposal |
+| **Privacy** (P1–P8) | Personal information handling | Notice, choice, collection, use, disclosure, access, quality, monitoring |
+
+**Type II distinction:** SOC 2 Type II evaluates **operating effectiveness over a period** (typically 6–12 months), not just control design. This means runtime evidence is essential.
+
+## 2. How This Framework Addresses It
+
+### Trust Service Criteria Mapping
+
+| Criterion | Requirement | Framework Implementation | Runtime Evidence |
+|-----------|-------------|-------------------------|------------------|
+| **CC1.1–CC1.5** | Control environment | 5-layer governance model, CODEOWNERS RACI, agent instruction hierarchy | Git history showing governance enforcement |
+| **CC2.1–CC2.3** | Communication & information | Versioned policies, PR-based decisions, signal system | Policy change PRs, signal artifacts |
+| **CC3.1–CC3.4** | Risk assessment | [Risk Management Policy](../../org/4-quality/policies/risk-management.md) — 5x5 matrix, AI risk taxonomy, KRIs | `risk.assessment.complete` OTel events, KRI dashboards |
+| **CC5.1–CC5.3** | Control activities | 18 quality policies with PASS/FAIL evaluation criteria | Quality eval results, CI/CD gate logs |
+| **CC6.1–CC6.8** | Logical/physical access | Least-privilege tooling, mTLS, short-lived tokens, data classification | `tool.execute` spans, authentication events |
+| **CC7.1–CC7.5** | System operations | [Observability Policy](../../org/4-quality/policies/observability.md), [Log Retention Policy](../../org/4-quality/policies/log-retention.md) — WORM for audit/security logs | Full OTel pipeline, WORM verification, integrity checks |
+| **CC8.1** | Change management | PR-based governance, CI/CD gates, progressive rollout | PR history, deployment traces |
+| **CC9.1–CC9.2** | Risk mitigation (vendors) | [Vendor Risk Management Policy](../../org/4-quality/policies/vendor-risk-management.md) — 4-tier model, SOC 2/ISO 27001 attestation for Tier 1–2 | Vendor assessment records, SLA dashboards |
+| **A1.1–A1.3** | Availability | [Availability Policy](../../org/4-quality/policies/availability.md) — tiered RTO/RPO, DR drills | Recovery dashboards, drill evidence |
+| **PI1.1–PI1.5** | Processing integrity | Quality gates, automated testing, progressive rollout with health checks | Test results, deployment health metrics |
+| **C1.1–C1.2** | Confidentiality | [Data Classification Policy](../../org/4-quality/policies/data-classification.md), [Cryptography Policy](../../org/4-quality/policies/cryptography.md) | `data.classification` attributes, encryption verification |
+| **P1–P8** | Privacy | [Privacy Policy](../../org/4-quality/policies/privacy.md) — lawful basis, DPA, DSAR, breach handling | DSAR OTel events, breach timeline spans |
+
+## 3. Where Observability Provides Evidence
+
+SOC 2 Type II is uniquely dependent on **runtime evidence** — the auditor needs proof that controls operated effectively over the audit period. This is where the observability platform is indispensable:
+
+| SOC 2 Evidence Need | Observability Source | Why It Matters |
+|--------------------|---------------------|----------------|
+| Audit trail completeness (CC7.1) | Agent spans with `governance.decision` events, WORM-stored logs | Proves every action was logged and logs weren't tampered with |
+| Change management effectiveness (CC8.1) | Git PR traces, CI/CD pipeline spans, deployment rollout metrics | Proves changes followed the governed process |
+| Access control operation (CC6.1) | `tool.execute` spans with tool scope verification | Proves least-privilege was enforced at runtime |
+| Incident detection & response (CC7.2–CC7.4) | Incident timeline spans with SLA measurements | Proves response times met commitments |
+| Availability commitments (A1) | SLO burn rate dashboards, uptime metrics, DR drill records | Proves availability targets were maintained |
+| Risk monitoring (CC3.1) | KRI dashboards, automated risk signals | Proves risks were actively monitored |
+| Vendor oversight (CC9) | Vendor SLA dashboards, attestation tracking | Proves vendor risk was managed continuously |
+| Log retention & integrity (CC7.1) | WORM verification alerts, hash chain validation | Proves logs are immutable and retained per schedule |
+
+## 4. Remaining Gaps
+
+| Gap | SOC 2 Requirement | What's Needed | Severity |
+|-----|-------------------|---------------|----------|
+| **Operating effectiveness evidence** | Type II core | Real runtime data over 6–12 months from a deployed instance | Critical — this is the Type II requirement |
+| **Formal control testing** | All criteria | Documented testing of each control's effectiveness | High — auditor expectation |
+| **Independent audit** | SOC 2 engagement | CPA firm engagement, management assertion letter | High — cannot self-certify |
+| **Complementary User Entity Controls (CUECs)** | Common | Documentation of what the adopter's customers must do | Medium |
+| **Subservice organization management** | CC9 | Formal subservice organization identification and monitoring | Medium — if using SaaS dependencies |
+| **Physical access controls** | CC6 | Deployment-specific physical security | Low — often inherited from cloud provider SOC 2 |
+
+## 5. External References
+
+- [AICPA Trust Service Criteria (2017, updated 2022)](https://www.aicpa-cima.com/topic/audit-assurance/audit-and-assurance-greater-than-soc-2) — Criteria definitions
+- [AICPA SOC 2 Guide](https://us.aicpa.org/interestareas/frc/assuranceadvisoryservices/sorhome) — Engagement guidance
+- [SOC 2 Trust Service Criteria Points of Focus](https://us.aicpa.org/content/dam/aicpa/interestareas/frc/assuranceadvisoryservices/downloadabledocuments/trust-services-criteria.pdf) — Detailed control points
+- [Cloud Security Alliance CCM to SOC 2 Mapping](https://cloudsecurityalliance.org/research/cloud-controls-matrix) — Cross-framework mapping

--- a/index.html
+++ b/index.html
@@ -978,8 +978,8 @@ footer{border-top:1px solid var(--border);padding:40px 24px;text-align:center;co
           <div class="cert-icon" style="background:rgba(74,222,128,0.1)"><span style="font-size:1.1rem">🔒</span></div>
           <div class="cert-name">ISO 27001<small>Information Security Management</small></div>
         </div>
-        <div class="cert-bar-wrap"><div class="cert-bar" style="width:90%;background:linear-gradient(90deg,var(--green),var(--cyan))"></div></div>
-        <div class="cert-meta"><span class="cert-pct" style="color:var(--green)">~90% controls addressed</span><span>Access, change mgmt, crypto, risk, ops security, log retention (A.12.4), vendor risk (A.5.19–A.5.23)</span></div>
+        <div class="cert-bar-wrap"><div class="cert-bar" style="width:85%;background:linear-gradient(90deg,var(--green),var(--cyan))"></div></div>
+        <div class="cert-meta"><span class="cert-pct" style="color:var(--green)">~85% controls addressed</span><span>Access, change mgmt, crypto, risk, ops security, log retention (A.12.4), vendor risk (A.5.19–A.5.23)</span></div>
         <div class="cert-controls">
           <span class="cert-ctrl" style="color:var(--green);border-color:rgba(74,222,128,0.3);background:rgba(74,222,128,0.08)">CODEOWNERS RBAC</span>
           <span class="cert-ctrl" style="color:var(--green);border-color:rgba(74,222,128,0.3);background:rgba(74,222,128,0.08)">PR change mgmt</span>
@@ -987,6 +987,8 @@ footer{border-top:1px solid var(--border);padding:40px 24px;text-align:center;co
           <span class="cert-ctrl" style="color:var(--green);border-color:rgba(74,222,128,0.3);background:rgba(74,222,128,0.08)">Risk framework</span>
           <span class="cert-ctrl" style="color:var(--green);border-color:rgba(74,222,128,0.3);background:rgba(74,222,128,0.08)">Log retention &amp; immutability</span>
           <span class="cert-ctrl" style="color:var(--green);border-color:rgba(74,222,128,0.3);background:rgba(74,222,128,0.08)">Vendor risk mgmt (A.5.19–A.5.23)</span>
+          <span class="cert-ctrl" style="color:var(--amber);border-color:rgba(251,191,36,0.3);background:rgba(251,191,36,0.08)">ISMS scope: open</span>
+          <span class="cert-ctrl" style="color:var(--amber);border-color:rgba(251,191,36,0.3);background:rgba(251,191,36,0.08)">SoA: open</span>
         </div>
       </div>
 
@@ -995,8 +997,8 @@ footer{border-top:1px solid var(--border);padding:40px 24px;text-align:center;co
           <div class="cert-icon" style="background:rgba(96,165,250,0.1)"><span style="font-size:1.1rem">🛡️</span></div>
           <div class="cert-name">SOC 2 Type II<small>Trust Service Principles</small></div>
         </div>
-        <div class="cert-bar-wrap"><div class="cert-bar" style="width:95%;background:linear-gradient(90deg,var(--blue),var(--accent))"></div></div>
-        <div class="cert-meta"><span class="cert-pct" style="color:var(--blue)">~95% controls addressed</span><span>Availability, integrity, confidentiality, incident SLAs, log retention, vendor risk (CC9)</span></div>
+        <div class="cert-bar-wrap"><div class="cert-bar" style="width:85%;background:linear-gradient(90deg,var(--blue),var(--accent))"></div></div>
+        <div class="cert-meta"><span class="cert-pct" style="color:var(--blue)">~85% controls addressed</span><span>Availability, integrity, confidentiality, incident SLAs, log retention, vendor risk (CC9)</span></div>
         <div class="cert-controls">
           <span class="cert-ctrl" style="color:var(--green);border-color:rgba(74,222,128,0.3);background:rgba(74,222,128,0.08)">OTel audit trail</span>
           <span class="cert-ctrl" style="color:var(--green);border-color:rgba(74,222,128,0.3);background:rgba(74,222,128,0.08)">18 quality policies</span>
@@ -1004,6 +1006,7 @@ footer{border-top:1px solid var(--border);padding:40px 24px;text-align:center;co
           <span class="cert-ctrl" style="color:var(--green);border-color:rgba(74,222,128,0.3);background:rgba(74,222,128,0.08)">Incident SLAs</span>
           <span class="cert-ctrl" style="color:var(--green);border-color:rgba(74,222,128,0.3);background:rgba(74,222,128,0.08)">Log retention &amp; WORM</span>
           <span class="cert-ctrl" style="color:var(--green);border-color:rgba(74,222,128,0.3);background:rgba(74,222,128,0.08)">Vendor risk mgmt (CC9)</span>
+          <span class="cert-ctrl" style="color:var(--amber);border-color:rgba(251,191,36,0.3);background:rgba(251,191,36,0.08)">Runtime evidence: needs deployment</span>
         </div>
       </div>
 
@@ -1013,12 +1016,14 @@ footer{border-top:1px solid var(--border);padding:40px 24px;text-align:center;co
           <div class="cert-name">GDPR<small>EU Data Protection</small></div>
         </div>
         <div class="cert-bar-wrap"><div class="cert-bar" style="width:75%;background:linear-gradient(90deg,var(--rose),var(--amber))"></div></div>
-        <div class="cert-meta"><span class="cert-pct" style="color:var(--amber)">~75% controls addressed</span><span>Privacy, DPA, DSAR, breach, transfer controls</span></div>
+        <div class="cert-meta"><span class="cert-pct" style="color:var(--amber)">~75% controls addressed</span><span>Privacy, DPA, DSAR, breach, transfer controls, data classification</span></div>
         <div class="cert-controls">
           <span class="cert-ctrl" style="color:var(--green);border-color:rgba(74,222,128,0.3);background:rgba(74,222,128,0.08)">Lawful basis</span>
           <span class="cert-ctrl" style="color:var(--green);border-color:rgba(74,222,128,0.3);background:rgba(74,222,128,0.08)">DPA/DSAR</span>
           <span class="cert-ctrl" style="color:var(--green);border-color:rgba(74,222,128,0.3);background:rgba(74,222,128,0.08)">Breach notification</span>
-          <span class="cert-ctrl" style="color:var(--amber);border-color:rgba(251,191,36,0.3);background:rgba(251,191,36,0.08)">Data classification: open</span>
+          <span class="cert-ctrl" style="color:var(--green);border-color:rgba(74,222,128,0.3);background:rgba(74,222,128,0.08)">Data classification</span>
+          <span class="cert-ctrl" style="color:var(--amber);border-color:rgba(251,191,36,0.3);background:rgba(251,191,36,0.08)">Consent UX: open</span>
+          <span class="cert-ctrl" style="color:var(--amber);border-color:rgba(251,191,36,0.3);background:rgba(251,191,36,0.08)">DPO appointment: open</span>
         </div>
       </div>
 
@@ -1027,14 +1032,16 @@ footer{border-top:1px solid var(--border);padding:40px 24px;text-align:center;co
           <div class="cert-icon" style="background:rgba(167,139,250,0.1)"><span style="font-size:1.1rem">🤖</span></div>
           <div class="cert-name">ISO 42001<small>AI Management Systems</small></div>
         </div>
-        <div class="cert-bar-wrap"><div class="cert-bar" style="width:90%;background:linear-gradient(90deg,var(--accent),var(--accent3))"></div></div>
-        <div class="cert-meta"><span class="cert-pct" style="color:var(--accent3)">~90% controls addressed</span><span>Governance, accountability, fairness, transparency</span></div>
+        <div class="cert-bar-wrap"><div class="cert-bar" style="width:80%;background:linear-gradient(90deg,var(--accent),var(--accent3))"></div></div>
+        <div class="cert-meta"><span class="cert-pct" style="color:var(--accent3)">~80% controls addressed</span><span>Governance, accountability, fairness, transparency</span></div>
         <div class="cert-controls">
           <span class="cert-ctrl" style="color:var(--green);border-color:rgba(74,222,128,0.3);background:rgba(74,222,128,0.08)">Agent telemetry</span>
           <span class="cert-ctrl" style="color:var(--green);border-color:rgba(74,222,128,0.3);background:rgba(74,222,128,0.08)">Human-in-the-loop</span>
           <span class="cert-ctrl" style="color:var(--green);border-color:rgba(74,222,128,0.3);background:rgba(74,222,128,0.08)">Decision audit trail</span>
           <span class="cert-ctrl" style="color:var(--green);border-color:rgba(74,222,128,0.3);background:rgba(74,222,128,0.08)">Fairness audit</span>
           <span class="cert-ctrl" style="color:var(--green);border-color:rgba(74,222,128,0.3);background:rgba(74,222,128,0.08)">Model cards</span>
+          <span class="cert-ctrl" style="color:var(--amber);border-color:rgba(251,191,36,0.3);background:rgba(251,191,36,0.08)">AIMS scope: open</span>
+          <span class="cert-ctrl" style="color:var(--amber);border-color:rgba(251,191,36,0.3);background:rgba(251,191,36,0.08)">Conformity assessment: open</span>
         </div>
       </div>
 
@@ -1043,13 +1050,14 @@ footer{border-top:1px solid var(--border);padding:40px 24px;text-align:center;co
           <div class="cert-icon" style="background:rgba(34,211,238,0.1)"><span style="font-size:1.1rem">🏛️</span></div>
           <div class="cert-name">NIST AI RMF<small>AI Risk Management Framework</small></div>
         </div>
-        <div class="cert-bar-wrap"><div class="cert-bar" style="width:95%;background:linear-gradient(90deg,var(--cyan),var(--green))"></div></div>
-        <div class="cert-meta"><span class="cert-pct" style="color:var(--cyan)">~95% controls addressed</span><span>Governance, monitoring, risk mitigation, fairness, transparency</span></div>
+        <div class="cert-bar-wrap"><div class="cert-bar" style="width:85%;background:linear-gradient(90deg,var(--cyan),var(--green))"></div></div>
+        <div class="cert-meta"><span class="cert-pct" style="color:var(--cyan)">~85% controls addressed</span><span>Governance, monitoring, risk mitigation, fairness, transparency</span></div>
         <div class="cert-controls">
           <span class="cert-ctrl" style="color:var(--green);border-color:rgba(74,222,128,0.3);background:rgba(74,222,128,0.08)">5-layer governance</span>
           <span class="cert-ctrl" style="color:var(--green);border-color:rgba(74,222,128,0.3);background:rgba(74,222,128,0.08)">Continuous monitoring</span>
           <span class="cert-ctrl" style="color:var(--green);border-color:rgba(74,222,128,0.3);background:rgba(74,222,128,0.08)">Risk framework</span>
           <span class="cert-ctrl" style="color:var(--green);border-color:rgba(74,222,128,0.3);background:rgba(74,222,128,0.08)">MEASURE function</span>
+          <span class="cert-ctrl" style="color:var(--amber);border-color:rgba(251,191,36,0.3);background:rgba(251,191,36,0.08)">Quantitative metrics: needs runtime</span>
         </div>
       </div>
 
@@ -1058,20 +1066,22 @@ footer{border-top:1px solid var(--border);padding:40px 24px;text-align:center;co
           <div class="cert-icon" style="background:rgba(251,191,36,0.1)"><span style="font-size:1.1rem">⚖️</span></div>
           <div class="cert-name">EU AI Act<small>European AI Regulation</small></div>
         </div>
-        <div class="cert-bar-wrap"><div class="cert-bar" style="width:85%;background:linear-gradient(90deg,var(--amber),var(--green))"></div></div>
-        <div class="cert-meta"><span class="cert-pct" style="color:var(--green)">~85% controls addressed</span><span>Risk classification, transparency, fairness, human oversight</span></div>
+        <div class="cert-bar-wrap"><div class="cert-bar" style="width:75%;background:linear-gradient(90deg,var(--amber),var(--green))"></div></div>
+        <div class="cert-meta"><span class="cert-pct" style="color:var(--amber)">~75% controls addressed</span><span>Risk classification, transparency, fairness, human oversight</span></div>
         <div class="cert-controls">
           <span class="cert-ctrl" style="color:var(--green);border-color:rgba(74,222,128,0.3);background:rgba(74,222,128,0.08)">Risk tier classification</span>
           <span class="cert-ctrl" style="color:var(--green);border-color:rgba(74,222,128,0.3);background:rgba(74,222,128,0.08)">Humans approve</span>
           <span class="cert-ctrl" style="color:var(--green);border-color:rgba(74,222,128,0.3);background:rgba(74,222,128,0.08)">Explainability levels</span>
           <span class="cert-ctrl" style="color:var(--green);border-color:rgba(74,222,128,0.3);background:rgba(74,222,128,0.08)">Adversarial testing</span>
           <span class="cert-ctrl" style="color:var(--amber);border-color:rgba(251,191,36,0.3);background:rgba(251,191,36,0.08)">Conformity assessment: open</span>
+          <span class="cert-ctrl" style="color:var(--amber);border-color:rgba(251,191,36,0.3);background:rgba(251,191,36,0.08)">CE marking: open</span>
+          <span class="cert-ctrl" style="color:var(--amber);border-color:rgba(251,191,36,0.3);background:rgba(251,191,36,0.08)">EU database: open</span>
         </div>
       </div>
     </div>
 
     <div class="compliance-note reveal">
-      <p><strong>Honest assessment, not marketing claims.</strong> Percentages reflect controls currently modeled in the framework — not certification status. Items marked "open" are tracked as <a href="https://github.com/wlfghdr/agentic-enterprise/issues?q=label%3Agap" target="_blank">gap issues on GitHub</a>. This framework provides governance infrastructure and policy surfaces to accelerate audit readiness — formal certification requires an independent audit of your deployed instance, configured controls, and real operating evidence.</p>
+      <p><strong>Honest assessment, not marketing claims.</strong> Percentages reflect controls currently modeled in the framework — not certification status. Items marked "open" are tracked as <a href="https://github.com/wlfghdr/agentic-enterprise/issues?q=label%3Agap" target="_blank">gap issues on GitHub</a>. Detailed article-level mappings, observability evidence sources, and external references are available in the <a href="https://github.com/wlfghdr/agentic-enterprise/tree/main/docs/compliance" target="_blank">compliance reference docs</a>. Formal certification requires an independent audit of your deployed instance, configured controls, and real operating evidence — the observability platform is designed to produce that evidence.</p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary

- **Compliance reference docs** — 6 per-standard documents in `docs/compliance/` with article-level mappings, observability evidence sources, external references, and honest gap assessments (addresses #104)
- **Honest coverage reassessment** — all compliance percentages corrected downward in README and index.html to reflect actual gaps (ISO 27001 90→85%, SOC 2 95→85%, GDPR 80→75%, ISO 42001 90→80%, NIST AI RMF 95→85%, EU AI Act 85→75%)
- **Validation script issues** — 7 GitHub issues (#111–#117) created for deterministic CI/cron scripts covering policy structure, agent instructions, work artifacts, cross-references, OTel contract, compliance mappings, and integration registry (supports #74)
- **Consistency fixes** — GDPR badge/text mismatch resolved, index.html GDPR card corrected (Data Classification is done, real gaps shown instead)

## Standards covered in `docs/compliance/`

| Document | Standard |
|----------|----------|
| `iso-27001.md` | ISO/IEC 27001:2022 — Annex A control mapping, clause-level alignment |
| `soc2.md` | SOC 2 Type II — Trust Service Criteria mapping |
| `gdpr.md` | GDPR — Article-level mapping (Art. 5–49) |
| `iso-42001.md` | ISO/IEC 42001:2023 — AIMS clause and Annex A mapping |
| `nist-ai-rmf.md` | NIST AI 100-1 + AI 600-1 — GOVERN/MAP/MEASURE/MANAGE function mapping |
| `eu-ai-act.md` | EU AI Act — Risk category and article-level mapping |

Each doc includes a dedicated **"Where Observability Provides Evidence"** section showing how telemetry bridges the gap between policy documents and auditable runtime evidence.

## Test plan

- [ ] CI passes (YAML, markdown links, placeholders, versioning, schema)
- [ ] Compliance percentages consistent across README badges, README table, and index.html cards
- [ ] All internal links in new docs resolve
- [ ] docs/README.md index includes compliance section
- [ ] Gap columns in README compliance table are populated (no empty "—" cells)

🤖 Generated with [Claude Code](https://claude.com/claude-code)