### PR TITLE
Add governed knowledge manifests to the framework

### DIFF
--- a/CONFIG.yaml
+++ b/CONFIG.yaml
@@ -192,6 +192,17 @@ toolchain:
   chat_tool: ""                     # e.g., "Slack", "Teams", "Discord"
 
 # ───────────────────────────────────────────────────────────────────────────
+# 7b. KNOWLEDGE GOVERNANCE
+# ───────────────────────────────────────────────────────────────────────────
+# Optional configuration for how your enterprise layers and reviews governed
+# knowledge sources. Use this when adopting org/knowledge manifests.
+
+knowledge:
+  enabled: false
+  default_review_cadence: "quarterly"   # per-change | weekly | monthly | quarterly | semiannual | annual
+  registry_path: "org/knowledge"
+
+# ───────────────────────────────────────────────────────────────────────────
 # 8. WORK BACKEND (Where operational work artifacts are tracked)
 # ───────────────────────────────────────────────────────────────────────────
 # The operating model defines WHAT artifacts exist (signals, missions, tasks,

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Keep these terms separate:
 - **Demo / reference scenario:** the public proof assets in [`index.html`](index.html) and [`concept-visualization.html`](concept-visualization.html)
 - **Runtime:** your agent platform of choice
 - **Observability:** your OpenTelemetry-native evidence layer
+- **Knowledge:** governed knowledge manifests define what agents may rely on, who owns it, and how fresh it must be
 - **Adoption:** start with Git, CODEOWNERS, signals, missions, and PRs; add agents later if you want
 
 The repo is the governance backbone. You bring the runtime, observability platform, and domain systems that actually execute business operations. The framework stays runtime-agnostic.
@@ -217,7 +218,7 @@ agentic-enterprise/
 ├── CONFIG.yaml              ← Central config (fill FIRST)
 ├── AGENTS.md                ← Global agent instructions
 ├── CODEOWNERS               ← RACI — who approves what
-├── org/                     ← 5-layer org structure + 17 divisions + 19 policies
+├── org/                     ← 5-layer org structure + agent/skill/knowledge registries
 ├── process/                 ← 4-loop lifecycle definitions
 ├── work/                    ← Active signals, missions, decisions, releases
 ├── docs/                    ← Quickstart, architecture, adoption, observability, compliance

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # docs/ — Operator Guides & Reference Documentation
 <!-- placeholder-ok -->
 
-> This folder contains operator guides and reference documentation for the Agentic Enterprise framework.
+> This folder contains operator guides and reference documentation for the Agentic Enterprise framework. Knowledge governance lives in `org/knowledge/`; docs remain the reference surface that knowledge manifests may point at.
 > For the framework overview, start with [`org/README.md`](../org/README.md) (organizational structure) and [`process/README.md`](../process/README.md) (process lifecycle).
 > For initial setup, start with [`customization-guide.md`](customization-guide.md).
 

--- a/org/README.md
+++ b/org/README.md
@@ -63,10 +63,11 @@ The critical addition — Layer 0: Steering — embeds what was historically inv
 | Term | Definition |
 |------|-----------|
 | **Division** | Persistent group of agents organized by expertise — the agentic equivalent of a department. Owns skills, standards, and institutional knowledge. |
+| **Knowledge manifest** | Governed record of what agents know: source paths, scope, freshness, and ownership. |
 | **Fleet** | Full pool of agents available to Orchestration. Total capacity across all divisions. |
 | **Crew** | Subset of agents drawn from the fleet for a specific mission. Assembled at mission start, disbanded at end. |
 
-Divisions define *what agents know*. The fleet is *who is available*. A crew is *who works on this mission now*.
+Divisions define *where expertise lives*. Knowledge manifests define *what agents know and how that knowledge is governed*. The fleet is *who is available*. A crew is *who works on this mission now*.
 
 ---
 
@@ -220,6 +221,9 @@ org/
 │   ├── orchestration/           ← Orchestration layer agent type definitions
 │   ├── execution/               ← Execution layer agent type definitions
 │   └── quality/                 ← Quality layer agent type definitions
