### PR TITLE
docs: add audit role and label governance guidance

### DIFF
--- a/docs/customization-guide.md
+++ b/docs/customization-guide.md
@@ -91,6 +91,20 @@ Minimum expectations for an OpenClaw-based instance:
 
 Use [`docs/runtimes/openclaw.md`](runtimes/openclaw.md) for the runtime-specific guidance.
 
+
+### Step 4c: Add A Lightweight Audit Function
+
+A realistic enterprise instance should include a lightweight internal audit role from the start.
+
+This role is not only for compliance. Its job is to verify that the operating model actually functions in practice:
+- work artifacts are linked coherently
+- ownership is explicit
+- repo work is synced and not stranded locally
+- automation loops can actually pick up the work they are expected to handle
+- local adoption friction becomes upstream product improvement
+
+In a minimal fleet, this can begin as an **internal auditor** role and later split into more specialized auditors (workflow, repo hygiene, compliance, evidence, adoption).
+
 ### Step 5: Register Your Integrations (5 min)
 
 Review `CONFIG.yaml → integrations` and register the external tools your organization uses:

--- a/docs/github/README.md
+++ b/docs/github/README.md
@@ -139,3 +139,18 @@ Scripts in `scripts/` work with both git-files and github-issues backends:
 | `archive_runs.sh` | Monthly run log rotation | git-files only |
 
 Scripts that are backend-aware use `work_backend.py` to read from the correct source (Issues or git files) based on `CONFIG.yaml`.
+
+## Label discipline
+
+Use labels for semantics that GitHub does **not** model natively well, such as:
+- artifact type
+- dispatch/agent fit
+- scope/product boundary
+- approval-needed semantics
+
+Do **not** recreate native GitHub state with redundant labels when the platform already models it:
+- issue open/closed
+- PR open/draft/merged/closed
+- assignee / reviewer ownership
+
+A practical work repo should also have a lightweight label baseline available immediately after initialization.

--- a/docs/runtimes/openclaw.md
+++ b/docs/runtimes/openclaw.md
@@ -161,6 +161,20 @@ Keep cron conservative:
 ---
 
 
+
+## Default Audit Role
+
+For real adoption, consider an **internal auditor** a default part of the instance fleet.
+
+This role checks:
+- work-flow integrity
+- ownership integrity
+- repo sync hygiene
+- automation pickup coverage
+- whether local findings are translated into upstream improvements
+
+This role sits close to the broader observability/control story: not only runtime telemetry, but whether the operating system of work is actually functioning.
+
 ## Discord Channel Setup For Instance Fleets
 
 When an instance uses Discord with OpenClaw, keep the human-facing topology role-first and environment-specific.


### PR DESCRIPTION
## Summary
- add default internal audit role guidance for enterprise instances
- define labels as complements to native GitHub state, not replacements
- connect the audit role to the broader observability and adoption feedback story

## Linked Issues
Closes #205
Closes #206
