### PR TITLE
docs: tighten continuity audit and assignment guidance

### DIFF
--- a/docs/automation-and-work-continuity.md
+++ b/docs/automation-and-work-continuity.md
@@ -37,6 +37,21 @@ A compact continuity pass should review:
 
 The pass should prefer one compact sweep over many tiny loops.
 
+## Compact Audit Checklist
+
+A continuity or hygiene pass should explicitly answer these questions for each active work chain:
+
+1. **Ownership present** — is every open issue and PR assigned to a named human or agent identity?
+2. **Artifact linkage present** — can we trace the chain across the relevant artifacts and product work?
+3. **Automation scope present** — do the configured recurring passes actually include the repo and item type?
+4. **Executable without hidden context** — can the next owner act from the artifact and linked references alone?
+
+If any answer is "no", treat that as open work:
+- assign the item
+- add or repair the missing links
+- expand automation scope if intended
+- or escalate to a human instead of pretending the loop is healthy
+
 ## Self-Assignment Defaults
 
 Use self-assignment only when all of the following are true:

--- a/docs/customization-guide.md
+++ b/docs/customization-guide.md
@@ -104,7 +104,7 @@ See `org/integrations/` for detailed guides per category. Start with observabili
 
 ### Step 6: Start Using It (5 min)
 
-Before switching on recurring automation, read [automation-and-work-continuity.md](automation-and-work-continuity.md). It defines continuity expectations, approval boundaries, self-assignment defaults, and backoff rules.
+Before switching on recurring automation, read [automation-and-work-continuity.md](automation-and-work-continuity.md). It defines continuity expectations, approval boundaries, self-assignment defaults, the no-unassigned rule for open GitHub work, the automation pickup audit checklist, and backoff rules.
 
 
 **Git-files backend:** Create your first signal in `work/signals/` and you're live.


### PR DESCRIPTION
## Summary
- add a compact continuity audit checklist covering ownership, linkage, automation scope, and hidden-context risk
- call out the no-unassigned rule and pickup audit in the customization guide

## Testing
- docs-only change; no runtime checks

Closes wlfghdr/agentic-enterprise#201
Closes wlfghdr/agentic-enterprise#202