+├── knowledge/                   ← Knowledge manifest registry (what agents know)
+│   ├── README.md                ← Layering model, lifecycle, and indexing guidance
+│   └── *.knowledge.json         ← Governed knowledge manifests with freshness + ownership
 ├── 0-steering/
 │   ├── AGENT.md                 ← Instructions for steering-layer agents
 │   └── EVOLUTION.md             ← How the company continuously evolves itself

--- a/org/capability-contracts/README.md
+++ b/org/capability-contracts/README.md
@@ -1,6 +1,6 @@
 # Capability Contracts Registry
 
-A **capability contract** is a versioned, approved record binding an agent type to specific skills and MCP profiles.
+A **capability contract** is a versioned, approved record binding an agent type to specific skills, MCP profiles, and knowledge sources.
 
 ## Schema
 
@@ -17,7 +17,7 @@ Example: `execution-builder.contract.json`
 ## Lifecycle
 
 1. Propose a new or updated contract via PR.
-2. Changes to any `mcp_profiles` entry or permission upgrade require **human approval** before merge.
+2. Changes to any `mcp_profiles` entry, knowledge scope expansion, or permission upgrade require **human approval** before merge.
 3. On approval and merge, the contract becomes active.
 4. Previous contract versions are preserved in `changelog`.
 5. Contracts must be reviewed on expiry or when the agent type's scope changes.

--- a/org/capability-contracts/execution-builder.contract.json
+++ b/org/capability-contracts/execution-builder.contract.json
@@ -19,6 +19,14 @@
       ]
     }
   ],
+  "knowledge_sources": [
+    {
+      "knowledge_id": "org-governance",
+      "version": "1.0.0",
+      "required": true,
+      "notes": "Shared governance baseline for all framework-aligned agent types."
+    }
+  ],
   "approved_by": "CTO",
   "review_required_by": "CTO",
   "changelog": [

--- a/org/capability-contracts/quality-pr-reviewer.contract.json
+++ b/org/capability-contracts/quality-pr-reviewer.contract.json
@@ -21,6 +21,14 @@
       ]
     }
   ],
