### PR TITLE
docs: make assignee state authoritative for handoffs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Agent Instructions (Global)
 
-> **Version:** 4.0 | **Last updated:** 2026-03-15
+> **Version:** 4.1 | **Last updated:** 2026-03-23
 
 Every AI agent in this repository must follow these instructions. Layer-specific and division-specific instructions extend (never contradict) these rules.
 
@@ -32,8 +32,8 @@ Never commit scope, timelines, resources, or strategic direction. Draft, analyze
 ### 3. Process is governed
 - Work tracked in the **configured work backend** — Markdown in `work/` or issues in the tracker (`CONFIG.yaml → work_backend`, see [docs/work-backends.md](docs/work-backends.md))
 - **Git-files:** Changes → PRs → merges. **Issues:** State transitions + human comments. Governance backbone (org structure, policies, templates) always in Git.
-- **Assignment:** Every issue/PR must have an assignee at all times. Agent-owned → agent. Human-owned → human. Never unassigned.
-- **Handoffs:** Re-assign to human with comment: (a) what was done, (b) what to review, (c) options (approve/reject/request changes). Human comments decision and re-assigns back.
+- **Assignment:** Every issue/PR must have an assignee at all times. Agent-owned → agent. Human-owned → human. Never unassigned. Assignee state is the source of truth for who must act next; do not leave human-needed work assigned to an agent or hide the handoff only in comments/body text.
+- **Handoffs:** Re-assign to human with comment: (a) what was done, (b) what to review, (c) options (approve/reject/request changes). Human comments decision and re-assigns back. Comments explain the handoff; assignment makes the required next actor explicit.
 - **PRs:** Request reviews from CODEOWNERS. Description explains what to review and reviewer's options.
 - **PR issue linking:** PRs MUST link to originating issues using `closes #NNN` or `fixes #NNN` syntax in the PR description. Issue references ensure automatic closure upon PR merge.
 - **Auto-merge:** PRs SHOULD be created with auto-merge enabled when all required checks pass.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ The framework uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html): `
 - `docs/runtimes/builder-fleet-pattern.md` — execution-layer reference for the builder fleet pattern: orchestrator → builder → checker → verifier role separation, wave-based execution, file-backed state, runtime-agnostic design. GSD referenced as existence proof without prescribing adoption.
 - `docs/runtimes/README.md` — added builder fleet pattern to the runtime guide table.
 
+### Changed
+
+- `AGENTS.md` — clarified that assignee state is the source of truth for the next required actor on issues/PRs, so human-needed work must be reassigned to the human owner instead of being implied only in comments. Closes #217.
+- `docs/github-issues.md` and `docs/work-backends.md` — tightened the GitHub issue-backend handoff rules so comments provide context but assignment remains authoritative for who must act next. Closes #217.
+
 ## [4.0.1] — 2026-03-16
 
 > **Patch release to realign packaged metadata with the shipped v4 source history.** No framework behavior changed beyond changelog and release-version bookkeeping.

--- a/docs/github-issues.md
+++ b/docs/github-issues.md
@@ -1,6 +1,6 @@
 # GitHub Issues Backend Guide
 
-> **Version:** 2.1 | **Last updated:** 2026-03-09
+> **Version:** 2.4 | **Last updated:** 2026-03-23
 
 > **What this document is:** The concrete implementation guide for running operational work artifacts in GitHub Issues. Use this when `CONFIG.yaml → work_backend.type` is `github-issues`.
 
@@ -297,7 +297,7 @@ Closure archives completed work. The project status transition (performed by the
 
 ## Assignment Rules
 
-Every issue, PR, and review request must have an assignee. Assignment is how ownership and next-action responsibility are communicated. These rules apply to **all GitHub artifacts**, not just issues.
+Every issue, PR, and review request must have an assignee. Assignment is how ownership and next-action responsibility are communicated. These rules apply to **all GitHub artifacts**, not just issues. **Assignee state is the source of truth for who must act next.** Comments, body text, and project status can add context, but they must not contradict or replace the assignee signal.
 
 ### Who Gets Assigned — Issues
 
@@ -326,8 +326,8 @@ Every issue, PR, and review request must have an assignee. Assignment is how own
 
 When work transitions between agent and human:
 
-1. **Agent finishes, needs approval:** Agent sets the project status (e.g., `Triage` or `Backlog`), re-assigns to the approving human, and leaves a comment that (a) summarizes what was done, (b) explains what to review, and (c) lists the human's options in plain language (e.g., "You can: **Approve** — comment 'approved' and assign back to @acme-ai-bot | **Reject** — comment what needs to change and assign back to @acme-ai-bot").
-2. **Human decides:** Human comments with their decision in plain language (e.g., "Approved", "Looks good, go ahead", "Rejected — need more detail on rollback") and re-assigns to the agent.
+1. **Agent finishes, needs approval:** Agent sets the project status (e.g., `Triage` or `Backlog`), re-assigns to the approving human, and leaves a comment that (a) summarizes what was done, (b) explains what to review, and (c) lists the human's options in plain language (e.g., "You can: **Approve** — comment 'approved' and assign back to @acme-ai-bot | **Reject** — comment what needs to change and assign back to @acme-ai-bot"). The assignment change is mandatory — do not leave the issue assigned to the agent while expecting human action.
+2. **Human decides:** Human comments with their decision in plain language (e.g., "Approved", "Looks good, go ahead", "Rejected — need more detail on rollback") and re-assigns to the agent. If the human keeps the item assigned to themselves, the required next action is still human-owned.
 3. **Agent processes decision:** Agent reads the comment, interprets the decision, updates the project status field accordingly (e.g., `Backlog` → `Approved`), and continues. If the comment is ambiguous, the agent asks a clarifying question and keeps the issue assigned to the human.
 
 ### Handoff Mechanics — Pull Requests
@@ -424,6 +424,7 @@ Git still holds the durable review-heavy artifacts.
 
 | Version | Date | Change |
 |---|---|---|
+| 2.4 | 2026-03-23 | Clarified that assignee state is the source of truth for next action and that human-needed work must be reassigned to the human owner rather than implied only in comments or body text. |
 | 2.3 | 2026-03-21 | Added template asset references for label bootstrap, slim work-repo CI, dynamic label sync from issue forms, and the GitHub setup checklist. |
 | 2.1 | 2026-03-09 | Updated sample file paths after consolidating GitHub instance assets under `docs/github/`. |
 | 2.0 | 2026-03-08 | Migrated status tracking from labels to GitHub Project Status field. Removed ~20 status labels. Added project setup guidance, project_owner/project_number config fields, unified status model (Backlog → Done + close), terminal state documentation. |

--- a/docs/work-backends.md
+++ b/docs/work-backends.md
@@ -1,6 +1,6 @@
 # Work Backends — Git Files vs. Issue Tracker
 
-> **Version:** 1.4 | **Last updated:** 2026-03-09
+> **Version:** 1.5 | **Last updated:** 2026-03-23
 
 > **What this document is:** A comprehensive guide to how work artifacts can be tracked using different backends — either as Markdown files in Git (the original model) or as issues in an issue tracker (GitHub Issues, Jira, Linear, etc.).
 
@@ -287,7 +287,7 @@ When `use_projects: true` (recommended), create a GitHub Project v2 with a **Sta
 
 ## Assignment Discipline (Issues, PRs, and Reviews)
 
-**Every issue, pull request, and review request must have an assignee at all times.** This applies regardless of which work backend is configured — PRs exist in both modes (governance backbone changes always go through PRs). Assignment is not optional metadata — it is the primary mechanism for communicating ownership and expected next action.
+**Every issue, pull request, and review request must have an assignee at all times.** This applies regardless of which work backend is configured — PRs exist in both modes (governance backbone changes always go through PRs). Assignment is not optional metadata — it is the primary mechanism for communicating ownership and expected next action. **Assignee state is the source of truth for who must act next.** If human input, approval, or a decision is required, the item must be assigned to that human rather than left with the agent and explained only in text.
 
 ### Assignment Rules — Issues
 
@@ -324,6 +324,7 @@ A PR without both an owner path and a reviewer path is operationally incomplete.
    - Summarizes what was done and what to review
    - Lists the human's options in plain language (e.g., "You can: **Approve** — comment 'approved' and assign back to @acme-ai-bot | **Reject** — comment what needs to change and assign back to @acme-ai-bot | **Ask questions** — comment your questions and keep yourself assigned")
    - Links to relevant artifacts if applicable
+   - Never relies on the comment alone to indicate human ownership; the assignee must also change
 2. **Human → Agent (any decision):** Human leaves a comment with their decision in plain language (e.g., "Approved", "Looks good", "Rejected — the rollback plan is incomplete", "Please revise the scope to exclude X") and re-assigns to the agent.
 3. **Agent processes human decision:** Agent reads the comment, interprets the decision, updates the project status field accordingly (e.g., `Backlog` → `Approved`), and continues with the next step. If the agent cannot confidently interpret the comment, it asks a clarifying question in a follow-up comment and keeps the issue assigned to the human.
 
@@ -455,6 +456,7 @@ Templates are **never** tracked in the issue system. They are framework files, g
 
 | Version | Date | Change |
 |---------|------|--------|
+| 1.5 | 2026-03-23 | Clarified that assignee state is the source of truth for next action and that human-needed work must be explicitly reassigned to the human owner. |
 | 1.4 | 2026-03-09 | Consolidated backend configuration here and removed the duplicate `WORK-BACKEND.md` doc. Clarified this file's scope vs. `github-issues.md`. |
 | 1.2 | 2026-03-08 | Added assignment discipline section covering issues, PRs, and reviews — mandatory assignees, handoff protocols for both issues and PRs, next-action clarity, unassigned item sweep, agent identity. Human approval via comment+re-assign (agents handle labels). |
 | 1.1 | 2026-03-07 | Clarified Git-only companion artifacts, added human approval cheat sheet, removed issue-only claims for digests/evaluations/outcome reports/fleet reports, linked GitHub implementation guide |


### PR DESCRIPTION
## Summary
- make `AGENTS.md` explicit that assignee state is the source of truth for who must act next
- tighten the GitHub issue backend docs so human-needed work must be reassigned to the human owner, not only described in comments
- record the clarification in the framework changelog

## What to review
- whether the assignment rule is now unambiguous for issue and PR handoffs
- whether the docs consistently treat comments as context and assignee state as authoritative

## Testing
- docs-only change; no runtime tests

Closes #217
