### PR TITLE
feat: add instance cleanup bootstrap script

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -55,6 +55,7 @@ These are the primary docs most operators need.
 | [`work-backends.md`](work-backends.md) | Canonical backend guide: backend choice, `CONFIG.yaml` structure, artifact placement, migration paths, and backend-specific behavior. |
 | [`github-issues.md`](github-issues.md) | GitHub issue-backend operations guide: project setup, labels, issue forms, handoff rules, and human approval flow. |
 | [`github/setup-checklist.md`](github/setup-checklist.md) | One-pass GitHub backend instantiation checklist: same-repo vs. dedicated-work-repo setup, labels, issue forms, Project, and slim CI. |
+| `scripts/instantiate_instance.py` | Scripted fork cleanup and GitHub issue-backend asset installation for real company instances. |
 | [`mission-lifecycle.md`](mission-lifecycle.md) | End-to-end mission lifecycle: status transitions, Divide & Conquer decomposition, gate requirements, anti-patterns. Required reading for Orchestration and Execution agents. |
 
 ---

--- a/docs/customization-guide.md
+++ b/docs/customization-guide.md
@@ -7,6 +7,8 @@
 
 > **New to the repo layout?** Read [docs/file-guide.md](file-guide.md) first — it explains which root files are part of the open-source template infrastructure (safe to delete in a private fork) and which are your company's actual operating model content (fill in and own).
 
+> **Fastest safe path:** fill `CONFIG.yaml`, install the GitHub issue-backend kit if needed, then run `python3 scripts/instantiate_instance.py cleanup-instance` to strip template-only assets and replace the top-level docs with instance-facing scaffolding.
+
 ---
 
 ## Quick Start (30 minutes to a working framework)
