### PR TITLE
chore: package v4.0.1 changelog fix release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,17 +19,16 @@ The framework uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html): `
 
 ## [Unreleased]
 
-_Changes merged to `main` after `v4.0.0` go here._
+_Changes merged to `main` after `v4.0.1` go here._
 
-### Added
+## [4.0.1] — 2026-03-16
 
-- New ISO 9001 implementation assets: `docs/compliance/guides/iso-9001-management-review.md`, `docs/compliance/guides/iso-9001-quality-objectives.md`, `docs/compliance/guides/iso-9001-customer-satisfaction.md`, and `docs/compliance/guides/iso-9001-internal-audit-programme.md` — concrete patterns for QMS management reviews, measurable objectives registers, customer-perception measurement, and formal internal audit programmes so the template ships executable guidance for the highest-friction ISO 9001 adopter gaps.
-- New OPA/Rego config rules: `policy/config/framework_governance.rego` and `policy/config/observability_registry.rego` — first policy-as-code expansion beyond workflows, covering semantic `framework_version`, supported work backend modes, Git-backed governance-critical artifact overrides, and observability registry structure in `CONFIG.yaml`. Runs via the `conftest` job in `validate.yml`.
+> **Patch release to realign packaged metadata with the shipped v4 source history.** No framework behavior changed beyond changelog and release-version bookkeeping.
 
 ### Changed
 
-- Tightened template-facing compliance positioning across `README.md`, `docs/compliance/README.md`, and `index.html`: posture percentages are now described more explicitly as template/editorial markers, stale `open` labels on public compliance cards were replaced with guide- or adopter-oriented language, and the public copy now emphasizes shipped implementation assets over unresolved-sounding placeholders.
-- Updated `docs/compliance/iso-9001.md` to point directly at the new ISO 9001 guide set and to describe the strengthened vendor-quality stance as template coverage rather than an unaddressed gap.
+- `CHANGELOG.md` — folded the final template compliance hardening work that already shipped in `v4.0.0` into the `4.0.0` section so the repository history matches the published release contents.
+- `CONFIG.yaml` and `README.md` — bumped the framework version marker from `4.0.0` to `4.0.1` to package the changelog correction as a formal patch release.
 
 ## [4.0.0] — 2026-03-16
 
@@ -37,6 +36,8 @@ _Changes merged to `main` after `v4.0.0` go here._
 
 ### Added
 
+- New ISO 9001 implementation assets: `docs/compliance/guides/iso-9001-management-review.md`, `docs/compliance/guides/iso-9001-quality-objectives.md`, `docs/compliance/guides/iso-9001-customer-satisfaction.md`, and `docs/compliance/guides/iso-9001-internal-audit-programme.md` — concrete patterns for QMS management reviews, measurable objectives registers, customer-perception measurement, and formal internal audit programmes so the template ships executable guidance for the highest-friction ISO 9001 adopter gaps.
+- New OPA/Rego config rules: `policy/config/framework_governance.rego` and `policy/config/observability_registry.rego` — first policy-as-code expansion beyond workflows, covering semantic `framework_version`, supported work backend modes, Git-backed governance-critical artifact overrides, and observability registry structure in `CONFIG.yaml`. Runs via the `conftest` job in `validate.yml`.
 - New CI validation: `scripts/validate_compliance_coverage.py` — compares the documented control/requirement IDs in all 11 primary compliance reference docs against quality-policy Compliance Mapping tables, expands grouped ranges such as `CC7.1–CC7.5`, `Art. 44–49`, and `GV.SC-03–SC-10`, reports unmapped controls per standard, and warns when a framework exceeds a configurable unmapped-coverage threshold. Runs as `validate-compliance-coverage` in `validate.yml`. Closes #165.
 - New NIST AI RMF quantitative-measurement assets: `docs/compliance/remediation/nist-ai-rmf-measure-metrics.md`, `docs/compliance/templates/_TEMPLATE-nist-ai-rmf-measure-dashboard.md`, and `docs/compliance/templates/_TEMPLATE-nist-ai-rmf-measure-report.md` — standard metric catalog aligned to MEASURE 1-4, OTel-to-metric mapping, baseline-establishment method, reusable dashboard specification, and periodic measurement-report template for AI risk quantification. Closes #128.
 - New SOC 2 audit-engagement assets: `docs/compliance/remediation/soc2-cpa-engagement.md` and `docs/compliance/templates/_TEMPLATE-soc2-management-assertion-letter.md` — CPA-firm selection and scoping workflow, auditor access and evidence-room coordination model, 3-6 month preparation timeline, and a reusable management assertion letter template for SOC 2 engagement packages. Closes #125.
@@ -64,6 +65,8 @@ _Changes merged to `main` after `v4.0.0` go here._
 
 ### Changed
 
+- Tightened template-facing compliance positioning across `README.md`, `docs/compliance/README.md`, and `index.html`: posture percentages are now described more explicitly as template/editorial markers, stale `open` labels on public compliance cards were replaced with guide- or adopter-oriented language, and the public copy now emphasizes shipped implementation assets over unresolved-sounding placeholders.
+- Updated `docs/compliance/iso-9001.md` and `org/4-quality/policies/vendor-risk-management.md` so the ISO 9001 reference set points directly at the new guide assets and the vendor-quality stance is expressed as shipped template coverage rather than an unaddressed gap.
 - `README.md`, `index.html`, `docs/reference-organization/sandboxcorp.md`, and `docs/architecture/agentic-enterprise-architecture.md` — replaced stale proof claims with directly inspectable public metrics as of 2026-03-16; documented the three-repo aggregation basis (`agentic-enterprise`, `sandboxcorp`, `agent-command-center`) so the public proof story is explicit and auditable.
 - Added executive-diligence positioning via `docs/executive-reality-check.md` and linked it from the main landing surfaces, clarifying what the framework is, what it is not, and where a CTO or CEO should remain skeptical.
 - Tightened compliance-positioning language across `README.md`, `docs/compliance/README.md`, `docs/executive-reality-check.md`, and `index.html`: public percentages are now explicitly labeled as editorial self-assessments rather than mechanized audit numbers, and the stale “open compliance issues” wording was replaced with language that points readers to the reference docs and implementation guides for remaining adopter responsibilities.

--- a/CONFIG.yaml
+++ b/CONFIG.yaml
@@ -14,7 +14,7 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # Tracks the overall framework release. Update when cutting a new version.
 # See CHANGELOG.md for what changed. Uses semantic versioning (MAJOR.MINOR.PATCH).
-framework_version: "4.0.0"
+framework_version: "4.0.1"
 # ═══════════════════════════════════════════════════════════════════════════
 
 # ───────────────────────────────────────────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <img src="https://img.shields.io/badge/model-Agentic%20Enterprise-blueviolet" alt="Agentic Enterprise">
-  <img src="https://img.shields.io/badge/version-4.0.0-brightgreen" alt="Version">
+  <img src="https://img.shields.io/badge/version-4.0.1-brightgreen" alt="Version">
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License">
   <img src="https://img.shields.io/badge/runtime-bring%20your%20own-orange" alt="Runtime">
   <a href="https://github.com/wlfghdr/agentic-enterprise/actions/workflows/validate.yml">


### PR DESCRIPTION
## Summary
- realign `CHANGELOG.md` so the final template compliance hardening work shipped in `v4.0.0` is recorded under the `4.0.0` section instead of `Unreleased`
- bump `CONFIG.yaml` and the README version badge from `4.0.0` to `4.0.1` so the changelog correction is packaged as a formal patch release
- leave `Unreleased` clean for post-`v4.0.1` work

## What To Review
- Does the changelog now describe `v4.0.0` accurately and leave `Unreleased` in a clean post-release state?
- Is `v4.0.1` appropriately scoped as a bookkeeping-only patch release?

## Reviewer Options
- Approve: merge and publish `v4.0.1`
- Request changes: point out any history or versioning line that still looks inconsistent
- Reject: if we should instead edit the existing `v4.0.0` release without cutting a patch release

## Validation
- `python3 scripts/validate_cross_references.py`
- `python3 scripts/check_placeholders.py`
- `python3 scripts/validate_content_security.py`
- `/tmp/conftest test CONFIG.yaml --policy policy/ --data policy/ --namespace config --output table`

## Scope note
- No framework behavior changes are included here beyond release bookkeeping and version metadata.