### PR TITLE
docs: require PR ownership and reviewer routing

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,13 @@
 
 Closes #
 
+## Ownership and review routing
+
+- Assignee / owner for next step: @
+- Requested reviewer(s): @
+- Reviewer focus:
+- Reviewer options: Approve / Request changes / Comment
+
 ## Type of change
 
 - [ ] Bug fix (broken link, YAML error, inconsistency)

--- a/docs/automation-and-work-continuity.md
+++ b/docs/automation-and-work-continuity.md
@@ -34,6 +34,7 @@ A compact continuity pass should review:
 3. active or blocked missions
 4. open tasks under active missions
 5. referenced product-repo issues that belong to those missions
+6. PR ownership and reviewer routing gaps (missing assignee, missing reviewer request, or unclear merge handoff)
 
 The pass should prefer one compact sweep over many tiny loops.
 
@@ -42,9 +43,10 @@ The pass should prefer one compact sweep over many tiny loops.
 A continuity or hygiene pass should explicitly answer these questions for each active work chain:
 
 1. **Ownership present** — is every open issue and PR assigned to a named human or agent identity?
-2. **Artifact linkage present** — can we trace the chain across the relevant artifacts and product work?
-3. **Automation scope present** — do the configured recurring passes actually include the repo and item type?
-4. **Executable without hidden context** — can the next owner act from the artifact and linked references alone?
+2. **Reviewer path present** — does every open PR that needs human action have explicit reviewer request(s) or a named merge owner?
+3. **Artifact linkage present** — can we trace the chain across the relevant artifacts and product work?
+4. **Automation scope present** — do the configured recurring passes actually include the repo and item type?
+5. **Executable without hidden context** — can the next owner act from the artifact and linked references alone?
 
 If any answer is "no", treat that as open work:
 - assign the item

--- a/docs/required-github-settings.md
+++ b/docs/required-github-settings.md
@@ -74,6 +74,13 @@ For repos where agents are expected to operate continuously:
 - enable GitHub Auto-merge if your plan supports it
 - require PR-based changes to protected branches
 - treat issue-linking as a governed requirement, not a nice-to-have
+- treat PR assignees and reviewer requests as required operating metadata, not optional hygiene
+
+Minimum PR discipline:
+- every open PR has a named assignee who owns the next step
+- every PR that needs human approval has explicit reviewer request(s)
+- the PR body tells reviewers what to focus on and what actions they can take
+- PRs waiting on a human should be visible in that human's queue via review requests and/or assignee handoff
 
 PR descriptions should use real closing keywords when work is meant to auto-close issues:
 - `closes #123`

--- a/docs/work-backends.md
+++ b/docs/work-backends.md
@@ -311,6 +311,11 @@ When `use_projects: true` (recommended), create a GitHub Project v2 with a **Sta
 | PR approved, ready to merge | The person who will merge (human or agent if permitted) | — | Clean handoff to final step |
 | PR is blocked or has failing checks | Agent bot account | — | Agent must investigate and fix |
 
+A PR without both an owner path and a reviewer path is operationally incomplete. The minimum acceptable state is:
+- a named assignee who owns the next step
+- explicit reviewer request(s) when human review is required
+- a PR description that tells reviewers what to review and what they can do next
+
 ### Handoff Protocol — Issues
 
 **Core principle:** Humans never need to touch labels or project status fields. They comment and re-assign. Agents handle all label and project status management.


### PR DESCRIPTION
## What does this PR do?

Adds explicit PR ownership/reviewer-routing guidance to the framework's GitHub governance docs and PR template so open PRs cannot sit without a clear owner path or reviewer path.

Closes #204

## Ownership and review routing

- Assignee / owner for next step: @WulfAI
- Requested reviewer(s): @wlfghdr
- Reviewer focus: confirm the governance rule is clear, minimal, and matches the intended continuity/audit behavior
- Reviewer options: Approve / Request changes / Comment

## Type of change

- [ ] Bug fix (broken link, YAML error, inconsistency)
- [x] Framework improvement (layers, loops, model)
- [ ] Template / policy update
- [ ] Agent instructions
- [x] Docs / examples

## Checklist

- [x] YAML files parse without errors
- [x] No unfilled placeholders in non-template files (`{{VAR}}`, `[TODO]`, `[TBD]`, `T.B.D.`, `Coming Soon`, etc.) — **CI blocks on violations** (see `docs/placeholder-check.md`)
- [x] This is a framework change, not a company-specific customization
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
