### PR TITLE
docs: make observability and agent quality explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The framework uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html): `
 
 ### Changed
 
+- `org/README.md` — added a Governance Primitives section and explicitly elevated the observability platform to a first-class governance artifact alongside the repo backbone, capability contracts, skill manifests, MCP profiles, and knowledge manifests. Related to #188.
+- `org/4-quality/AGENT.md` — added outcome-oriented agent quality dimensions (completeness, containment, correctness, control, resolution, turn efficiency, escalation quality) and directed evaluators to prefer observability evidence when available. Related to #188.
 - `AGENTS.md` — clarified that assignee state is the source of truth for the next required actor on issues/PRs, so human-needed work must be reassigned to the human owner instead of being implied only in comments. Closes #217.
 - `docs/github-issues.md` and `docs/work-backends.md` — tightened the GitHub issue-backend handoff rules so comments provide context but assignment remains authoritative for who must act next. Closes #217.
 

--- a/org/4-quality/AGENT.md
+++ b/org/4-quality/AGENT.md
@@ -3,13 +3,13 @@
 > **Role:** You are a Quality Layer agent (eval agent, policy guardian, compliance checker). You evaluate ALL outputs before they are merged, published, shipped, or sent externally.
 > **Layer:** Quality (the immune system of the organization)
 > **Authority:** You enforce quality policies. You can BLOCK any output. Humans set policies and resolve disputes.
-> **Version:** 1.13 | **Last updated:** 2026-03-14
+> **Version:** 1.14 | **Last updated:** 2026-03-27
 
 ---
 
 ## Your Purpose
 
-Protect organizational quality across every dimension: code, security, agent security (prompt injection & tool abuse), AI governance & responsible AI (fairness, model cards, explainability), vendor & third-party risk, log retention & immutability, risk management, data classification & handling, encryption & key management, architecture, user experience, performance, content, delivery process, and customer interactions. Every output — regardless of which layer or division produced it — must pass through quality evaluation before it reaches its destination.
+Protect organizational quality across every dimension: code, security, agent security (prompt injection & tool abuse), AI governance & responsible AI (fairness, model cards, explainability), vendor & third-party risk, log retention & immutability, risk management, data classification & handling, encryption & key management, architecture, user experience, performance, content, delivery process, and customer interactions. For agent-produced work, quality is judged not only by technical correctness but by observable outcomes: completeness, containment, correctness, control, resolution, turn efficiency, and escalation quality. Every output — regardless of which layer or division produced it — must pass through quality evaluation before it reaches its destination.
 
 ## Context You Must Read Before Every Evaluation
 
@@ -44,7 +44,16 @@ Protect organizational quality across every dimension: code, security, agent sec
    - Verify production baselines are queried and documented for all modified components (or N/A documented for greenfield)
    - Verify impact assessment: no proposed change targets a component near error budget exhaustion without documented mitigation
    - **A Technical Design without a complete Observability Design section is FAIL** — do not wait to discover missing observability at PR review time
-7. **Produce a verdict:**
+7. **For agent-produced outputs — evaluate outcome-oriented quality dimensions when applicable:**
+   - **Completeness** — did the agent address the full requested scope and acceptance criteria?
+   - **Containment** — did it stay within approved boundaries, permissions, and assigned ownership?
+   - **Correctness** — are the claims, decisions, and artifacts materially right?
+   - **Control** — did it follow policies, review gates, escalation rules, and handoff expectations?
+   - **Resolution** — did the work actually move the underlying mission or user goal forward?
+   - **Turn efficiency** — did it reach the result with reasonable tool usage, iteration count, and latency?
+   - **Escalation quality** — when autonomy was insufficient, did it escalate at the right time with the right evidence and context?
+   - Use observability evidence where available instead of relying only on artifact inspection or self-report.
+8. **Produce a verdict:**
 
 | Verdict | Meaning | Action |
 |---------|---------|--------|
@@ -173,6 +182,7 @@ Surface improvement signals (to `work/signals/` for git-files backend, or as an 
 
 | Version | Date | Change |
 |---|---|---|
+| 1.14 | 2026-03-27 | Added outcome-oriented agent quality dimensions (completeness, containment, correctness, control, resolution, turn efficiency, escalation quality) and instructed evaluators to prefer observability evidence when available |
 | 1.11 | 2026-03-14 | Added AI governance & responsible AI (fairness, model cards, explainability) to quality dimensions; references new `ai-governance.md` policy |
 | 1.10 | 2026-03-14 | Added data classification & handling to quality dimensions; references new `data-classification.md` policy |
 | 1.9 | 2026-03-13 | Added encryption & key management to quality dimensions; references new `cryptography.md` policy |

--- a/org/README.md
+++ b/org/README.md
@@ -1,6 +1,6 @@
 # Organizational Structure
 
-> **Version:** 1.2 | **Last updated:** 2026-03-15
+> **Version:** 1.3 | **Last updated:** 2026-03-27
 
 > **What this is:** The static structure of the agentic enterprise {{COMPANY_SHORT}} organization — who exists, where they sit, what they own, how they relate. This covers the **entire company**, not just R&D: engineering, delivery, go-to-market, sales, customer success, and support all operate within the same 5-layer model.  
 > **What it replaces:** Legacy role hierarchies, ticket-based coordination, manual phase gates, and siloed functional departments.  
@@ -58,12 +58,28 @@ The critical addition is Layer 0: Steering. The company does not just operate th
 
 ---
 
+## Governance Primitives
+
+The framework relies on a small set of governed artifacts and channels that every adopter can reason about explicitly:
+
+| Primitive | Role in the operating model |
+|-----------|-----------------------------|
+| **Git repository** | Governance backbone for instructions, decisions, approvals, and durable evidence |
+| **Capability contracts** | Govern what an agent type is allowed to do by binding it to approved skills, MCP profiles, and knowledge sources |
+| **Skill manifests** | Govern reusable process instructions and runtime expectations |
+| **MCP profiles** | Govern tool access boundaries and permissions |
+| **Knowledge manifests** | Govern what context agents may rely on, with scope, freshness, and ownership |
+| **Observability platform** | Governance evidence channel for execution reality: telemetry, baselines, anomalies, and outcome measurement |
+
+**Observability is a governance primitive, not just runtime plumbing.** The repo captures what was approved. The observability platform captures what actually happened. Both are required to govern agentic work credibly.
+
 ## Key Terminology
 
 | Term | Definition |
 |------|-----------|
 | **Division** | Persistent group of agents organized by expertise — the agentic equivalent of a department. Owns skills, standards, and institutional knowledge. |
 | **Knowledge manifest** | Governed record of what agents know: source paths, scope, freshness, and ownership. |
+| **Observability platform** | Governed evidence layer for telemetry, production baselines, anomaly detection, and outcome measurement. |
 | **Fleet** | Full pool of agents available to Orchestration. Total capacity across all divisions. |
 | **Crew** | Subset of agents drawn from the fleet for a specific mission. Assembled at mission start, disbanded at end. |
 
@@ -281,5 +297,6 @@ org/
 
 | Version | Date | Change |
 |---|---|---|
+| 1.3 | 2026-03-27 | Added Governance Primitives section and explicitly elevated the observability platform to a first-class governance artifact alongside contracts, manifests, and the repo backbone |
 | 1.1 | 2026-03-07 | Reframed execution divisions into core defaults, optional extensions, and company-specific product divisions; removed AI & Intelligence and Quality & Security Engineering as implied defaults |
 | 1.0 | 2026-02-19 | Initial version |


### PR DESCRIPTION
## Summary
- add an explicit Governance Primitives section to `org/README.md`
- elevate the observability platform from runtime plumbing to a first-class governance evidence channel
- add outcome-oriented agent quality dimensions to the existing Quality Layer instructions

## Why
Issue #188 asks for a lean upstream-generic way to make observability explicit as a governance primitive and to make agent quality evaluation more outcome-oriented.

This PR keeps the change narrow by editing the most natural existing governance locations instead of spreading the same idea across README, demo, and policy surfaces.

## What to review
1. `org/README.md` now names the core governance primitives explicitly and explains why observability belongs beside the repo, contracts, manifests, and profiles.
2. `org/4-quality/AGENT.md` now tells quality evaluators which outcome dimensions to apply to agent-produced work: completeness, containment, correctness, control, resolution, turn efficiency, and escalation quality.
3. Version/date metadata and changelog entries follow the repo's governance rules.

## Deferred intentionally
- no README / landing-page / demo copy changes
- no schema or template changes for capability contracts or evaluation reports
- no process-model expansion for shared reasoning layer language
- no new policy file edits, since observability policy already treats observability as a hard gate

Related to #188.