+  "knowledge_sources": [
+    {
+      "knowledge_id": "org-governance",
+      "version": "1.0.0",
+      "required": true,
+      "notes": "Shared governance baseline for all framework-aligned agent types."
+    }
+  ],
   "approved_by": "CTO",
   "review_required_by": "CTO",
   "changelog": [

--- a/org/knowledge/README.md
+++ b/org/knowledge/README.md
@@ -1,0 +1,41 @@
+# Knowledge Manifests Registry
+
+> **Last updated:** 2026-03-23
+
+This directory is the governed registry of **what agents know**.
+
+Skill manifests govern reusable process instructions. MCP profiles govern tool access. **Knowledge manifests govern the sources, freshness, and ownership of context agents may rely on.**
+
+## Schema
+
+All manifests must conform to [`schemas/knowledge-manifest.schema.json`](../../schemas/knowledge-manifest.schema.json).
+
+## Naming Convention
+
+```
+<knowledge-id>.knowledge.json
+```
+
+Example: `org-governance.knowledge.json`
+
+## Layer Model
+
+| Layer | Scope | Typical examples |
+|---|---|---|
+| **1** | org-wide | standards, security baselines, shared vocabulary |
+| **2** | capability/domain | platform engineering playbooks, sales domain guidance |
+| **3** | product | product workflows, troubleshooting surfaces, integration behavior |
+| **4** | repo | AGENTS.md, ADRs, build/deploy specifics |
+
+## Lifecycle
+
+1. Propose or update a manifest via PR.
+2. Name the source paths, owners, and freshness expectations explicitly.
+3. Reference the manifest from capability contracts when an agent type depends on that knowledge.
+4. Review and refresh on the declared cadence.
+
+## Index
+
+| Knowledge ID | Layer | Version | Purpose |
+|---|---:|---|---|
+| `org-governance` | 1 | 1.0.0 | Shared governance, process, and policy knowledge shipped with the framework |

--- a/org/knowledge/org-governance.knowledge.json
+++ b/org/knowledge/org-governance.knowledge.json
@@ -1,0 +1,53 @@
+{
+  "schema_version": "1.0",
+  "knowledge_id": "org-governance",
+  "version": "1.0.0",
+  "title": "Shared governance and process knowledge",
+  "description": "Framework-wide guidance that agents should treat as reusable governance context.",
+  "layer": 1,
+  "scope": "org-wide",
+  "status": "active",
+  "owners": [
+    {
+      "role": "Steering Layer",
+      "team": "framework-maintainers"
+    }
+  ],
+  "sources": [
+    {
+      "kind": "repo-glob",
+      "path": "org/**/*.md",
+      "notes": "Governed layer instructions, registry docs, and policy surfaces."
+    },
+    {
+      "kind": "repo-glob",
+      "path": "process/**/*.md",
+      "notes": "Shared operating-loop and lifecycle guidance."
+    },
+    {
+      "kind": "repo-glob",
+      "path": "docs/**/*.md",
+      "notes": "Operator and reference guidance when promoted into reusable framework knowledge."
+    }
+  ],
+  "freshness": {
+    "review_cadence": "quarterly",
+    "max_age_days": 120,
+    "owner": "framework-maintainers",
+    "last_reviewed": "2026-03-23"
+  },
+  "discovery": {
+    "tags": ["governance", "policies", "process", "framework"],
+    "audiences": ["all-agent-types"]
+  },
+  "usage_constraints": [
+    "Repo-local implementation details should stay in layer-4 knowledge manifests instead of being copied here."
+  ],
+  "change_log": [
+    {
+      "version": "1.0.0",
+      "date": "2026-03-23",
+      "change": "Initial org-wide knowledge manifest example."
+    }
+  ]
+}

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -31,5 +31,6 @@ Three new schemas support the skills/tools/MCP profiles system:
 | `skill-manifest.schema.json` | `org/skills/*.skill.json` | Declarative skill manifests |
 | `mcp-profile.schema.json` | `org/mcp-profiles/*.mcp-profile.json` | MCP server permission matrices |
 | `capability-contract.schema.json` | `org/capability-contracts/*.contract.json` | Versioned capability contracts per agent type |
+| `knowledge-manifest.schema.json` | `org/knowledge/*.knowledge.json` | Governed knowledge sources, ownership, and freshness |
 
 See [docs/capability-contracts.md](../docs/capability-contracts.md) for the full design.

--- a/schemas/capability-contract.schema.json
+++ b/schemas/capability-contract.schema.json
@@ -2,16 +2,27 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://github.com/wlfghdr/agentic-enterprise/schemas/capability-contract.schema.json",
   "title": "Agent Capability Contract",
-  "description": "Versioned capability contract for an agent type. Binds an agent type to a specific set of skills and MCP profiles, forming an auditable capability record.",
+  "description": "Versioned capability contract for an agent type. Binds an agent type to a specific set of skills, MCP profiles, and knowledge sources, forming an auditable capability record.",
   "type": "object",
   "required": ["schema_version", "agent_type_id", "contract_version", "effective_date", "skills", "mcp_profiles", "approved_by"],
   "additionalProperties": false,
   "properties": {
     "schema_version": { "type": "string", "enum": ["1.0"] },
-    "agent_type_id": { "type": "string", "description": "Agent type this contract applies to (matches agent type registry ID)." },
-    "contract_version": { "type": "string", "pattern": "^\\d+\\.\\d+\\.\\d+$", "description": "Version of this contract. Increment on any permission change." },
+    "agent_type_id": {
+      "type": "string",
+      "description": "Agent type this contract applies to (matches agent type registry ID)."
+    },
+    "contract_version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$",
+      "description": "Version of this contract. Increment on any permission or governed-knowledge change."
+    },
     "effective_date": { "type": "string", "format": "date" },
-    "expiry_date": { "type": "string", "format": "date", "description": "Optional. Contract must be renewed before this date." },
+    "expiry_date": {
+      "type": "string",
+      "format": "date",
+      "description": "Optional. Contract must be renewed before this date."
+    },
     "status": { "type": "string", "enum": ["draft", "active", "superseded", "revoked"] },
     "skills": {
       "type": "array",
@@ -51,6 +62,24 @@
               }
             }
           }
