### PR TITLE
docs: tighten openclaw heartbeat and reporting guidance

### DIFF
--- a/docs/runtimes/openclaw-onboarding.md
+++ b/docs/runtimes/openclaw-onboarding.md
@@ -1,5 +1,7 @@
 # OpenClaw Onboarding for an Instance
 
+Last updated: 2026-03-27
+
 ## Goal
 
 Reduce the amount of manual work required after instantiating an enterprise repo.
@@ -97,6 +99,16 @@ Use labels for:
 
 Do **not** use labels to duplicate native GitHub state, assignee ownership, or approval state.
 Ownership and approval handoff belong in assignees and review requests.
+
+## Reporting and Owner Handoff
+
+Bootstrap should also define the reporting contract, not leave it implicit.
+
+Minimum expectation:
+- a low-noise twice-daily owner report
+- explicit owner-action section with issue/PR links
+- model/token consumption summary by agent/model
+- no human-needed work left assigned to an automation identity
 
 ## Cleanup caution
 

--- a/docs/runtimes/openclaw.md
+++ b/docs/runtimes/openclaw.md
@@ -3,6 +3,7 @@
 > **Purpose:** Practical operator guide for running the Agentic Enterprise operating model on [OpenClaw](https://openclaw.ai).
 > **Audience:** Operators bootstrapping an "agentic company" runtime (fleet, loops, automation).
 > **Status:** Living document — adjust as your fleet, budgets, and reliability needs evolve.
+> **Last updated:** 2026-03-27
 
 ---
 
@@ -32,6 +33,9 @@ Start with **5 agents**.
 Optional scale-ups:
 - `security` for security-sensitive reviews
 - `content` for GTM/docs/website copy
+
+Practical production note:
+- once work is tracked in GitHub Issues and human handoffs matter, add an **internal auditor** as the default 6th role rather than treating audit/reporting as invisible side work
 
 ---
 
@@ -137,6 +141,23 @@ Keep cron conservative:
 - never merge with `CHANGES_REQUESTED`
 - require `mergeable_state == clean`
 
+## Reporting Contract
+
+A useful runtime report is **exception-oriented and actionable**, not a play-by-play transcript.
+
+Recommended default:
+- twice daily report for the owner
+- `HEARTBEAT_OK` when nothing meaningful changed
+
+Minimum report content:
+- what actually advanced, in plain language
+- what the human owner must do next, with issue/PR links
+- critical audit findings (ownership drift, red CI, stale work)
+- model/token consumption by agent and model
+
+Ownership rule:
+- if the report says the human must act, that work should also be explicit in issue/PR assignment where the platform supports it
+
 ---
 
 
@@ -153,6 +174,15 @@ This role checks:
 - whether local findings are translated into upstream improvements
 
 This role sits close to the broader observability/control story: not only runtime telemetry, but whether the operating system of work is actually functioning.
+
+## Bounded Specialist Loops
+
+If you need a short-lived recurring loop for telemetry validation, ingest normalization, or another sharply bounded operating concern, prefer a **dedicated specialist identity** over overloading the main execution agent.
+
+Rules:
+- keep it bounded to the active mission/issue
+- do not make it part of the default fleet unless the workload proves durable
+- give it its own reporting/audit expectations so the loop does not become hidden work
 
 ## Discord Channel Setup For Instance Fleets
 

--- a/scripts/validate_config_completeness.py
+++ b/scripts/validate_config_completeness.py
@@ -144,6 +144,21 @@ DOCUMENTATION_FILES = {
 }
 
 
+def matches_rel_file(rel_path: str, target: str) -> bool:
+    """Return True when *rel_path* names *target* directly or under a vendored root."""
+    return rel_path == target or rel_path.endswith(f"/{target}")
+
+
+def matches_rel_prefix(rel_path: str, prefix: str) -> bool:
+    """Return True when *rel_path* falls under *prefix*, even in a nested repo."""
+    return (
+        rel_path == prefix
+        or rel_path.startswith(f"{prefix}/")
+        or rel_path.endswith(f"/{prefix}")
+        or f"/{prefix}/" in rel_path
+    )
+
+
 def resolve_config_path(data: dict[str, Any], dot_path: str) -> Any:
     """Resolve a dot-path like 'company.name' or 'ventures[0].name' against
     a parsed YAML dict. Returns None if path doesn't exist."""
@@ -213,11 +228,11 @@ def scan_framework_files(repo_root: Path) -> dict[str, list[tuple[str, int]]]:
         # Skip specific files
         if rel.name in SKIP_FILES:
             continue
-        if str(rel) in DOCUMENTATION_FILES:
+        rel_str = str(rel)
+        if any(matches_rel_file(rel_str, doc) for doc in DOCUMENTATION_FILES):
             continue
         # Skip directory prefixes (compliance templates, etc.)
-        rel_str = str(rel)
-        if any(rel_str.startswith(prefix) for prefix in SKIP_DIR_PREFIXES):
+        if any(matches_rel_prefix(rel_str, prefix) for prefix in SKIP_DIR_PREFIXES):
             continue
         # Skip template files
         if rel.name.startswith("_TEMPLATE"):


### PR DESCRIPTION
## Summary
- document the heartbeat/reporting target state for OpenClaw-backed instance operations
- align the OpenClaw onboarding docs with the repo-local reporting and owner-handoff loop
- make `validate_config_completeness.py` robust for vendored/nested framework paths

## Validation
- `python3 scripts/validate_config_completeness.py --self-check`

## Why
This keeps the framework docs aligned with the live Sagicorp/OpenClaw rollout and avoids false validator noise when the framework is vendored into an instance workspace.