### PR TITLE
docs: add SOC 2 control testing guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ _Changes merged to `main` but not yet tagged as a release go here. Move to a new
 
 ### Added
 
+- New SOC 2 audit-readiness assets: `docs/compliance/remediation/soc2-control-testing.md`, `docs/compliance/templates/_TEMPLATE-soc2-control-testing-matrix.md`, and `docs/compliance/templates/_TEMPLATE-soc2-control-test-result.md` — formal control testing guidance, pre-seeded TSC-to-procedure matrix, CI/CD validation-to-control-test mapping, and reusable result records for documenting control effectiveness. Closes #124.
 - New CI validation: `scripts/validate_cross_references.py` — semantic cross-reference integrity checks for work artifacts, signal supersession chains, governance exception references, and quality-policy file references including bare `.md` mentions. Runs as blocking `validate-cross-references` job in `validate.yml`. Closes #114.
 - New CI validation: `scripts/validate_otel_contract.py` — OTel contract compliance checks for agent type telemetry sections, skill manifest telemetry declarations, observability integration documentation examples, and telemetry-aware policy references to `docs/otel-contract.md`. Runs as blocking `validate-otel-contract` job in `validate.yml`. Closes #115.
 - New CI validation: `scripts/validate_compliance_mapping.py` — compliance mapping validation for quality policies, including framework normalization, control identifier format checks, compliance reference document presence, and reused-control consistency warnings. Runs as blocking `validate-compliance-mapping` job in `validate.yml`. Closes #116.

--- a/docs/compliance/README.md
+++ b/docs/compliance/README.md
@@ -15,7 +15,7 @@ This directory contains one reference document per external standard or regulati
 | Standard | Document | Framework Coverage | Key Gaps |
 |----------|----------|-------------------|----------|
 | [ISO/IEC 27001:2022](iso-27001.md) | Information Security Management | ~90% | Management review records, competence records |
-| [SOC 2 Type II](soc2.md) | Trust Service Criteria | ~90% | Formal control testing, independent audit |
+| [SOC 2 Type II](soc2.md) | Trust Service Criteria | ~90% | Independent audit |
 | [GDPR](gdpr.md) | EU Data Protection | ~75% | Consent management UX, DPO appointment, supervisory authority registration, cookie/tracking compliance |
 | [ISO/IEC 42001:2023](iso-42001.md) | AI Management Systems | ~80% | Formal AIMS scope, conformity assessment, management review, internal audit programme |
 | [NIST AI RMF](nist-ai-rmf.md) | AI Risk Management Framework | ~85% | MEASURE function quantitative metrics, third-party evaluation, organizational AI risk profile document |

--- a/docs/compliance/remediation/README.md
+++ b/docs/compliance/remediation/README.md
@@ -1,6 +1,6 @@
 # Compliance Remediation Guides
 
-> **Purpose:** Actionable guides for closing P0-critical compliance gaps identified in the [compliance reference docs](../README.md).
+> **Purpose:** Actionable guides and templates for closing high-priority compliance gaps identified in the [compliance reference docs](../README.md).
 
 These guides are for **adopters deploying the framework** in a real environment. Each guide addresses a specific gap from the compliance reference documents and provides step-by-step remediation instructions.
 