@@ -93,9 +95,22 @@ Before switching on recurring automation, read [automation-and-work-continuity.m
 
 **Git-files backend:** Create your first signal in `work/signals/` and you're live.
 
-**Issue backend:** Before creating your first signal, finish the minimum setup from [docs/github/setup-checklist.md](github/setup-checklist.md): enable Issues + Issue Forms, create the GitHub Project v2 `Status` field, copy the issue-form samples into `.github/ISSUE_TEMPLATE/`, and create the required labels.
+**Issue backend:** Before creating your first signal, finish the minimum setup from [docs/github/setup-checklist.md](github/setup-checklist.md). The preferred path is now scripted:
+
+```bash
+python3 scripts/instantiate_instance.py install-github-work-repo \
+  --main-repo your-org/your-instance \
+  --target-dir ../your-instance-work \
+  --include-label-sync
+```
 
 If you use a **dedicated work repo** for issues, put those issue forms and labels there. Keep CI in that repo intentionally slim: validate issue-template YAML and any repo-local automation, but leave the full framework validation in the operating-model repo. The template now includes reference assets for both: `docs/github/workflows/validate-issue-templates.yml` and `docs/github/workflows/sync-issue-form-labels.yml`.
+
+Once the GitHub assets are installed, clean the instance repo itself:
+
+```bash
+python3 scripts/instantiate_instance.py cleanup-instance
+```
 
 After that setup, create your first GitHub Issue with label `artifact:signal` and you're live.
 

--- a/docs/file-guide.md
+++ b/docs/file-guide.md
@@ -1,6 +1,6 @@
 # File Guide — What Is What and What to Do in a Fork
 
-> **Purpose:** This repo serves a dual role. It is simultaneously an **open-source template project** (publicly hosted on GitHub) and a **concrete example of a company operating model** (the thing you fork and run with). That means the root directory mixes two very different kinds of files. This guide tells you exactly what each file is for, and what to do with it when you fork.
+> **Purpose:** This repo serves a dual role. It is simultaneously an **open-source template project** and a **concrete example of a company operating model**. This guide tells you what each file is for, what belongs in a real instance, and which cleanup steps are now scripted.
 
 ---
 
@@ -22,7 +22,7 @@ Most adopters only ever need the **Company fork** context. The OSS context matte
 
 | File | Purpose | Fork action |
 |---|---|---|
-| `README.md` | Public-facing overview of the open-source framework. 496-line marketing/adoption doc targeting GitHub visitors. | Delete or replace with your own internal README |
+| `README.md` | Public-facing overview of the open-source framework. | Replace with your instance README. `python3 scripts/instantiate_instance.py cleanup-instance` does this automatically. |
 | `CONTRIBUTING.md` | How to contribute to the upstream OSS template. | Delete (irrelevant to a private fork) |
 | `CODE_OF_CONDUCT.md` | OSS community conduct standards (Contributor Covenant). | Delete (or keep if your org wants community norms documented) |
 | `SECURITY.md` | Security disclosure policy for the public OSS project. | Delete or replace with your org's actual security policy |
@@ -45,7 +45,7 @@ The `.github/` folder mixes OSS infrastructure with governance tooling that's ge
 |---|---|---|
 | `workflows/validate.yml` | Core CI: validates operating model docs, schemas, locks, placeholders, OPA/Conftest policy enforcement | **Keep** — these gates enforce governance in your fork too. They check that your config, policies, and artifacts stay consistent. |
 | `workflows/security.yml` | Gitleaks secret scanning + GitHub Dependency Review | **Keep** if using security scanning (see `docs/security-scanning.md`); delete if not |
-| `ISSUE_TEMPLATE/` | Bug report and config forms for OSS contributors | **Template repo:** keep for OSS contributor workflows. **Company fork with issue backend:** replace/adapt using the samples in `docs/github/issue-templates/`. **Company fork with git-files backend:** delete if not needed. |
+| `ISSUE_TEMPLATE/` | Bug report and config forms for OSS contributors | **Template repo:** keep for OSS contributor workflows. **Company fork with issue backend:** install the dedicated work-repo kit via `python3 scripts/instantiate_instance.py install-github-work-repo ...`. **Company fork with git-files backend:** delete if not needed. |
 | `PULL_REQUEST_TEMPLATE.md` | PR checklist reminding contributors to cite policies and evidence | **Keep and adapt** — update checklist items to match your fork's governance conventions |
 | `docs/runtimes/github-copilot-instructions.md` | GitHub Copilot agent instructions for working in this repo | **Keep and update** — edit after customization to reference your company name, divisions, and active missions |
 | `docs/runtimes/github-copilot-prompts/` | Agent skill prompts (e.g., `/deploy` workflow) | **Keep and adapt** — update prompts to reference your company's structure and toolchain |
@@ -73,7 +73,7 @@ The `.github/` folder mixes OSS infrastructure with governance tooling that's ge
 | File | Purpose | Fork action |
 |---|---|---|
 | `CLAUDE.md` | Auto-loaded by Claude Code (Anthropic's agent). **Mirrors the content of `AGENTS.md`** for the Claude tooling context. When you update `AGENTS.md`, keep this in sync — they must be consistent. Exists solely because Claude Code reads `CLAUDE.md` by convention; `AGENTS.md` is the canonical source of truth. | Keep and sync with `AGENTS.md` after any changes |
-| `docs/customization-guide.md` | Step-by-step guide for tailoring this framework to your company. | Read and follow during initial setup; keep for onboarding new team members |
+| `docs/customization-guide.md` | Step-by-step guide for tailoring this framework to your company. | Read during initial setup. After cleanup, move instance-only operator guidance into your own docs. |
 
 ---
 
@@ -101,7 +101,7 @@ CLAUDE.md          ← Claude Code companion (auto-loaded by Anthropic tooling)
 
 ## What a Clean Fork Looks Like
 
-After forking and completing `docs/customization-guide.md` Step 1–5, your root should contain:
+After forking, installing any GitHub issue-backend assets you need, and running `python3 scripts/instantiate_instance.py cleanup-instance`, your root should contain:
 
 ```
 # Keep & fill in — this is your operating model
@@ -118,13 +118,20 @@ NOTICE
 # Optionally keep
 examples/                   # useful until team is fluent
 
-# Delete — OSS/demo only, irrelevant in a private fork
-README.md                   # replace with your own
+# Deleted or replaced by the cleanup script
+README.md                   # replaced with an instance-facing README
 CONTRIBUTING.md
 CODE_OF_CONDUCT.md
 SECURITY.md                 # replace with your org's policy
 index.html
 concept-visualization.html
+
+# docs/ removed by the cleanup script
+docs/customization-guide.md
+docs/file-guide.md
+docs/adoption/
+docs/reference-organization/
+docs/github/
 
 # .github/ — keep selectively (see per-file table above)
 # Keep: validate.yml, PULL_REQUEST_TEMPLATE.md

--- a/docs/github-issues.md
+++ b/docs/github-issues.md
@@ -25,8 +25,8 @@ Complete these steps before using the issue backend in a real fork:
 1. Set `work_backend.type: "github-issues"` in `CONFIG.yaml`.
 2. Enable GitHub Issues and Issue Forms in the repository settings.
 3. **Create a GitHub Project (v2)** with a **Status** field containing these single-select options: `Backlog`, `Triage`, `Approved`, `Planning`, `In Progress`, `Blocked`, `Done`. Set `project_owner` and `project_number` in `CONFIG.yaml`.
-4. Copy the sample forms from `docs/github/issue-templates/forms/` into `.github/ISSUE_TEMPLATE/` in your instance repository.
-5. Copy `docs/github/issue-templates/config.sample.yml` to `.github/ISSUE_TEMPLATE/config.yml` in your instance repository and customize the links.
+4. Prefer the scripted install path: `python3 scripts/instantiate_instance.py install-github-work-repo --main-repo your-org/your-instance --target-dir <issue-hosting-repo>`.
+5. If you are doing it manually instead, copy the sample forms from `docs/github/issue-templates/forms/` into `.github/ISSUE_TEMPLATE/` in your instance repository and copy `docs/github/issue-templates/config.sample.yml` to `.github/ISSUE_TEMPLATE/config.yml`.
 6. Create the required labels listed below. (Note: status is tracked via the Project Status field, not via labels.) Use `docs/github/labels/labels.sample.yml` as your bootstrap source.
 7. Tell humans who approve work to use the approval transitions exactly as written in the approval table.
 8. Keep Git-backed companion artifacts in the repository: signal digests, technical designs, quality evaluations, fleet reports, outcome reports, asset registry entries, governance exceptions, and locks.
@@ -69,7 +69,7 @@ In that case, keep CI intentionally small:
 - ensure required template files exist
 - optionally validate any repo-local automation
 
-Use `docs/github/workflows/validate-issue-templates.yml` as the reference workflow for this slim CI profile.
+Use `docs/github/workflows/validate-issue-templates.yml` as the reference workflow for this slim CI profile, or let the scripted installer copy it for you.
 
 Do **not** copy the full operating-model validation suite into the work repo unless that repo actually stores the framework files those checks are designed for.
 
@@ -272,7 +272,7 @@ labels:
 
 If you prefer GitHub CLI, create labels with `gh label create` using the same names.
 
-If you want issue-form answers such as `priority`, `category`, `confidence`, or `urgency` to become labels automatically, use `docs/github/workflows/sync-issue-form-labels.yml`. Issue Forms themselves can only set static labels directly.
+If you want issue-form answers such as `priority`, `category`, `confidence`, or `urgency` to become labels automatically, use `docs/github/workflows/sync-issue-form-labels.yml` or install it with `--include-label-sync`. Issue Forms themselves can only set static labels directly.
 
 ---
 
@@ -366,7 +366,7 @@ These rules keep GitHub collaboration consistent. **You never need to manage lab
 
 ## Sample Files To Copy Into An Instance Repo
 
-This template repository keeps the operational GitHub issue forms as documentation samples so the framework repo itself does not behave like an instance repo.
+This template repository keeps the operational GitHub issue forms as documentation samples so the framework repo itself does not behave like an instance repo. The recommended way to move them into a real instance is `scripts/instantiate_instance.py install-github-work-repo`.
 
 Copy these into `.github/ISSUE_TEMPLATE/` in your company fork when you enable the issue backend:
 

--- a/docs/github/README.md
+++ b/docs/github/README.md
@@ -12,6 +12,14 @@ This folder is the GitHub instance kit for company forks:
 - `labels/` contains a copyable label bootstrap sample.
 - `workflows/` contains reference workflows you can copy into `.github/workflows/`.
 
+The preferred installation path is scripted:
+
+```bash
+python3 scripts/instantiate_instance.py install-github-work-repo \
+  --main-repo your-org/your-instance \
+  --target-dir ../your-instance-work
+```
+
 ---
 
 ## 1. GitHub Issues as Work Backend
@@ -54,7 +62,7 @@ Consider creating `.github/ISSUE_TEMPLATE/` templates for:
 - Mission (strategic intent with outcomes)
 - Task (concrete work item)
 
-Copy the samples from `issue-templates/` in this folder into your instance repository when you enable the issue backend.
+Copy the samples from `issue-templates/` in this folder into your instance repository when you enable the issue backend, or use the scripted install step above.
 
 Important limitation:
 - Issue Forms can set only static base labels directly.

--- a/docs/github/setup-checklist.md
+++ b/docs/github/setup-checklist.md
@@ -57,7 +57,26 @@ If you use a dedicated work repo, set `repo` to that repository.
 
 ## 3. Copy The Template Assets
 
-Copy these files into the repository that will host the issues:
+Preferred path: use the script from the freshly cloned template or fork before you run `cleanup-instance`.
+
+Example for a dedicated work repo:
+
+```bash
+python3 scripts/instantiate_instance.py install-github-work-repo \
+  --main-repo your-org/your-instance \
+  --target-dir ../your-instance-work \
+  --include-label-sync
+```
+
+Example for a same-repo issue backend:
+
+```bash
+python3 scripts/instantiate_instance.py install-github-work-repo \
+  --main-repo your-org/your-instance \
+  --target-dir .
+```
+
+If you need or prefer to do it manually, copy these files into the repository that will host the issues:
 
 - `docs/github/issue-templates/config.sample.yml` -> `.github/ISSUE_TEMPLATE/config.yml`
 - `docs/github/issue-templates/forms/*.sample.yml` -> `.github/ISSUE_TEMPLATE/*.yml`
@@ -165,3 +184,28 @@ Usually enough:
 - validate repo-local GitHub automation
 
 Do not copy the full framework CI into the work repo unless that repo actually stores the framework files those checks validate.
+
+---
+
+## 9. Clean The Instance Repo
+
+Once any required GitHub issue-backend assets have been copied out, clean the instance repo itself:
+
+```bash
+python3 scripts/instantiate_instance.py cleanup-instance
+```
+
+That command removes template-only assets such as:
+
+- `CONTRIBUTING.md`
+- `CODE_OF_CONDUCT.md`
+- `SECURITY.md`
+- `index.html`
+- `concept-visualization.html`
+- `docs/customization-guide.md`
+- `docs/file-guide.md`
+- `docs/adoption/`
+- `docs/reference-organization/`
+- `docs/github/`
+
+It also rewrites the top-level `README.md` and `docs/README.md`, and adds instance-facing `docs/repo-scope.md` and `docs/work-tracking.md`.

--- a/docs/required-github-settings.md
+++ b/docs/required-github-settings.md
@@ -26,7 +26,8 @@ Repo → **Settings → General → Features**
 - ✅ Issues
 - ✅ Issue forms
 
-Then copy the sample files from `docs/github/issue-templates/` into `.github/ISSUE_TEMPLATE/` in your instance repository and customize them.
+Prefer the scripted install path from `scripts/instantiate_instance.py install-github-work-repo`.
+If you need the manual path, copy the sample files from `docs/github/issue-templates/` into `.github/ISSUE_TEMPLATE/` in your instance repository and customize them.
 Use `docs/github/labels/labels.sample.yml` for label bootstrap and `docs/github/setup-checklist.md` for the full GitHub issue-backend setup sequence.
 
 Minimum required label families for a usable GitHub issue backend:
@@ -88,7 +89,7 @@ If you split work into a **dedicated GitHub issue repo**:
 - use only slim checks on the work repo for the files that repo actually stores (for example issue-template YAML)
 - do not require framework checks on the work repo if it does not contain the framework files those checks validate
 
-The template includes a reference workflow for this pattern at `docs/github/workflows/validate-issue-templates.yml`.
+The template includes a reference workflow for this pattern at `docs/github/workflows/validate-issue-templates.yml`, and the scripted installer can copy it into the work repo for you.
 
 ---
 

--- a/docs/work-backends.md
+++ b/docs/work-backends.md
@@ -260,7 +260,7 @@ Git-backed companion artifacts still exist alongside the issue hierarchy where r
 
 ### Issue Templates
 
-GitHub Issue Templates (`.github/ISSUE_TEMPLATE/`) can mirror the Markdown templates. In this template repository, the operational forms are stored as docs-only samples under `docs/github/issue-templates/forms/` so the framework repo itself does not behave like an instance repo.
+GitHub Issue Templates (`.github/ISSUE_TEMPLATE/`) can mirror the Markdown templates. In this template repository, the operational forms are stored as docs-only samples under `docs/github/issue-templates/forms/` so the framework repo itself does not behave like an instance repo. The preferred instantiation path is the scripted installer in `scripts/instantiate_instance.py`.
 
 - `signal.sample.yml` — maps to `_TEMPLATE-signal.md`
 - `mission.sample.yml` — maps to `_TEMPLATE-mission-brief.md`

--- a/scripts/instantiate_instance.py
+++ b/scripts/instantiate_instance.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+"""Bootstrap helpers for turning the framework template into a live instance.
+
+Two high-friction tasks are intentionally automated here:
+
+1. ``cleanup-instance`` removes template-only assets and rewrites the top-level
+   instance-facing docs after ``CONFIG.yaml`` has been filled in.
+2. ``install-github-work-repo`` copies the GitHub issue-backend kit into the
+   repo that will host operational issues.
+
+Recommended order for GitHub issue-backend adopters:
+
+1. Fill in ``CONFIG.yaml``
+2. Run ``install-github-work-repo`` if the issue backend will be used
+3. Run ``cleanup-instance`` to strip template-facing assets from the instance
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+import textwrap
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from work_backend import ISSUE_BACKEND, load_work_backend
+
+DEFAULT_REPO_ROOT = Path(__file__).resolve().parent.parent
+TEMPLATE_REPO_URL = "https://github.com/wlfghdr/agentic-enterprise"
+
+TEMPLATE_ONLY_PATHS = [
+    "CODE_OF_CONDUCT.md",
+    "CONTRIBUTING.md",
+    "SECURITY.md",
+    "index.html",
+    "concept-visualization.html",
+    "docs/customization-guide.md",
+    "docs/file-guide.md",
+    "docs/adoption",
+    "docs/reference-organization",
+    "docs/github",
+]
+
+ISSUE_FORM_SAMPLES = {
+    "config.yml": "docs/github/issue-templates/config.sample.yml",
+    "signal.yml": "docs/github/issue-templates/forms/signal.sample.yml",
+    "mission.yml": "docs/github/issue-templates/forms/mission.sample.yml",
+    "task.yml": "docs/github/issue-templates/forms/task.sample.yml",
+    "decision.yml": "docs/github/issue-templates/forms/decision.sample.yml",
+    "release.yml": "docs/github/issue-templates/forms/release.sample.yml",
+    "retrospective.yml": "docs/github/issue-templates/forms/retrospective.sample.yml",
+}
+
+WORKFLOW_SAMPLES = {
+    "validate-issue-templates.yml": "docs/github/workflows/validate-issue-templates.yml",
+    "sync-issue-form-labels.yml": "docs/github/workflows/sync-issue-form-labels.yml",
+}
+
+LABELS_SAMPLE = "docs/github/labels/labels.sample.yml"
+
+
+def load_config(repo_root: Path) -> dict[str, Any]:
+    config_path = repo_root / "CONFIG.yaml"
+    try:
+        loaded = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    except FileNotFoundError as exc:
+        raise SystemExit(f"CONFIG.yaml not found at {config_path}") from exc
+    if not isinstance(loaded, dict):
+        raise SystemExit("CONFIG.yaml must parse to a mapping")
+    return loaded
+
+
+def company_value(config: dict[str, Any], key: str, default: str) -> str:
+    company = config.get("company") or {}
+    value = company.get(key)
+    if not isinstance(value, str):
+        return default
+    stripped = value.strip()
+    return stripped or default
+
+
+def write_text(path: Path, content: str, dry_run: bool) -> None:
+    if dry_run:
+        print(f"WOULD WRITE {path}")
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content.rstrip() + "\n", encoding="utf-8")
+    print(f"WROTE {path}")
+
+
+def remove_path(path: Path, dry_run: bool) -> None:
+    if not path.exists():
+        return
+    if dry_run:
+        print(f"WOULD REMOVE {path}")
+        return
+    if path.is_dir():
+        shutil.rmtree(path)
+    else:
+        path.unlink()
+    print(f"REMOVED {path}")
+
+
+def render_readme(company_name: str, instance_repo: str, backend_type: str, issue_repo: str) -> str:
+    backend_note = "Operational work lives directly in `work/`." if backend_type != ISSUE_BACKEND else (
+        f"Day-to-day issue tracking lives in `{issue_repo}`."
+        if issue_repo and issue_repo != instance_repo
+        else "Day-to-day issue tracking lives in GitHub Issues in this repository."
+    )
+    repo_boundary = (
+        f"- `{issue_repo}` is the issue frontend: issue forms, labels, Project status tracking, and work board views.\n"
+        if backend_type == ISSUE_BACKEND and issue_repo and issue_repo != instance_repo
+        else ""
+    )
+    return textwrap.dedent(
+        f"""
+        # {company_name} Operating Model
+
+        This repository is the live `{company_name}` instance of the Agentic Enterprise operating model. It holds the governed backbone for roles, policies, decision records, durable work evidence, and validation.
+
+        This is not the public framework template. Generic instantiation guidance belongs upstream in [`wlfghdr/agentic-enterprise`]({TEMPLATE_REPO_URL}).
+
+        ## Start Here
+
+        - [`docs/repo-scope.md`](docs/repo-scope.md) explains what belongs in this repo versus upstream template or work repo.
+        - [`docs/work-tracking.md`](docs/work-tracking.md) explains how work is tracked in this instance.
+        - [`docs/github-issues.md`](docs/github-issues.md) defines the live GitHub issue-backend operating rules.
+        - [`docs/required-github-settings.md`](docs/required-github-settings.md) lists the GitHub governance settings that must remain enforced.
+        - [`org/README.md`](org/README.md) is the organizational backbone for layers, roles, and ownership.
+
+        ## Repository Boundaries
+
+        - `{instance_repo}` is the governance backbone: org model, policies, process rules, durable evidence, and validation.
+        {repo_boundary}- `agentic-enterprise` is the upstream template: reusable framework guidance, instantiation assets, and generic setup tooling.
+
+        ## Operating Notes
+
+        - {backend_note}
+        - Git-backed companion artifacts still stay here: technical designs, quality evaluations, fleet reports, outcome reports, governance exceptions, locks, and asset registry entries.
+        - Generic framework improvements should go upstream first and then be pulled back into this instance deliberately.
+        """
+    ).strip()
+
+
+def render_docs_readme() -> str:
+    return textwrap.dedent(
+        """
+        # docs/ — Instance Operator Guides
+        <!-- placeholder-ok -->
+
+        This folder contains the instance-specific operating notes that sit on top of the upstream Agentic Enterprise framework.
+
+        ## Start Here
+
+        | If you need to... | Read this first |
+        |---|---|
+        | Understand what this repo is responsible for | [`repo-scope.md`](repo-scope.md) |
+        | Understand where work lives | [`work-tracking.md`](work-tracking.md) |
+        | Run the issue backend day to day | [`github-issues.md`](github-issues.md) |
+        | Verify GitHub governance settings | [`required-github-settings.md`](required-github-settings.md) |
+        | Understand backend behavior and artifact placement | [`work-backends.md`](work-backends.md) |
+
+        ## Core Instance Docs
+
+        - [`repo-scope.md`](repo-scope.md)
+        - [`work-tracking.md`](work-tracking.md)
+        - [`github-issues.md`](github-issues.md)
+        - [`required-github-settings.md`](required-github-settings.md)
+        - [`automation-and-work-continuity.md`](automation-and-work-continuity.md)
+
+        ## Upstream-Only Concerns
+
+        Generic fork cleanup, reusable GitHub kits, and template-facing onboarding belong upstream in [`wlfghdr/agentic-enterprise`](https://github.com/wlfghdr/agentic-enterprise).
+        """
+    ).strip()
+
+
+def render_repo_scope(instance_repo: str, backend_type: str, issue_repo: str) -> str:
+    extra = (
+        f"- operational issue frontend in `{issue_repo}`\n"
+        if backend_type == ISSUE_BACKEND and issue_repo and issue_repo != instance_repo
+        else ""
+    )
+    return textwrap.dedent(
+        f"""
+        # Repository Scope
+
+        This repository is the operating-model backbone for `{instance_repo}`. It is intentionally narrower than the upstream template and intentionally different from any dedicated issue frontend.
+
+        ## What belongs here
+
+        - organizational structure under `org/`
+        - global agent instructions and governance rules
+        - quality policies and validation scripts
+        - process definitions and reference guides
+        - durable Git-backed work evidence such as technical designs, fleet reports, outcome reports, governance exceptions, locks, and asset registry entries
+        - instance-specific operator documentation in `docs/`
+
+        ## What does not belong here
+
+        - template marketing/demo assets
+        - generic fork or instantiation walkthroughs
+        - GitHub asset sample kits meant to be copied into other repos
+        - a second copy of upstream framework adoption material unless this instance has explicitly customized it
+
+        ## Where those things live instead
+
+        - upstream template and reusable instantiation assets: [`wlfghdr/agentic-enterprise`]({TEMPLATE_REPO_URL})
+        {extra}- separate product repos stay separate from the governance backbone
+
+        ## Rule of Thumb
+
+        If the artifact is reusable across many companies, it belongs upstream.
+        If the artifact defines or records how this organization is governed, it belongs here.
+        """
+    ).strip()
+
+
+def render_work_tracking(instance_repo: str, backend_type: str, issue_repo: str) -> str:
+    if backend_type == ISSUE_BACKEND:
+        topology_lines = [
+            f"- `{instance_repo}` is the governed operating-model repository.",
+            (
+                f"- `{issue_repo}` is the GitHub issue frontend configured in `CONFIG.yaml`."
+                if issue_repo and issue_repo != instance_repo
+                else "- GitHub Issues in this repository are the operational work frontend."
+            ),
+        ]
+        active_backend = textwrap.dedent(
+            f"""
+            `CONFIG.yaml` currently declares:
+
+            - `work_backend.type: "github-issues"`
+            - `work_backend.github_issues.repo: "{issue_repo if issue_repo else ''}"`
+            - `work_backend.github_issues.use_projects: true`
+
+            That means day-to-day signals, missions, tasks, releases, and retrospectives are tracked as issues, while durable companion artifacts remain in Git here.
+            """
+        ).strip()
+    else:
+        topology_lines = [f"- `{instance_repo}` is both the governance backbone and the work-tracking repository."]
+        active_backend = textwrap.dedent(
+            """
+            `CONFIG.yaml` currently declares:
+
+            - `work_backend.type: "git-files"`
+
+            That means operational work artifacts are tracked directly under `work/`.
+            """
+        ).strip()
+
+    topology_block = "\n".join(topology_lines)
+
+    return textwrap.dedent(
+        f"""
+        # Work Tracking
+
+        {topology_block}
+
+        ## Active Backend Configuration
+
+        {active_backend}
+
+        ## What stays in this repo
+
+        - mission-adjacent technical designs, fleet reports, and outcome reports
+        - governance exceptions and decision records that must stay durable in Git
+        - asset registry entries
+        - locks and validation scripts
+        - the organization model, policies, and operating instructions
+
+        ## Operator Shortcut
+
+        Use [`github-issues.md`](github-issues.md) for the live issue workflow and [`work-backends.md`](work-backends.md) for the backend contract underneath it.
+        """
+    ).strip()
+
+
+def cmd_cleanup_instance(args: argparse.Namespace) -> int:
+    repo_root = Path(args.repo_root).resolve()
+    config = load_config(repo_root)
+    backend = load_work_backend(repo_root)
+    company_name = company_value(config, "name", repo_root.name)
+    repo_slug = company_value(config, "repo_slug", repo_root.name)
+    issue_repo = backend.configured_issue_repo() or repo_slug
+
+    for rel_path in TEMPLATE_ONLY_PATHS:
+        remove_path(repo_root / rel_path, args.dry_run)
+
+    generated_docs = {
+        repo_root / "README.md": render_readme(company_name, repo_slug, backend.type, issue_repo),
+        repo_root / "docs/README.md": render_docs_readme(),
+        repo_root / "docs/repo-scope.md": render_repo_scope(repo_slug, backend.type, issue_repo),
+        repo_root / "docs/work-tracking.md": render_work_tracking(repo_slug, backend.type, issue_repo),
+    }
+
+    for path, content in generated_docs.items():
+        write_text(path, content, args.dry_run)
+
+    return 0
+
+
+def read_asset(repo_root: Path, relative_path: str) -> str:
+    asset_path = repo_root / relative_path
+    if not asset_path.exists():
+        raise SystemExit(
+            f"Required asset not found: {asset_path}\n"
+            "Run this command from a fresh template checkout or before cleanup-instance removes docs/github."
+        )
+    return asset_path.read_text(encoding="utf-8")
+
+
+def write_yaml(path: Path, data: Any, dry_run: bool) -> None:
+    if dry_run:
+        print(f"WOULD WRITE {path}")
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+    print(f"WROTE {path}")
+
+
+def cmd_install_github_work_repo(args: argparse.Namespace) -> int:
+    repo_root = Path(args.repo_root).resolve()
+    load_config(repo_root)  # fail fast if CONFIG.yaml is missing/broken
+    target_dir = Path(args.target_dir).resolve()
+
+    config_template = yaml.safe_load(read_asset(repo_root, ISSUE_FORM_SAMPLES["config.yml"]))
+    contact_links = config_template.get("contact_links") or []
+    if contact_links:
+        contact_links[0]["url"] = f"https://github.com/{args.main_repo}/blob/main/docs/github-issues.md"
+    if len(contact_links) > 1:
+        contact_links[1]["url"] = args.discussion_url or f"https://github.com/{args.main_repo}/discussions"
+
+    write_yaml(target_dir / ".github/ISSUE_TEMPLATE/config.yml", config_template, args.dry_run)
+
+    for target_name, source_rel in ISSUE_FORM_SAMPLES.items():
+        if target_name == "config.yml":
+            continue
+        content = read_asset(repo_root, source_rel)
+        write_text(target_dir / ".github/ISSUE_TEMPLATE" / target_name, content, args.dry_run)
+
+    labels_content = read_asset(repo_root, LABELS_SAMPLE)
+    write_text(target_dir / ".github/labels.sample.yml", labels_content, args.dry_run)
+
+    validate_workflow = read_asset(repo_root, WORKFLOW_SAMPLES["validate-issue-templates.yml"])
+    write_text(
+        target_dir / ".github/workflows/validate-issue-templates.yml",
+        validate_workflow,
+        args.dry_run,
+    )
+
+    if args.include_label_sync:
+        sync_workflow = read_asset(repo_root, WORKFLOW_SAMPLES["sync-issue-form-labels.yml"])
+        write_text(
+            target_dir / ".github/workflows/sync-issue-form-labels.yml",
+            sync_workflow,
+            args.dry_run,
+        )
+
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        default=str(DEFAULT_REPO_ROOT),
+        help="Path to the framework checkout or freshly forked instance repo",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Print actions without writing files")
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    cleanup = subparsers.add_parser(
+        "cleanup-instance",
+        help="Remove template-only assets and rewrite top-level instance docs",
+    )
+    cleanup.set_defaults(func=cmd_cleanup_instance)
+
+    install = subparsers.add_parser(
+        "install-github-work-repo",
+        help="Copy issue-backend assets into the repo that will host operational issues",
+    )
+    install.add_argument(
+        "--target-dir",
+        required=True,
+        help="Path to the repo that should receive the GitHub issue-backend assets",
+    )
+    install.add_argument(
+        "--main-repo",
+        required=True,
+        help="owner/name of the main operating-model repo whose docs the forms should link to",
+    )
+    install.add_argument(
+        "--discussion-url",
+        default="",
+        help="Optional GitHub Discussions URL for the issue-template config",
+    )
+    install.add_argument(
+        "--include-label-sync",
+        action="store_true",
+        help="Also install the optional workflow that maps issue-form answers to labels",
+    )
+    install.set_defaults(func=cmd_install_github_work_repo)
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add `scripts/instantiate_instance.py` to automate two high-friction instantiation steps: GitHub work-repo asset installation and post-fork cleanup of template-only assets
- update the customization, file-guide, GitHub setup, and required-settings docs to make the scripted path the recommended path
- explicitly document the cleanup step so live instances stop carrying template/demo/instantiation material after setup

## What To Review
- Does the new `instantiate_instance.py` cover the intended instance-cleanup and GitHub issue-backend bootstrap flow without overreaching?
- Do the doc changes now make the safe instantiation sequence clearer than the previous copy-and-manually-delete guidance?
- Are the generated instance-facing docs and cleanup targets the right default set for a real company instance?

## Validation
- `PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m py_compile scripts/instantiate_instance.py`
- `python3 scripts/instantiate_instance.py --dry-run cleanup-instance`
- `python3 scripts/instantiate_instance.py --dry-run install-github-work-repo --main-repo acme/acme-operating --target-dir /tmp/ae-work --include-label-sync`
- `python3 scripts/validate_cross_references.py`
