### PR TITLE
docs: trim github issue backend guides

### DIFF
--- a/docs/github-issues.md
+++ b/docs/github-issues.md
@@ -8,13 +8,15 @@
 
 ## Goal
 
-This guide makes the GitHub issue backend operational without implicit knowledge.
+This guide is the canonical operating guide for the GitHub issue backend.
 
-If a human needs to approve something, the required status transition is written out explicitly.
-If GitHub needs configuration, the exact repo settings, labels, project setup, and issue forms are listed here.
+Use it for:
+- labels
+- project status model
+- assignment and approval handoff
+- issue-backend operating rules
 
-Use this guide together with [work-backends.md](work-backends.md), [required-github-settings.md](required-github-settings.md), and [github/README.md](github/README.md).
-If you want the shortest copy-and-configure path, start with [github/setup-checklist.md](github/setup-checklist.md).
+For the shortest setup path, start with [github/setup-checklist.md](github/setup-checklist.md).
 
 ---
 
@@ -23,13 +25,12 @@ If you want the shortest copy-and-configure path, start with [github/setup-check
 Complete these steps before using the issue backend in a real fork:
 
 1. Set `work_backend.type: "github-issues"` in `CONFIG.yaml`.
-2. Enable GitHub Issues and Issue Forms in the repository settings.
-3. **Create a GitHub Project (v2)** with a **Status** field containing these single-select options: `Backlog`, `Triage`, `Approved`, `Planning`, `In Progress`, `Blocked`, `Done`. Set `project_owner` and `project_number` in `CONFIG.yaml`.
+2. Enable GitHub Issues and Issue Forms.
+3. Create a GitHub Project (v2) with `Backlog`, `Triage`, `Approved`, `Planning`, `In Progress`, `Blocked`, `Done`.
 4. Prefer the scripted install path: `python3 scripts/instantiate_instance.py install-github-work-repo --main-repo your-org/your-instance --target-dir <issue-hosting-repo>`.
-5. If you are doing it manually instead, copy the sample forms from `docs/github/issue-templates/forms/` into `.github/ISSUE_TEMPLATE/` in your instance repository and copy `docs/github/issue-templates/config.sample.yml` to `.github/ISSUE_TEMPLATE/config.yml`.
-6. Create the required labels listed below. (Note: status is tracked via the Project Status field, not via labels.) Use `docs/github/labels/labels.sample.yml` as your bootstrap source.
-7. Tell humans who approve work to use the approval transitions exactly as written in the approval table.
-8. Keep Git-backed companion artifacts in the repository: signal digests, technical designs, quality evaluations, fleet reports, outcome reports, asset registry entries, governance exceptions, and locks.
+5. Install the required labels.
+6. Use the approval handoff rules from this document.
+7. Keep Git-backed companion artifacts in the main repo.
 
 ---
 

--- a/docs/github/setup-checklist.md
+++ b/docs/github/setup-checklist.md
@@ -107,7 +107,7 @@ This adds:
 
 For governed repo work:
 - use PRs rather than direct pushes to protected branches
-- enable auto-merge when the PR is reviewable and checks are green
+- enable auto-merge by default when the PR is reviewable and checks are green
 - use real closing keywords in the PR description:
   - `Closes owner/repo#123`
   - `Fixes owner/repo#123`

--- a/docs/work-backends.md
+++ b/docs/work-backends.md
@@ -2,24 +2,21 @@
 
 > **Version:** 1.5 | **Last updated:** 2026-03-23
 
-> **What this document is:** A comprehensive guide to how work artifacts can be tracked using different backends — either as Markdown files in Git (the original model) or as issues in an issue tracker (GitHub Issues, Jira, Linear, etc.).
+> **What this document is:** The backend selection and contract guide.
 
-> **Use this document for:** choosing a backend, configuring `CONFIG.yaml`, understanding which artifacts stay in Git, and comparing backend behavior.
+> **Use this document for:** choosing a backend, configuring `CONFIG.yaml`, understanding what stays in Git, and comparing backend behavior.
 > **Do not use this document for:** step-by-step GitHub issue operations. For that, use [github-issues.md](github-issues.md).
 
 ---
 
 ## Why Two Backends?
 
-The operating model defines **what artifacts exist** and **how they flow** between layers and loops. The original framework tracked everything as Markdown files in `work/`. This is fully self-contained and auditable, but creates friction for human collaboration:
+The operating model defines the artifacts and flow. The backend decides where active work is tracked.
 
-- **Visibility:** Scanning 20+ Markdown files to understand mission status is harder than glancing at a labeled issue board.
-- **Interaction:** Commenting, assigning, re-labeling, and triaging are native to issue trackers — and clunky via file edits + PRs.
-- **Notifications:** Issue trackers have built-in notification, mention, and subscription systems.
-- **Mobile:** Issue trackers work well on mobile. Editing Markdown in a repo does not.
-- **Collaboration:** Discussion threads, reactions, and cross-references are first-class in issue trackers.
+- **Git files** optimize for auditability and self-containment.
+- **Issue backends** optimize for visibility, assignment, comments, notifications, and mobile use.
 
-The framework now supports **both backends**. The choice is made at instance configuration time via `CONFIG.yaml → work_backend`.
+The choice is made via `CONFIG.yaml → work_backend`.
 
 ---
 
@@ -323,23 +320,8 @@ Minimum acceptable GitHub issue-backend state:
 
 | Mechanism | Git Files Backend | Issue Backend |
 |-----------|-------------------|---------------|
-| Signal triage | PR merge = approval | Human comments with triage decision (e.g., "proceed", "defer", "monitor", "done") and re-assigns to agent. Agent updates the project status field accordingly (e.g., `Triage` → `Approved`). |
-| Mission approval | PR merge = approval | Human comments approval (e.g., "approved") and re-assigns to agent. Agent changes project status `Backlog` → `Approved`. |
-| Decision approval | PR merge = approval | Human comments acceptance and re-assigns to agent. Agent changes project status `Backlog` → `Approved`. |
+| Human approval / triage / go-no-go | PR merge = approval | Assignee + comment handoff. Human comments in plain language and re-assigns; agent updates project status. See [`github-issues.md`](github-issues.md). |
 | Quality gate | Evaluation file with PASS verdict | Evaluation file in Git references the issue-backed mission/task |
-| Release go/no-go | PR merge = approval | Human comments approval and re-assigns to agent. Agent changes project status `Backlog` → `Approved`. |
-
-### Human Approval Cheat Sheet
-
-Humans approve by **commenting and re-assigning** — they never need to touch labels or project status fields. The agent's handoff comment always explains the available options.
-
-| Artifact | Human does this | Agent does this after |
-|----------|-----------------|---------------------|
-| Signal | Review the issue, comment with triage decision (e.g., "proceed" or "defer — not a priority this quarter"), re-assign to agent | Agent updates the project status based on the comment (e.g., `Triage` → `Approved` or `Done`) |
-| Mission | Review scope and outcomes, comment approval or rejection, re-assign to agent | Agent changes project status `Backlog` → `Approved` (or keeps and notes rejection) |
-| Decision | Review context and tradeoffs, comment acceptance or rejection, re-assign to agent | Agent changes project status `Backlog` → `Approved` (or keeps and notes rejection) |
-| Release | Review rollout and rollback plan, comment approval, re-assign to agent | Agent changes project status `Backlog` → `Approved` |
-| Retrospective | Review findings and follow-ups, comment acceptance, re-assign to agent | Agent changes project status to `Done` |
 
 Do not rely on issue closure alone as approval. Closure archives work; the project status transition (performed by the agent) is the approval event.
 


### PR DESCRIPTION
Lean follow-up on the GitHub issue-backend docs.

## What changed
- trimmed `docs/github-issues.md` intro and minimum setup section
- reduced duplicated approval mechanics in `docs/work-backends.md` back to the backend contract
- made `docs/github/setup-checklist.md` explicit that auto-merge should be enabled by default when a PR is reviewable and green

## Why
These are high-traffic docs. They should carry the minimum needed rule set without repeating the same mechanics in multiple places.

## Result
- less setup overhead
- less approval-rule duplication
- clearer auto-merge default for governed PR flows