### PR TITLE
docs: tighten GitHub PR governance and OpenClaw bootstrap guidance

### DIFF
--- a/docs/customization-guide.md
+++ b/docs/customization-guide.md
@@ -77,6 +77,20 @@ For the shortest template-instantiation path, use [docs/github/setup-checklist.m
 
 > **Note:** Governance backbone files (org structure, policies, agent instructions, templates) always stay in Git regardless of this choice.
 
+
+### Step 4b: If You Run OpenClaw, Bootstrap The Instance Fleet
+
+Do not treat the repo instantiation as complete until the runtime shape is also defined.
+
+Minimum expectations for an OpenClaw-based instance:
+- define a minimal role-first fleet (for example: steering, strategy, orchestration, execution, quality)
+- document the routing policy (subscription-first, then fallback provider subscription, then API fallback)
+- make each running agent use the **instance repo** as its workspace rather than a generic shared workspace
+- create per-agent `agentDir` locations with the credentials/config they actually need
+- document Discord/channel bindings separately from the generic repo bootstrap, because channel IDs remain environment-specific
+
+Use [`docs/runtimes/openclaw.md`](runtimes/openclaw.md) for the runtime-specific guidance.
+
 ### Step 5: Register Your Integrations (5 min)
 
 Review `CONFIG.yaml → integrations` and register the external tools your organization uses:

--- a/docs/github/README.md
+++ b/docs/github/README.md
@@ -18,6 +18,8 @@ The preferred installation path is scripted:
 python3 scripts/instantiate_instance.py install-github-work-repo \
   --main-repo your-org/your-instance \
   --target-dir ../your-instance-work
+
+python3 scripts/instantiate_instance.py install-pr-automation
 ```
 
 ---

--- a/docs/github/setup-checklist.md
+++ b/docs/github/setup-checklist.md
@@ -89,6 +89,38 @@ Optional but recommended:
 
 ---
 
+
+## 3b. Install PR Automation
+
+Before agents start opening PRs in the instance repo, install the governed PR automation assets:
+
+```bash
+python3 scripts/instantiate_instance.py install-pr-automation
+```
+
+This adds:
+- auto-merge workflow support
+- issue-link validation for PR bodies
+- PR template help text for linked issues
+
+### Required PR behavior
+
+For governed repo work:
+- use PRs rather than direct pushes to protected branches
+- enable auto-merge when the PR is reviewable and checks are green
+- use real closing keywords in the PR description:
+  - `Closes owner/repo#123`
+  - `Fixes owner/repo#123`
+  - `Resolves owner/repo#123`
+- do **not** rely on `Addresses` if the issue should auto-close on merge
+
+### Dependabot
+
+Treat routine Dependabot PRs as agent-owned operating work by default. Humans should only be interrupted when:
+- CI is not green
+- the change looks breaking or policy-sensitive
+- the repo's risk posture requires explicit human review
+
 ## 4. Enable GitHub Features
 
 In the issue-hosting repository:

--- a/docs/required-github-settings.md
+++ b/docs/required-github-settings.md
@@ -66,6 +66,22 @@ Recommended minimum rule for `main`:
 
 ---
 
+
+## 3b) PR governance defaults
+
+For repos where agents are expected to operate continuously:
+
+- enable GitHub Auto-merge if your plan supports it
+- require PR-based changes to protected branches
+- treat issue-linking as a governed requirement, not a nice-to-have
+
+PR descriptions should use real closing keywords when work is meant to auto-close issues:
+- `closes #123`
+- `fixes owner/repo#123`
+- `resolves owner/repo#123`
+
+`Addresses` is useful as context, but it is not sufficient for automatic closure.
+
 ## 4) CODEOWNERS must exist and be meaningful
 
 - Keep `CODEOWNERS` current.

--- a/docs/runtimes/openclaw.md
+++ b/docs/runtimes/openclaw.md
@@ -83,6 +83,24 @@ If you choose this, **keep it internal** (operator docs) and avoid scattering mo
 
 ---
 
+
+## Instance Bootstrap Checklist
+
+When you instantiate a company fork, the repo is only half the job. For an OpenClaw-based deployment, make the runtime bootstrap explicit too:
+
+1. **Pick the minimal fleet first** — usually one agent per active layer.
+2. **Keep routing role-first** — define the agent role, then map it to a subscription-first provider order.
+3. **Use the instance repo as workspace** — instance agents should work in the instantiated company repo, not a generic catch-all workspace.
+4. **Create per-agent `agentDir` state intentionally** — credentials and provider profiles are scoped there. Do not assume one configured agent automatically configures another.
+5. **Document channel bindings as environment data** — keep channel IDs in an operator-facing config artifact; do not hard-code unknown IDs into generic docs.
+6. **Separate generic products from the instance** — if the instance depends on another product repo, reference it; do not embed it into the instance tree.
+
+A practical operator artifact set is:
+- a fleet intent document in the repo
+- a routing target document with placeholder channel IDs
+- per-agent OpenClaw directories on the host
+- a reviewed `openclaw.json` entry per running agent
+
 ## Heartbeat Strategy
 
 Heartbeats are periodic wake-ups. They should **batch** small checks and either:


### PR DESCRIPTION
## Summary
- tighten GitHub setup guidance for auto-merge, closing keywords, and Dependabot handling
- make OpenClaw instance bootstrap expectations explicit in onboarding docs
- connect the scripted install path to PR-governance setup

## Why
The template should make two things explicit for adopters:
1. governed PR lifecycle hygiene (`Closes/Fixes/Resolves`, auto-merge, agent-owned Dependabot)
2. OpenClaw instance bootstrap expectations beyond just repo scaffolding

## Linked Issues
Closes #196
Closes #197
