### PR TITLE
docs: make human handoffs and Discord provisioning explicit

### DIFF
--- a/docs/automation-and-work-continuity.md
+++ b/docs/automation-and-work-continuity.md
@@ -72,6 +72,20 @@ Do **not** self-assign when:
 - scope changes strategy, roadmap, architecture, security posture, or spend
 - the work would look like an implicit human decision
 
+## Human-Needed Work Must Be Explicit
+
+If a task, mission, review, or product issue needs a human action or decision, do not leave that implicit.
+
+When human action is required:
+- assign the item explicitly when the repo permits it
+- or update the corresponding work artifact so it clearly states:
+  - what decision or action is needed
+  - why it is needed now
+  - what options exist
+  - what the recommended next step is
+
+This applies to approvals, review handoffs, missing configuration, runtime setup, and any other dependency the automation cannot honestly complete alone.
+
 ## Approval Boundaries
 
 Agents may continue execution inside already-approved scope.

--- a/docs/customization-guide.md
+++ b/docs/customization-guide.md
@@ -90,6 +90,7 @@ Minimum expectations for an OpenClaw-based instance:
 - document the routing policy (subscription-first, then fallback provider subscription, then API fallback)
 - make each running agent use the **instance repo** as its workspace rather than a generic shared workspace
 - create per-agent `agentDir` locations with the credentials/config they actually need
+- define an auditable Discord admin/provisioning path for categories/channels and binding capture
 - document Discord/channel bindings separately from the generic repo bootstrap, because channel IDs remain environment-specific
 
 Use [`docs/runtimes/openclaw.md`](runtimes/openclaw.md) for the runtime-specific guidance.

--- a/docs/runtimes/openclaw-onboarding.md
+++ b/docs/runtimes/openclaw-onboarding.md
@@ -70,6 +70,23 @@ Example minimal channel set:
 - `<instance>-auditor`
 - optional: `<instance>-research`, `<instance>-content`
 
+## Discord admin / provisioning path
+
+Treat Discord provisioning as a first-class onboarding step, not an undocumented manual side quest.
+
+The runtime/bootstrap path should support at least:
+- create category
+- create channel
+- list existing channels
+- return resulting channel IDs for runtime bindings
+- optionally apply permission overwrites
+
+Operational rules:
+- keep the provisioning path auditable
+- store environment-specific channel IDs in the runtime binding artifact, not buried in prose
+- separate generic topology guidance from instance-specific IDs
+- if channel creation still requires a human, make that handoff explicit with the exact channels/categories to create
+
 ## Labels
 
 Install a practical minimum label baseline in the work repo.


### PR DESCRIPTION
## Summary
- add an explicit rule for human-needed work in continuity guidance
- add a first-class Discord admin/provisioning path to OpenClaw onboarding
- reflect the provisioning expectation in the customization guide

## Validation
- `python3 scripts/check_placeholders.py`
- `git diff --check`

Closes wlfghdr/agentic-enterprise#213
Closes wlfghdr/agentic-enterprise#214
Refs WulfAI/sagicorp-work#40
Refs WulfAI/sagicorp-work#37