### PR TITLE
docs: add instance topology and work continuity guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@
 <p align="center">
   <a href="https://wlfghdr.github.io/agentic-enterprise/"><strong>Live Demo</strong></a> ·
   <a href="https://wlfghdr.github.io/agentic-enterprise/concept-visualization.html"><strong>Reference Scenario</strong></a> ·
-  <a href="docs/adoption/minimal-adoption.md"><strong>Minimal Adoption</strong></a>
+  <a href="docs/adoption/minimal-adoption.md"><strong>Minimal Adoption</strong></a> ·
+  <a href="docs/automation-and-work-continuity.md"><strong>Work Continuity</strong></a>
 </p>
 
 <p align="center">

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ Pick the shortest path that matches what you are trying to do:
 |---|---|---|
 | Understand what belongs where in the repo | [`file-guide.md`](file-guide.md) | [`mission-lifecycle.md`](mission-lifecycle.md) if you are working on missions |
 | Choose or configure a work backend | [`work-backends.md`](work-backends.md) | [`github-issues.md`](github-issues.md) for the GitHub issue backend |
+| Decide same-repo vs separate work repo and external product topology | [`adoption/minimal-adoption.md`](adoption/minimal-adoption.md) | [`automation-and-work-continuity.md`](automation-and-work-continuity.md) for ongoing operations |
 | Make GitHub governance enforceable | [`required-github-settings.md`](required-github-settings.md) | [`github/README.md`](github/README.md) |
 | Understand mission flow and status gates | [`mission-lifecycle.md`](mission-lifecycle.md) | [`work-backends.md`](work-backends.md) for backend differences |
 | Work on CI or policy gates | One of the CI feature guides below | [`automation-patterns.md`](automation-patterns.md) for script-vs-agent guidance |

--- a/docs/adoption/minimal-adoption.md
+++ b/docs/adoption/minimal-adoption.md
@@ -24,6 +24,27 @@ Edit `CONFIG.yaml` with your company name and basics. You can leave most fields 
 
 ### Step 2: Set Up Work Directories (5 min)
 