+        }
+      }
+    },
+    "knowledge_sources": {
+      "type": "array",
+      "description": "Governed knowledge manifests this agent type may rely on.",
+      "items": {
+        "type": "object",
+        "required": ["knowledge_id", "version"],
+        "additionalProperties": false,
+        "properties": {
+          "knowledge_id": { "type": "string" },
+          "version": { "type": "string" },
+          "required": {
+            "type": "boolean",
+            "description": "Whether the agent type is expected to load this source by default."
+          },
+          "notes": { "type": "string" }
         }
       }
     },

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -123,6 +123,18 @@
       "type": "string",
       "description": "Primary product or offering name."
     },
+    "knowledge": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "default_review_cadence": {
+          "type": "string",
+          "enum": ["per-change", "weekly", "monthly", "quarterly", "semiannual", "annual"]
+        },
+        "registry_path": { "type": "string" }
+      }
+    },
     "work_backend": {
       "type": "object",
       "description": "Where operational work artifacts are tracked. See docs/work-backends.md.",

--- a/schemas/knowledge-manifest.schema.json
+++ b/schemas/knowledge-manifest.schema.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/wlfghdr/agentic-enterprise/schemas/knowledge-manifest.schema.json",
+  "title": "Knowledge Manifest",
+  "description": "Versioned manifest for governed knowledge sources that agents may rely on.",
+  "type": "object",
+  "required": ["schema_version", "knowledge_id", "version", "title", "layer", "scope", "owners", "sources", "freshness"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": { "type": "string", "enum": ["1.0"] },
+    "knowledge_id": { "type": "string", "pattern": "^[a-z0-9-]+$" },
+    "version": { "type": "string", "pattern": "^\\d+\\.\\d+\\.\\d+$" },
+    "title": { "type": "string", "minLength": 1 },
+    "description": { "type": "string" },
+    "layer": { "type": "integer", "enum": [1, 2, 3, 4], "description": "Knowledge layering tier: 1 org-wide, 2 capability/domain, 3 product surface, 4 repo-local." },
+    "scope": { "type": "string", "enum": ["org-wide", "capability", "product", "repo"] },
+    "status": { "type": "string", "enum": ["draft", "active", "deprecated", "retired"] },
+    "owners": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["role"],
+        "additionalProperties": false,
+        "properties": {
+          "role": { "type": "string" },
+          "team": { "type": "string" },
+          "contact": { "type": "string" }
+        }
+      }
+    },
+    "sources": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["kind", "path"],
+        "additionalProperties": false,
+        "properties": {
+          "kind": { "type": "string", "enum": ["repo-path", "repo-glob", "external-url", "generated-artifact"] },
+          "path": { "type": "string" },
+          "notes": { "type": "string" }
+        }
+      }
+    },
+    "freshness": {
+      "type": "object",
+      "required": ["review_cadence", "owner"],
+      "additionalProperties": false,
+      "properties": {
+        "review_cadence": { "type": "string", "enum": ["per-change", "weekly", "monthly", "quarterly", "semiannual", "annual"] },
+        "max_age_days": { "type": "integer", "minimum": 1 },
+        "owner": { "type": "string" },
+        "last_reviewed": { "type": "string", "format": "date" }
+      }
+    },
+    "discovery": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "tags": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "audiences": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "depends_on": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "usage_constraints": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "change_log": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["version", "date", "change"],
+        "additionalProperties": false,
+        "properties": {
+          "version": { "type": "string" },
+          "date": { "type": "string", "format": "date" },
+          "change": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/scripts/validate_schema.py
+++ b/scripts/validate_schema.py
@@ -353,6 +353,12 @@ def main() -> int:
         all_errors.extend(errs)
         all_ok.extend(oks)
 
+        # ── 8. Knowledge manifests ────────────────────────────────────────
+        knowledge_schema_path = REPO / "schemas" / "knowledge-manifest.schema.json"
+        errs, oks = validate_json_artifacts(knowledge_schema_path, "org/knowledge/*.knowledge.json")
+        all_errors.extend(errs)
+        all_ok.extend(oks)
+
     # ── Report ──────────────────────────────────────────────────────────────
     for ok in all_ok:
         print(f"  ✓  {ok}")


### PR DESCRIPTION
## Summary
- add a knowledge manifest schema and initial org/knowledge registry
- extend capability contracts and CONFIG guidance to reference governed knowledge sources
- validate knowledge manifests in the schema validation script

## Testing
- python3 scripts/validate_schema.py
- python3 scripts/validate_cross_references.py

Closes wlfghdr/agentic-enterprise#187