### PR TITLE
docs: trim setup and navigation guides

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,24 +23,17 @@ Pick the shortest path that matches what you are trying to do:
 
 ---
 
-## Template vs. Company Fork
+## Keep / Delete Rule of Thumb
 
-Each document falls into one of three categories:
+- **Keep** docs that define how your company instance operates.
+- **Keep if used** docs that support a runtime, CI gate, or platform feature you actually run.
+- **Delete or ignore** template-only setup material after instantiation.
 
-| Document | Category | Template repo | Company fork |
-|---|---|---|---|
-| [`file-guide.md`](file-guide.md) | Setup reference | ✅ Framework doc | **Keep** — read once during fork setup to understand what each root file does |
-| [`required-github-settings.md`](required-github-settings.md) | Setup reference | ✅ Applies to both | **Apply** — configure branch protection and CODEOWNERS before going live |
-| [`runtimes/README.md`](runtimes/README.md) | Runtime reference | ✅ Framework doc | **Keep** as runtime guide index |
-| [`runtimes/openclaw.md`](runtimes/openclaw.md) | Runtime reference | ✅ Framework doc | **Keep** if using OpenClaw; ignore otherwise |
-| [`policy-as-code.md`](policy-as-code.md) | CI feature | ✅ Template CI gate | **Keep** if using OPA/Conftest gate; delete otherwise |
-| [`security-scanning.md`](security-scanning.md) | CI feature | ✅ Template CI gate | **Keep** if using Gitleaks/Dependency Review; delete otherwise |
-| [`lock-enforcement.md`](lock-enforcement.md) | CI feature | ✅ Template CI gate | **Keep** if using lock enforcement; delete otherwise |
-| [`placeholder-check.md`](placeholder-check.md) | CI feature | ✅ Template CI gate | **Keep** if using placeholder CI gate; delete otherwise |
-| [`schema-guide.md`](schema-guide.md) | CI feature | ✅ Template CI gate | **Keep** if using schema validation; delete otherwise |
-| [`mission-lifecycle.md`](mission-lifecycle.md) | Process reference | ✅ Framework doc | **Keep** — mission lifecycle, status transitions, Divide & Conquer pattern |
-| [`github-issues.md`](github-issues.md) | Setup reference | ✅ Framework doc | **Keep** — concrete GitHub issue-backend implementation guide |
-| [`work-backends.md`](work-backends.md) | Setup reference | ✅ Framework doc | **Keep** — guide to work backend choice (git-files vs. issue tracker) |
+In practice:
+- keep `work-backends.md`, `github-issues.md`, `mission-lifecycle.md`, and `required-github-settings.md`
+- keep runtime docs only for runtimes you actually use
+- keep CI feature guides only for gates you actually keep enabled
+- use `file-guide.md` when doing one-time fork cleanup
 
 ---
 

--- a/docs/customization-guide.md
+++ b/docs/customization-guide.md
@@ -2,12 +2,10 @@
 
 > **Version:** 3.6 | **Last updated:** 2026-03-14
 
-> **Start here** after cloning this framework.
-> This guide walks you through every step of making this operating model your own.
+> **Start here** after cloning the framework.
+> Fastest safe path: fill `CONFIG.yaml`, install the GitHub issue-backend kit if needed, then run `python3 scripts/instantiate_instance.py cleanup-instance`.
 
-> **New to the repo layout?** Read [docs/file-guide.md](file-guide.md) first — it explains which root files are part of the open-source template infrastructure (safe to delete in a private fork) and which are your company's actual operating model content (fill in and own).
-
-> **Fastest safe path:** fill `CONFIG.yaml`, install the GitHub issue-backend kit if needed, then run `python3 scripts/instantiate_instance.py cleanup-instance` to strip template-only assets and replace the top-level docs with instance-facing scaffolding.
+> New to the repo layout? Read [docs/file-guide.md](file-guide.md) first.
 
 ---
 
@@ -52,31 +50,21 @@ If you're a small team or solo founder, start with a **minimal agent fleet** —
 Also decide whether operational work lives in the same repo as the governance backbone or in a separate `*-work` repo.
 
 **Simple rule:**