+Before you commit to the default layout, decide where operational work should live.
+
+#### Repo topology rule
+
+Keep these concerns separate:
+- **template repo** — the generic operating model you forked from
+- **instance repo** — your company-specific governance backbone
+- **work repo** *(optional but often recommended)* — operational issues, missions, and human-visible flow
+- **product repos** — actual products or systems delivered by missions
+
+A realistic topology often looks like this:
+
+```text
+agentic-enterprise      -> template repo
+my-company              -> company instance / governance repo
+my-company-work         -> operational work repo (issues backend)
+my-product              -> separate product repo referenced by missions
+```
+
+Use a separate `*-work` repo when you want better human visibility, notifications, and a cleaner separation between governance docs and day-to-day operational backlog.
+
 You only need three directories to start:
 
 ```
@@ -150,6 +171,21 @@ These are load-bearing from day one:
 | Signal → Mission → PR flow | This is the core workflow — everything else supports it |
 | At least one quality policy | Without standards, reviews are subjective |
 
+## External Products and Cross-Repo Work
+
+If a mission in your instance repo drives work in another repository, do not absorb that product backlog into the operating-model repo.
+
+Use this pattern instead:
+- mission ownership stays in the instance repo or work repo
+- product-specific implementation work goes to the product repo
+- generic framework gaps go back to the template repo
+
+At minimum, link both directions:
+- mission -> product issue
+- product issue -> origin mission
+
+This keeps adoption clean and prevents the company instance from becoming a dumping ground for unrelated implementation detail.
+
 ## Common Mistakes
 
 1. **Trying to adopt everything at once.** Start with signals, missions, and PRs. Add layers as you need them.
@@ -165,6 +201,14 @@ These are load-bearing from day one:
 ## Next Steps
 
 - [10-Minute Quickstart](../quickstart/10-minute-agentic-enterprise.md) — Walk through the workflow
+- [End-to-End Example](../../examples/e2e-loop/) — See a complete lifecycle
+- [Architecture Overview](../architecture/agentic-enterprise-architecture.md) — Understand the full system
+- [customization-guide.md](../customization-guide.md) — Full onboarding walkthrough
+erprise.md) — Walk through the workflow
+- [End-to-End Example](../../examples/e2e-loop/) — See a complete lifecycle
+- [Architecture Overview](../architecture/agentic-enterprise-architecture.md) — Understand the full system
+- [customization-guide.md](../customization-guide.md) — Full onboarding walkthrough
+erprise.md) — Walk through the workflow
 - [End-to-End Example](../../examples/e2e-loop/) — See a complete lifecycle
 - [Architecture Overview](../architecture/agentic-enterprise-architecture.md) — Understand the full system
 - [customization-guide.md](../customization-guide.md) — Full onboarding walkthrough

--- a/docs/automation-and-work-continuity.md
+++ b/docs/automation-and-work-continuity.md
@@ -1,0 +1,111 @@
+# Automation and Work Continuity
+
+> Short operational rules for keeping the operating model alive without creating noisy loops.
+
+This guide defines the minimum automation expectations once a team uses the framework with recurring agent or automation passes.
+
+## Core Rule
+
+**Open assigned work should not be silently abandoned.**
+
+That includes:
+- assigned issues
+- open PRs
+- requested reviews
+- active missions
+- open tasks linked to an approved mission
+- open signals that already have enough clarity for direct triage or decomposition
+
+The default expectation is: revisit, continue, close, escalate, or explicitly pause.
+
+## What a Continuity Pass Checks
+
+A compact continuity pass should review:
+
+1. open assigned issues and PRs
+2. review requests
+3. active or blocked missions
+4. open tasks under active missions
+5. referenced product-repo issues that belong to those missions
+
+The pass should prefer one compact sweep over many tiny loops.
+
+## Self-Assignment Defaults
+
+Use self-assignment only when all of the following are true:
+- the repo permits agent-owned work items
+- the task is clearly executable without new human scope decisions
+- the work is operationally useful to mark as owned
+
+Good candidates:
+- documentation gaps
+- broken links
+- missing wiring for already-approved behavior
+- clearly scoped follow-up tasks derived from an approved mission
+
+Do **not** self-assign when:
+- approval or prioritization is still unclear
+- scope changes strategy, roadmap, architecture, security posture, or spend
+- the work would look like an implicit human decision
+
+## Approval Boundaries
+
+Agents may continue execution inside already-approved scope.
+
+Agents should **not** silently push missions across human decision gates such as:
+- approving a mission brief
+- materially expanding mission scope
+- shipping sensitive production changes without the expected approval path
+- merging changes that repo policy expects humans to review
+- closing strategic questions that the mission explicitly leaves for a human
+
+When approval is needed, create or update the artifact so the next human decision is easy:
+- summarize current state
+- state the blocking decision
+- link the exact issue, PR, or mission
+- stop there
+
+## Backoff and Cadence
+
+Avoid tight loops.
+
+Recommended pattern:
+- run a compact scheduled pass (for example daily, twice daily, or workday morning/evening)
+- do one useful sweep per run
+- prefer batched updates over repetitive micro-comments
+- if nothing is clearly actionable, leave the system quiet
+
+Bad pattern:
+- polling every few minutes
+- repeated "still blocked" comments
+- creating many tiny follow-up issues that should have been one pass
+
+## Daily / Morning Review Expectation
+
+A healthy instance usually has one lightweight review rhythm:
+- check assigned work
+- check open reviews
+- check active missions and blocked tasks
+- continue what is executable
+- escalate what needs a human
+
+This can be done by a human, an agent, or scheduled automation.
+
+## Cross-Repo Continuity Rule
+
+If a mission in the instance repo creates product work in another repo, continuity should follow the full chain:
+
+`signal -> mission -> task -> product issue -> PR`
+
+At minimum, the mission or task should link to the product issue, and the product issue should link back to the originating mission.
+
+## Practical Outcome States
+
+After each continuity pass, each reviewed item should land in one of five states:
+- **done** — completed and closed
+- **in progress** — actively advanced
+- **blocked** — waiting on a named dependency
+- **awaiting approval** — waiting on an explicit human decision
+- **not now** — intentionally deferred with rationale
+
+The important thing is not constant activity. The important thing is that open work remains explainable.

--- a/docs/customization-guide.md
+++ b/docs/customization-guide.md
@@ -47,6 +47,19 @@ If you're a small team or solo founder, start with a **minimal agent fleet** —
 
 ### Step 4: Choose Your Work Backend (2 min)
 
+Also decide whether operational work lives in the same repo as the governance backbone or in a separate `*-work` repo.
+
+**Simple rule:**
+- keep work in the same repo for very small or early setups
+- split to a dedicated work repo once humans need cleaner backlog visibility, notifications, mobile access, or clearer separation from the governance backbone
+- keep product implementation in its own product repo either way
+
+Example topology:
+- template: `agentic-enterprise`
+- instance: `my-company`
+- work repo: `my-company-work`
+- product repo: `my-product`
+
 Decide where operational work artifacts (signals, missions, tasks, decisions) will be tracked:
 
 | Backend | Best For | Set In CONFIG.yaml |
@@ -70,6 +83,9 @@ Review `CONFIG.yaml → integrations` and register the external tools your organ
 See `org/integrations/` for detailed guides per category. Start with observability and CI/CD — they provide the most immediate value.
 
 ### Step 6: Start Using It (5 min)
+
+Before switching on recurring automation, read [automation-and-work-continuity.md](automation-and-work-continuity.md). It defines continuity expectations, approval boundaries, self-assignment defaults, and backoff rules.
+
 
 **Git-files backend:** Create your first signal in `work/signals/` and you're live.
 
@@ -525,6 +541,19 @@ With configuration complete, point your agents at the repo. Each agent needs thr
 3. **Read their assigned mission** in `work/missions/` — the specific task context.
 
 That is the complete bootstrap. No additional configuration files required. AGENTS.md auto-loads in Claude Code (via `CLAUDE.md`) and GitHub Copilot (via `.github/copilot-instructions.md`) — for other runtimes, point them at `AGENTS.md` explicitly.
+
+> **Tip:** Don't bootstrap agents against an unconfigured fork. Complete Steps 1–2 first — agents working against template placeholders will produce placeholder-filled outputs that fail CI.
+
+For runtime-specific setup (fleet sizing, scheduling, model tier strategy), see **[docs/runtimes/](runtimes/)**.
+point them at `AGENTS.md` explicitly.
+
+> **Tip:** Don't bootstrap agents against an unconfigured fork. Complete Steps 1–2 first — agents working against template placeholders will produce placeholder-filled outputs that fail CI.
+
+For runtime-specific setup (fleet sizing, scheduling, model tier strategy), see **[docs/runtimes/](runtimes/)**.
+k. Complete Steps 1–2 first — agents working against template placeholders will produce placeholder-filled outputs that fail CI.
+
+For runtime-specific setup (fleet sizing, scheduling, model tier strategy), see **[docs/runtimes/](runtimes/)**.
+point them at `AGENTS.md` explicitly.
 
 > **Tip:** Don't bootstrap agents against an unconfigured fork. Complete Steps 1–2 first — agents working against template placeholders will produce placeholder-filled outputs that fail CI.
 


### PR DESCRIPTION
## Summary\n- add adoption guidance for instance repo vs work repo vs external product repo topology\n- add a dedicated work continuity guide covering continuity passes, self-assignment defaults, approval boundaries, and backoff\n- link the new guidance from the main README and docs index\n\n## Context\nAddresses:\n- #184\n- #185\n\n## Why\nSagicorp bootstrap exposed two recurring adoption gaps: how to model external product outputs cleanly, and what operating continuity behavior prevents assigned/open work from stalling.