@@ -13,6 +13,13 @@ These guides are for **adopters deploying the framework** in a real environment.
 | [NIST CSF Network Security Architecture](nist-csf-network-security.md) | NIST CSF 2.0 | No network segmentation/firewall/monitoring | [#134](https://github.com/wlfghdr/agentic-enterprise/issues/134) |
 | [EU AI Act Conformity Assessment](eu-ai-act-conformity-assessment.md) | EU AI Act | No conformity assessment procedure | [#129](https://github.com/wlfghdr/agentic-enterprise/issues/129) |
 | [EU AI Act CE Marking & EU Database](eu-ai-act-ce-marking.md) | EU AI Act | No CE marking or EU database registration | [#130](https://github.com/wlfghdr/agentic-enterprise/issues/130) |
+
+## SOC 2 Audit Readiness Guides
+
+| Guide | Standard | Gap | Issue |
+|-------|----------|-----|-------|
+| [SOC 2 Operating Effectiveness Evidence](soc2-operating-effectiveness.md) | SOC 2 Type II | No runtime evidence for Type II audit | [#123](https://github.com/wlfghdr/agentic-enterprise/issues/123) |
+| [SOC 2 Formal Control Testing Documentation](soc2-control-testing.md) | SOC 2 Type II | No formal control testing matrix, cadence, or result records | [#124](https://github.com/wlfghdr/agentic-enterprise/issues/124) |
 
 ## ISO 27001 Core ISMS Templates
 

--- a/docs/compliance/remediation/soc2-control-testing.md
+++ b/docs/compliance/remediation/soc2-control-testing.md
@@ -1,0 +1,275 @@
+<!-- placeholder-ok -->
+# SOC 2 — Formal Control Testing Documentation Guide
+
+> **Closes gap:** Formal control testing documentation
+> **Standard:** SOC 2 Type II — Trust Service Criteria
+> **Severity:** High — required before formal audit fieldwork
+> **Related issue:** [#124](https://github.com/wlfghdr/agentic-enterprise/issues/124)
+> **Related compliance doc:** [SOC 2 Compliance Reference](../soc2.md)
+> **Companion guide:** [SOC 2 Operating Effectiveness Evidence](soc2-operating-effectiveness.md)
+
+---
+
+## 1. Gap Summary
+
+The Agentic Enterprise framework already provides the raw ingredients for SOC 2 testing:
+
+- control design in the quality policies and governance model
+- runtime evidence collection guidance in the [operating effectiveness guide](soc2-operating-effectiveness.md)
+- CI/CD validations, policy-as-code checks, and Git-based approval trails
+
+What it lacked was the **formal documentation layer** that auditors expect when they ask, "Show me how you test each control, how often you test it, what evidence you reviewed, and how you tracked failures."
+
+Without that layer, adopters can collect telemetry and still fail readiness because they cannot demonstrate a repeatable control testing programme. This guide closes that gap by providing:
+
+1. a control testing methodology
+2. a reusable testing matrix template
+3. a reusable test result template
+4. a mapping from existing framework validations to SOC 2 control tests
+
+Use this guide together with the [operating effectiveness evidence guide](soc2-operating-effectiveness.md):
+
+- this guide explains **how to test controls**
+- the companion guide explains **how to retain evidence over the observation period**
+
+---
+
+## 2. What Auditors Expect From Formal Control Testing
+
+Formal control testing means more than keeping a spreadsheet of controls. At minimum, an auditor expects the organization to maintain the following documented information:
+
+| Artifact | Purpose | Minimum Content |
+|---------|---------|-----------------|
+| **Control testing matrix** | Defines the full control population and how each control is tested | Control ID, TSC mapping, owner, frequency, test method, evidence source, tester |
+| **Test procedures** | Makes the testing approach repeatable | Inspection steps, sample logic, expected result, failure criteria |
+| **Test result records** | Proves testing actually occurred | Test date, population/sample, evidence reviewed, exceptions, conclusion |
+| **Remediation tracker** | Shows failed tests were acted on | Exception description, severity, owner, due date, retest status |
+| **Testing calendar** | Demonstrates planned intervals | Monthly / quarterly / annual schedule tied to control type |
+
+If any of these are missing, the testing programme is usually treated as ad hoc rather than governed.
+
+---
+
+## 3. Control Testing Methodology
+
+### 3.1 Build the Control Population
+
+Start with the framework's SOC 2 control mapping in [soc2.md](../soc2.md). Convert the high-level criterion mapping into a deployment-specific control inventory. Each control in the inventory should answer:
+
+- What is the control trying to prevent or detect?
+- Which TSC criterion does it support?
+- Who owns the control?
+- Is it automated, manual, or hybrid?
+- What evidence proves it operated effectively?
+
+The [control testing matrix template](../templates/_TEMPLATE-soc2-control-testing-matrix.md) is the governed place to capture this inventory.
+
+### 3.2 Classify Controls by Testing Method
+
+Use the testing method that matches how the control actually works.
+
+| Method | When to Use | Example in This Framework |
+|--------|-------------|---------------------------|
+| **Inspection** | Review documents, configuration, or system settings | Inspect `CODEOWNERS`, policy versions, branch protection screenshots |
+| **Inquiry** | Confirm understanding of a process with the control owner | Interview the reviewer responsible for release approvals |
+| **Observation** | Watch the control being performed | Observe an access review or incident drill |
+| **Reperformance** | Re-run the control or recreate the test | Re-run a validation script against the current branch |
+| **Data requery / sampling** | Pull a population and sample it | Review merged PRs for approval evidence and passing checks |
+
+Auditors rarely accept inquiry alone. Prefer inspection, reperformance, or data requery wherever possible.
+
+### 3.3 Set Minimum Testing Frequency by Control Category
+
+Frequency should be risk-based, but the table below provides a strong default baseline for this framework.
+
+| Control Category | Typical Examples | Minimum Frequency | Notes |
+|------------------|------------------|-------------------|-------|
+| **Governance and oversight** | CODEOWNERS reviews, policy approval flows, risk review cadence | Quarterly | Increase if governance exceptions or process bypasses occur |
+| **Automated SDLC / CI controls** | schema validation, content security scanning, policy-as-code checks | Per change + monthly summary review | Automated controls should also have periodic reviewer validation |
+| **Access and change management** | branch protection, reviewer approvals, credential rotation evidence | Monthly or quarterly | Higher cadence if privileged access changes frequently |
+| **Operations and monitoring** | alerting, incident handling, log integrity, SLO monitoring | Monthly | Evidence should span the full observation period |
+| **Vendor and privacy controls** | vendor attestations, DPA checks, DSAR workflow | Quarterly or upon material change | Also retest after vendor scope changes |
+| **Resilience and recovery** | DR drills, backup restores, rollback tests | Quarterly or annual, depending on risk | Retain drill outputs and follow-up actions |
+
+### 3.4 Define Sampling Rules Up Front
+
+Sampling rules should be written before testing starts. This prevents cherry-picking.
+
+Recommended default sampling rules:
+
+- **Automated controls that run on every change:** inspect one successful run from each month in the audit period plus any failed run that triggered remediation
+- **Manual quarterly controls:** inspect all occurrences if the population is small; otherwise sample at least one occurrence per quarter
+- **Recurring approvals:** sample enough items to cover different reviewers, systems, and months in the period under review
+- **Exception handling controls:** test all exceptions, because the population should be small and each exception is high-signal
+
+If an auditor or CPA firm provides stricter sample guidance, follow that instead.
+
+---
+
+## 4. How to Use the Control Testing Matrix
+
+Instantiate the [SOC 2 control testing matrix template](../templates/_TEMPLATE-soc2-control-testing-matrix.md) as a deployment artifact, for example:
+
+- `docs/compliance/soc2-control-testing-matrix.md`
+- `work/assets/soc2-control-testing-matrix.md`
+
+The matrix should be the master index for the testing programme. Each row represents one control or one independently testable control family.
+
+### 4.1 Required Columns
+
+At minimum, keep these fields for every row:
+
+- control ID
+- trust service criterion
+- control objective
+- framework artifact or policy
+- deployment implementation reference
+- testing frequency
+- test method
+- evidence source
+- control owner
+- tester
+- latest result reference
+
+### 4.2 Example TSC-to-Test Mapping
+
+The template is pre-seeded with a starter mapping. Expand it to match the actual deployment.
+
+| TSC | Example Control Family | Suggested Procedure |
+|-----|------------------------|---------------------|
+| **CC1** | Governance and approval boundaries | Sample merged PRs and verify required reviewer approval and correct assignee handoff |
+| **CC3** | Risk assessment process | Inspect risk register entries and confirm review cadence matches policy |
+| **CC5** | Quality gates | Reperform CI validations and inspect failed-run remediation |
+| **CC6** | Access control | Inspect privileged access roster, credential rotation records, and branch protection settings |
+| **CC7** | Monitoring and incident response | Inspect alerting configuration, incident timelines, and immutable log settings |
+| **CC8** | Change management | Sample deployments and confirm linked PR approval, green checks, and rollback readiness |
+| **CC9** | Vendor oversight | Inspect vendor assessments, attestation currency, and review cadence |
+| **A1** | Availability commitments | Inspect SLO reporting, capacity thresholds, and DR drill evidence |
+| **PI1** | Processing integrity | Inspect validation results, deployment health checks, and defect remediation |
+| **C1** | Confidentiality | Inspect data classification enforcement and encryption verification outputs |
+| **P1-P8** | Privacy operations | Inspect DSAR, breach handling, consent, and retention evidence as applicable |
+
+---
+
+## 5. Mapping Existing CI/CD Validations to SOC 2 Control Tests
+
+The framework already includes a meaningful automated control surface. These checks can serve as part of formal control testing when they are documented in the matrix and paired with retained evidence.
+
+### 5.1 Validate Framework Workflow
+
+| Workflow / Check | Primary TSC Coverage | How to Test It | Evidence to Retain |
+|------------------|----------------------|----------------|--------------------|
+| `validate-yaml` | PI1, CC8 | Reperform on a recent change set and confirm malformed YAML does not merge | Workflow run logs and remediation for any failures |
+| `validate-markdown` | PI1, CC5 | Inspect a sample of successful runs and one failed run if available | Workflow logs showing broken-link detection and correction |
+| `validate-placeholders` | PI1, CC5 | Reperform and confirm non-template docs do not ship unresolved placeholders | Workflow logs and corrected commit references |
+| `validate-versioning` | CC2, CC8 | Inspect governed-file changes and verify version/date enforcement triggered | Workflow logs plus diff showing updated metadata |
+| `validate-github-governance` | CC1, CC6, CC8 | Inspect advisory output and pair it with direct verification of CODEOWNERS and branch protection settings | Advisory run logs plus GitHub settings evidence |
+| `validate-schema` | PI1, CC5 | Reperform against `CONFIG.yaml` and governed schemas | Workflow logs and schema validation outputs |
+| `validate-content-security` | CC5, CC7 | Reperform to confirm prompt-injection and unsafe-content patterns are blocked | Workflow logs and any approved suppression rationale |
+| `validate-policy-structure` | CC5 | Inspect that policy metadata and cross-policy references remain complete | Workflow run logs |
+| `validate-otel-contract` | CC7, PI1 | Reperform and confirm telemetry-linked artifacts reference the canonical contract | Workflow logs |
+| `validate-compliance-mapping` | CC5, PI1 | Reperform and confirm policy mappings remain structurally valid | Workflow logs |
+| `validate-integration-registry` | CC7, CC9 | Reperform and confirm observability integrations remain structurally complete | Workflow logs |
+| `validate-agent-instructions` | CC1, CC5 | Reperform and verify hierarchy and boundary enforcement | Workflow logs |
+| `validate-work-artifacts` | CC2, PI1 | Inspect run results for structured artifact compliance | Workflow logs |
+| `validate-cross-references` | PI1, CC8 | Reperform and confirm references between governed artifacts resolve | Workflow logs |
+
+### 5.2 Policy-as-Code Workflow
+
+| Workflow / Check | Primary TSC Coverage | How to Test It | Evidence to Retain |
+|------------------|----------------------|----------------|--------------------|
+| `Policy Checks (OPA/Conftest)` | CC5, CC7, CC8 | Reperform against workflow definitions and inspect deny/warn outputs | Conftest run logs and remediation for policy violations |
+
+### 5.3 Important Limitation
+
+Automated validations are strong evidence, but they do **not** replace all manual control testing. They prove that certain detective or preventive controls executed. They do not, by themselves, prove:
+
+- that branch protection is configured in GitHub correctly
+- that reviewers were actually independent where required
+- that vendor evidence was current and interpreted correctly
+- that exception handling followed policy after a failure
+
+Treat CI/CD controls as one layer of the testing programme, not the entire programme.
+
+---
+
+## 6. How to Document Test Results
+
+Use the [SOC 2 control test result template](../templates/_TEMPLATE-soc2-control-test-result.md) for every executed test. Instantiate it into a stable location such as:
+
+- `docs/compliance/testing-results/`
+- `work/assets/soc2-testing-results/`
+
+Each test result should capture:
+
+- the control being tested
+- the period under review
+- the exact sample or population tested
+- the evidence reviewed
+- step-by-step procedure execution notes
+- whether the test passed, failed, or passed with exceptions
+
+### 6.1 Result Rating Guidance
+
+| Result | Meaning | Required Follow-up |
+|--------|---------|--------------------|
+| **Pass** | Control operated as designed with no exceptions | Retain evidence and continue normal cadence |
+| **Pass with exception** | Control operated, but one or more exceptions were found that do not invalidate the control overall | Track remediation and consider expanded sampling |
+| **Fail** | Control did not operate effectively, or evidence is insufficient to support operation | Immediate remediation plan, owner assignment, and retest |
+| **Not tested** | Planned test not executed | Record reason and reschedule promptly |
+
+### 6.2 Exception Handling
+
+Every failed test or meaningful exception should be linked to a remediation record. Good options in this framework include:
+
+- a tracked issue in GitHub
+- a risk entry using [work/decisions/_TEMPLATE-risk-register.md](../../../work/decisions/_TEMPLATE-risk-register.md) when the exception raises ongoing risk
+- a retrospective if the exception caused a production incident
+
+Do not overwrite failed results. File a new retest record after remediation.
+
+---
+
+## 7. Recommended Testing Calendar
+
+The table below is a practical default cadence for the framework's control set.
+
+| Month / Quarter | Activity |
+|-----------------|----------|
+| **Monthly** | Review automated CI/CD controls, monitoring alerts, and any failed exceptions that need retest |
+| **Quarterly** | Test governance, access, vendor, and privacy controls; update sampling across the observation period |
+| **Semi-annually** | Reassess testing coverage and adjust the matrix for new systems, integrations, or scope changes |
+| **Annually** | Perform full control testing refresh, readiness review, and align with the CPA firm's expected audit window |
+| **Upon significant change** | Add or retest controls after new integrations, policy changes, major incidents, or control failures |
+
+If the organization changes scope mid-year, revise the matrix immediately. Waiting until the next annual cycle creates audit gaps.
+
+---
+
+## 8. Verification Checklist
+
+Use this checklist before calling the control testing programme audit-ready.
+
+- [ ] A control testing matrix exists and covers every in-scope TSC criterion
+- [ ] Every matrix row defines frequency, method, evidence source, owner, and tester
+- [ ] Existing CI/CD validations are explicitly mapped where they act as control tests
+- [ ] Test result records exist for executed tests and are linked from the matrix
+- [ ] Sampling rules are documented before testing begins
+- [ ] Exceptions are tracked with owners and target dates
+- [ ] Failed tests are retested with a new result record after remediation
+- [ ] Testing cadence aligns to the control risk level and audit period
+- [ ] The testing programme is used together with the [operating effectiveness guide](soc2-operating-effectiveness.md) so evidence retention spans the full observation window
+
+---
+
+## References
+
+- [SOC 2 Compliance Reference](../soc2.md)
+- [SOC 2 Operating Effectiveness Evidence](soc2-operating-effectiveness.md)
+- [SOC 2 Control Testing Matrix Template](../templates/_TEMPLATE-soc2-control-testing-matrix.md)
+- [SOC 2 Control Test Result Template](../templates/_TEMPLATE-soc2-control-test-result.md)
+- [Delivery Policy](../../../org/4-quality/policies/delivery.md)
+- [Observability Policy](../../../org/4-quality/policies/observability.md)
+- [Log Retention Policy](../../../org/4-quality/policies/log-retention.md)
+- [Vendor Risk Management Policy](../../../org/4-quality/policies/vendor-risk-management.md)
+- [Risk Management Policy](../../../org/4-quality/policies/risk-management.md)

--- a/docs/compliance/soc2.md
+++ b/docs/compliance/soc2.md
@@ -56,13 +56,12 @@ SOC 2 Type II is uniquely dependent on **runtime evidence** — the auditor need
 
 | Gap | SOC 2 Requirement | What's Needed | Severity |
 |-----|-------------------|---------------|----------|
-| **Formal control testing** | All criteria | Documented testing of each control's effectiveness | High — auditor expectation |
 | **Independent audit** | SOC 2 engagement | CPA firm engagement, management assertion letter | High — cannot self-certify |
 | **Complementary User Entity Controls (CUECs)** | Common | Documentation of what the adopter's customers must do | Medium |
 | **Subservice organization management** | CC9 | Formal subservice organization identification and monitoring | Medium — if using SaaS dependencies |
 | **Physical access controls** | CC6 | Deployment-specific physical security | Low — often inherited from cloud provider SOC 2 |
 
-**Addressed by framework:** Operating effectiveness evidence collection — see [evidence guide](remediation/soc2-operating-effectiveness.md) for TSC-to-OTel mapping, sample evidence packages, and auditor engagement preparation.
+**Addressed by framework:** Operating effectiveness evidence collection — see [evidence guide](remediation/soc2-operating-effectiveness.md) for TSC-to-OTel mapping, sample evidence packages, and auditor engagement preparation. Formal control testing documentation — see [control testing guide](remediation/soc2-control-testing.md), [control testing matrix template](templates/_TEMPLATE-soc2-control-testing-matrix.md), and [control test result template](templates/_TEMPLATE-soc2-control-test-result.md).
 
 ## 5. External References
 

--- a/docs/compliance/templates/_TEMPLATE-soc2-control-test-result.md
+++ b/docs/compliance/templates/_TEMPLATE-soc2-control-test-result.md
@@ -1,0 +1,126 @@
+# SOC 2 Control Test Result
+
+> **Template version:** 1.0
+> **Last updated:** 2026-03-15
+> **Standard:** SOC 2 Type II — Trust Service Criteria
+> **Purpose:** Record the execution, evidence, and conclusion of a single SOC 2 control test
+
+---
+
+## Test Metadata
+
+| Field | Value |
+|-------|-------|
+| Test ID | {{TEST_ID}} |
+| Control ID | {{CONTROL_ID}} |
+| Trust Service Criterion | {{TSC}} |
+| Control owner | {{CONTROL_OWNER}} |
+| Tester | {{TESTER}} |
+| Reviewer | {{REVIEWER}} |
+| Date executed | {{DATE_EXECUTED}} |
+| Audit period under review | {{AUDIT_PERIOD}} |
+| Test method | Inspection / Inquiry / Observation / Reperformance / Sampling |
+| Result | Pass / Pass with exception / Fail / Not tested |
+| Related matrix | [SOC 2 Control Testing Matrix](_TEMPLATE-soc2-control-testing-matrix.md) |
+
+## Control Description
+
+### Objective
+
+{{CONTROL_OBJECTIVE}}
+
+### Expected operation
+
+{{EXPECTED_OPERATION}}
+
+### Why this control matters
+
+{{RATIONALE}}
+
+## Population and Sampling
+
+| Field | Value |
+|-------|-------|
+| Population description | {{POPULATION_DESCRIPTION}} |
+| Population size | {{POPULATION_SIZE}} |
+| Sampling approach | {{SAMPLING_APPROACH}} |
+| Sample selected | {{SAMPLE_SELECTED}} |
+| Sampling rationale | {{SAMPLING_RATIONALE}} |
+
+## Test Procedure
+
+Document the exact steps performed. Keep the wording concrete enough that a different tester could repeat the same test.
+
+1. {{STEP_1}}
+2. {{STEP_2}}
+3. {{STEP_3}}
+
+## Evidence Reviewed
+
+| Evidence Item | Location / Reference | Date Range | Notes |
+|---------------|----------------------|------------|-------|
+| {{EVIDENCE_1}} | {{LOCATION}} | {{DATE_RANGE}} | {{NOTES}} |
+| {{EVIDENCE_2}} | {{LOCATION}} | {{DATE_RANGE}} | {{NOTES}} |
+
+## Execution Notes
+
+### What was tested
+
+{{EXECUTION_SUMMARY}}
+
+### Observations
+
+{{OBSERVATIONS}}
+
+## Exceptions
+
+### Exception summary
+
+{{EXCEPTION_SUMMARY_OR_NONE}}
+
+### Severity
+
+{{SEVERITY_OR_NA}}
+
+### Impact assessment
+
+{{IMPACT_ASSESSMENT}}
+
+## Conclusion
+
+### Result rationale
+
+{{RESULT_RATIONALE}}
+
+### Remediation required
+
+| Required | Action | Owner | Target Date | Tracking Reference |
+|----------|--------|-------|-------------|--------------------|
+| Yes / No | {{ACTION}} | {{OWNER}} | {{DATE}} | {{TRACKING_REF}} |
+
+### Retest required
+
+Yes / No
+
+### Retest criteria
+
+{{RETEST_CRITERIA}}
+
+## Sign-off
+
+| Role | Name | Date |
+|------|------|------|
+| Tester | {{TESTER}} | {{DATE}} |
+| Reviewer | {{REVIEWER}} | {{DATE}} |
+
+## Revision History
+
+| Version | Date | Author | Change Description |
+|---------|------|--------|--------------------|
+| 1.0 | {{DATE}} | {{AUTHOR}} | Initial test result record |
+
+## Changelog
+
+| Version | Date | Change |
+|---------|------|--------|
+| Template 1.0 | 2026-03-15 | Initial template for documenting SOC 2 control test execution, evidence, exceptions, and remediation |

--- a/docs/compliance/templates/_TEMPLATE-soc2-control-testing-matrix.md
+++ b/docs/compliance/templates/_TEMPLATE-soc2-control-testing-matrix.md
@@ -1,0 +1,82 @@
+# SOC 2 Control Testing Matrix
+
+> **Template version:** 1.0
+> **Last updated:** 2026-03-15
+> **Standard:** SOC 2 Type II — Trust Service Criteria
+> **Purpose:** Define the full control population, testing cadence, and test procedures for SOC 2 readiness and audit support
+
+---
+
+## Document Control
+
+| Field | Value |
+|-------|-------|
+| Document ID | SOC2-CTM-001 |
+| Version | {{VERSION}} |
+| Organization | {{ORGANIZATION_NAME}} |
+| Audit period | {{AUDIT_PERIOD_START}} to {{AUDIT_PERIOD_END}} |
+| Owner | {{CONTROL_TESTING_OWNER}} |
+| Approved by | {{APPROVER}} |
+| Review cycle | Quarterly (minimum) |
+| Related | [SOC 2 Control Test Result Template](_TEMPLATE-soc2-control-test-result.md) |
+
+## How to Use This Template
+
+1. Expand the seeded control families below into the full deployment-specific control inventory.
+2. Assign a unique `Control ID` and a named owner to each row.
+3. Replace framework references with the actual deployed control implementation where needed.
+4. Link each completed test to a result record created from `_TEMPLATE-soc2-control-test-result.md`.
+5. Update this matrix whenever new systems, vendors, workflows, or control changes enter scope.
+
+## Status Legend
+
+| Status | Meaning |
+|--------|---------|
+| Planned | Control exists in scope but has not yet been tested in the current cycle |
+| In progress | Test execution is underway |
+| Pass | Latest test supports operating effectiveness |
+| Pass with exception | Control largely operated but exceptions require remediation |
+| Fail | Test failed or evidence was insufficient |
+| Not applicable | Criterion not in scope for this deployment (justify separately) |
+
+## Control Population
+
+| Control ID | TSC | Control Objective | Framework Artifact / Policy | Deployment Implementation | Frequency | Test Method | Population / Sample Rule | Evidence Source | Control Owner | Tester | Latest Result Ref | Status |
+|------------|-----|-------------------|-----------------------------|---------------------------|-----------|-------------|--------------------------|----------------|---------------|--------|-------------------|--------|
+| CC1-001 | CC1 | Governance changes require appropriate approval and ownership handoff | `AGENTS.md`, `CODEOWNERS`, PR workflow | {{DEPLOYMENT_REFERENCE}} | Quarterly | Inspection + sampling | Sample merged PRs from each quarter; verify reviewer and assignee history | PR metadata, review history, issue/PR assignee trail | {{OWNER}} | {{TESTER}} | {{RESULT_REF}} | Planned |
+| CC3-001 | CC3 | Risks are identified, scored, and reviewed on schedule | `org/4-quality/policies/risk-management.md` | {{DEPLOYMENT_REFERENCE}} | Quarterly | Inspection + inquiry | Sample open and recently updated risks; verify review dates and treatment | Risk register, review notes, alerts | {{OWNER}} | {{TESTER}} | {{RESULT_REF}} | Planned |
+| CC5-001 | CC5 | Quality gates block non-compliant changes before merge | `.github/workflows/validate.yml`, policy checks workflow | {{DEPLOYMENT_REFERENCE}} | Per change + monthly review | Reperformance + inspection | Inspect one successful run per month plus failed runs with remediation | Workflow runs, logs, remediation issues | {{OWNER}} | {{TESTER}} | {{RESULT_REF}} | Planned |
+| CC6-001 | CC6 | Access to governed changes and credentials is restricted appropriately | `CODEOWNERS`, branch protection, cryptography policy | {{DEPLOYMENT_REFERENCE}} | Monthly / quarterly | Inspection + observation | Review privileged users and recent access changes | Access roster, branch settings, KMS logs | {{OWNER}} | {{TESTER}} | {{RESULT_REF}} | Planned |
+| CC7-001 | CC7 | Monitoring, log integrity, and incident handling operate effectively | observability + log retention controls | {{DEPLOYMENT_REFERENCE}} | Monthly | Inspection + requery | Review alerts, incidents, and log integrity evidence for the month | Dashboards, incident records, WORM verification | {{OWNER}} | {{TESTER}} | {{RESULT_REF}} | Planned |
+| CC8-001 | CC8 | Changes follow approved workflow before deployment | PR workflow, delivery policy, release gates | {{DEPLOYMENT_REFERENCE}} | Monthly / quarterly | Sampling + inspection | Sample changes across the audit period; verify approval, checks, and release evidence | PRs, CI logs, deployment traces | {{OWNER}} | {{TESTER}} | {{RESULT_REF}} | Planned |
+| CC9-001 | CC9 | Critical vendors are assessed and monitored on schedule | `org/4-quality/policies/vendor-risk-management.md` | {{DEPLOYMENT_REFERENCE}} | Quarterly / annual | Inspection | Review all Tier 1-2 vendors or sample by criticality if volume is high | Vendor assessments, attestations, SLA reports | {{OWNER}} | {{TESTER}} | {{RESULT_REF}} | Planned |
+| A1-001 | A1 | Availability commitments are monitored and recovery readiness is tested | availability + observability controls | {{DEPLOYMENT_REFERENCE}} | Monthly + drill cadence | Inspection + observation | Review monthly SLOs and the latest drill / restore exercise | SLO dashboards, DR drill records, runbooks | {{OWNER}} | {{TESTER}} | {{RESULT_REF}} | Planned |
+| PI1-001 | PI1 | Processing integrity controls detect malformed or incomplete changes | validation workflows, release checks | {{DEPLOYMENT_REFERENCE}} | Per change + monthly review | Reperformance + sampling | Re-run selected validators and inspect failed-change remediation | Workflow logs, defect records, deployment health | {{OWNER}} | {{TESTER}} | {{RESULT_REF}} | Planned |
+| C1-001 | C1 | Confidential data is classified, encrypted, and access-controlled | data classification + cryptography policies | {{DEPLOYMENT_REFERENCE}} | Quarterly | Inspection | Sample sensitive stores and transmission paths | Classification evidence, encryption settings, KMS logs | {{OWNER}} | {{TESTER}} | {{RESULT_REF}} | Planned |
+| P1-001 | P1-P8 | Privacy obligations are executed for in-scope personal information | privacy policy and DSAR / breach workflows | {{DEPLOYMENT_REFERENCE}} | Quarterly / upon event | Inspection + sampling | Review all DSARs / privacy incidents or sample by quarter | DSAR records, breach logs, retention evidence | {{OWNER}} | {{TESTER}} | {{RESULT_REF}} | Planned |
+
+## Planned Test Calendar
+
+| Quarter / Month | Controls Scheduled | Notes |
+|-----------------|--------------------|-------|
+| {{PERIOD_1}} | {{CONTROL_IDS}} | {{NOTES}} |
+| {{PERIOD_2}} | {{CONTROL_IDS}} | {{NOTES}} |
+| {{PERIOD_3}} | {{CONTROL_IDS}} | {{NOTES}} |
+
+## Exception and Retest Tracking
+
+| Control ID | Result Ref | Exception Summary | Severity | Remediation Owner | Target Date | Retest Ref | Status |
+|------------|------------|-------------------|----------|-------------------|-------------|------------|--------|
+| {{CONTROL_ID}} | {{RESULT_REF}} | {{EXCEPTION}} | {{SEVERITY}} | {{OWNER}} | {{DATE}} | {{RETEST_REF}} | Open / Closed |
+
+## Revision History
+
+| Version | Date | Author | Change Description |
+|---------|------|--------|--------------------|
+| 1.0 | {{DATE}} | {{AUTHOR}} | Initial control testing matrix |
+
+## Changelog
+
+| Version | Date | Change |
+|---------|------|--------|
+| Template 1.0 | 2026-03-15 | Initial template for SOC 2 control population, testing cadence, evidence sources, and result linkage |


### PR DESCRIPTION
## Summary
- add a SOC 2 remediation guide for formal control testing documentation
- add reusable control testing matrix and control test result templates
- update the SOC 2 compliance reference, compliance index, remediation index, and root changelog to reflect the new guidance

## Validation
- `python3 scripts/check_placeholders.py`
- `python3 scripts/validate_cross_references.py`
- `python3 scripts/validate_content_security.py`
- changed-file markdown links check

## Review focus
Please review whether the new guide and templates are sufficient to treat formal control testing as framework-addressed guidance for adopters, and whether the SOC 2 reference updates are scoped correctly.

## Reviewer options
- Approve if the remediation guide and templates close the framework gap for issue #124.
- Request changes if the testing matrix, result template, or SOC 2 reference updates need adjustment before merge.

Closes #124