-- keep work in the same repo for very small or early setups
-- split to a dedicated work repo once humans need cleaner backlog visibility, notifications, mobile access, or clearer separation from the governance backbone
-- keep product implementation in its own product repo either way
-
-Example topology:
-- template: `agentic-enterprise`
-- instance: `my-company`
-- work repo: `my-company-work`
-- product repo: `my-product`
-
-Decide where operational work artifacts (signals, missions, tasks, decisions) will be tracked:
+- same repo for very small or early setups
+- dedicated work repo once humans need cleaner backlog visibility and separation
+- product implementation stays in product repos either way
 
 | Backend | Best For | Set In CONFIG.yaml |
 |---------|----------|--------------------|
-| **Git files** (default) | Self-contained, no external dependencies, maximum auditability | `work_backend.type: "git-files"` |
-| **GitHub Issues** | Better human collaboration, native boards, labels, notifications, mobile access | `work_backend.type: "github-issues"` |
+| **Git files** | Self-contained, maximum auditability | `work_backend.type: "git-files"` |
+| **GitHub Issues** | Better human collaboration and visibility | `work_backend.type: "github-issues"` |
 
-If using GitHub, **GitHub Issues is recommended** — it's always available and provides dramatically better visibility for humans. See [docs/work-backends.md](work-backends.md) for the full guide including label taxonomy.
+If you choose GitHub Issues, use:
+- [docs/work-backends.md](work-backends.md) for backend choice and contract
+- [docs/github-issues.md](github-issues.md) for live operating rules
+- [docs/github/setup-checklist.md](github/setup-checklist.md) for the shortest setup path
 
-If you choose the issue backend, do not stop at `work_backend.type: "github-issues"`.
-You also need the GitHub operating setup from [docs/github-issues.md](github-issues.md): Project v2 for status tracking, labels, and issue forms.
-For the shortest template-instantiation path, use [docs/github/setup-checklist.md](github/setup-checklist.md).
-
-> **Note:** Governance backbone files (org structure, policies, agent instructions, templates) always stay in Git regardless of this choice.
-
+> Governance backbone files stay in Git regardless of backend choice.
 
 ### Step 4b: If You Run OpenClaw, Bootstrap The Instance Fleet
 

--- a/docs/github/README.md
+++ b/docs/github/README.md
@@ -142,24 +142,16 @@ Scripts that are backend-aware use `work_backend.py` to read from the correct so
 
 ## Label discipline
 
-Use labels for semantics that GitHub does **not** model natively well, such as:
+Use labels for semantics that GitHub does **not** model natively well:
 - artifact type
 - dispatch/agent fit
 - scope/product boundary
-- approval-needed semantics
 
-Do **not** recreate native GitHub state with redundant labels when the platform already models it:
+Do **not** recreate native GitHub state with labels:
 - issue open/closed
 - PR open/draft/merged/closed
 - assignee / reviewer ownership
+- approval state
 
-A practical work repo should also have a lightweight label baseline available immediately after initialization.
-
-
-## Ownership and labels
-
-Use GitHub assignees as the ownership source of truth.
-
-Labels should help with dispatch and scope, not duplicate ownership or native GitHub state.
-
-Do **not** add `owner:*` labels or `status:*` labels that simply restate what GitHub already models via state, assignees, or review requests.
+Use assignees and review requests as the ownership source of truth.
+Do **not** add `owner:*` or `status:*` labels that merely restate native GitHub state.


### PR DESCRIPTION
Follow-up after #220.

## Goal
General lean pass on high-traffic operator docs: less navigation bloat, fewer repeated explanations, no stale label semantics.

## What changed
- trimmed `docs/customization-guide.md` intro and work-backend section
- collapsed the oversized keep/delete matrix in `docs/README.md` into a short rule-of-thumb section
- simplified `docs/github/README.md` label discipline and removed the stale `approval-needed semantics` wording

## Why
These docs are read often during setup and instance work. Extra prose here creates friction, drift, and wrong mental models.

## Result
- fewer words
- clearer canonical paths
- less duplicated guidance