### PR TITLE
Require issue-backed tracking for ad-hoc chat tasks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Agent Instructions (Global)
 
-> **Version:** 4.2 | **Last updated:** 2026-03-28
+> **Version:** 4.3 | **Last updated:** 2026-03-28
 
 Every AI agent in this repository must follow these instructions. Layer-specific and division-specific instructions extend (never contradict) these rules.
 
@@ -39,6 +39,7 @@ Never commit scope, timelines, resources, or strategic direction. Draft, analyze
 - **CI green gate:** No PR is considered ready for review or merge until all CI checks pass. Agents MUST verify CI status after push and fix failures before requesting review. A red PR = work is not done. A red `main` = immediate priority to fix.
 - **Sub-issue linkage:** Child issues MUST be linked to their parent issue using GitHub sub-issues or explicit `parent: #NNN` reference in the issue body. Orphaned issues without parent linkage are not acceptable.
 - **Auto-merge:** PRs MUST be created with auto-merge enabled. This ensures that once CI passes and the required approvals are given, the PR merges immediately without manual intervention.
+- **Ad-hoc chat work:** If a task starts in chat and the configured backend is issue-based, create or adopt a tracking issue before execution continues. Treat the issue as the durable work interface and audit record: capture context, intended outcome, completion criteria, ownership, current status, and relevant links; record meaningful progress, blockers, decisions, and handoffs as issue comments; keep status current; close the issue when complete or assign it to the responsible human when verification is required.
 
 ### 4. Policies are law
 Policies in `org/4-quality/policies/` are mandatory. Fix violations before submitting. If a policy seems wrong, flag it — don't ignore it. Governance exceptions: formal process via `work/decisions/EXC-YYYY-NNN-*.md`, time-bounded, Steering-approved.

--- a/docs/github-issues.md
+++ b/docs/github-issues.md
@@ -1,6 +1,6 @@
 # GitHub Issues Backend Guide
 
-> **Version:** 2.4 | **Last updated:** 2026-03-23
+> **Version:** 2.5 | **Last updated:** 2026-03-28
 
 > **What this document is:** The concrete implementation guide for running operational work artifacts in GitHub Issues. Use this when `CONFIG.yaml → work_backend.type` is `github-issues`.
 
@@ -15,6 +15,7 @@ Use it for:
 - project status model
 - assignment and approval handoff
 - issue-backend operating rules
+- ad-hoc chat tasks that must be turned into durable issue-backed work
 
 For the shortest setup path, start with [github/setup-checklist.md](github/setup-checklist.md).
 
@@ -300,6 +301,8 @@ Closure archives completed work. The project status transition (performed by the
 
 Every issue, PR, and review request must have an assignee. Assignment is how ownership and next-action responsibility are communicated. These rules apply to **all GitHub artifacts**, not just issues. **Assignee state is the source of truth for who must act next.** Comments, body text, and project status can add context, but they must not contradict or replace the assignee signal.
 
+For ad-hoc tasks initiated in chat, agents must create or adopt a tracking issue before execution continues when the configured backend is issue-based. Chat may initiate or discuss the work, but the issue is the durable operational record.
+
 ### Who Gets Assigned — Issues
 
 | Issue state | Assigned to | Rationale |
@@ -425,6 +428,7 @@ Git still holds the durable review-heavy artifacts.
 
 | Version | Date | Change |
 |---|---|---|
+| 2.5 | 2026-03-28 | Added the rule that ad-hoc chat tasks must become issue-backed work when the issue backend is enabled. |
 | 2.4 | 2026-03-23 | Clarified that assignee state is the source of truth for next action and that human-needed work must be reassigned to the human owner rather than implied only in comments or body text. |
 | 2.3 | 2026-03-21 | Added template asset references for label bootstrap, slim work-repo CI, dynamic label sync from issue forms, and the GitHub setup checklist. |
 | 2.1 | 2026-03-09 | Updated sample file paths after consolidating GitHub instance assets under `docs/github/`. |

--- a/docs/work-backends.md
+++ b/docs/work-backends.md
@@ -1,6 +1,6 @@
 # Work Backends — Git Files vs. Issue Tracker
 
-> **Version:** 1.5 | **Last updated:** 2026-03-23
+> **Version:** 1.6 | **Last updated:** 2026-03-28
 
 > **What this document is:** The backend selection and contract guide.
 
@@ -70,6 +70,8 @@ These are the **dynamic, frequently-changing** artifacts that track active work.
 | **Release Contracts** | `work/releases/YYYY-MM-DD-name.md` | Issue with `artifact:release` label |
 | **Retrospectives** | `work/retrospectives/YYYY-MM-DD-name.md` | Issue with `artifact:retrospective` label |
 | **Locks** | `work/locks/<lock-id>.md` | Not applicable — locks stay in Git (concurrency mechanism) |
+
+When the configured backend is issue-based, ad-hoc tasks initiated in chat should also be captured as tracking issues so execution state, ownership, and handoffs do not live only in chat.
 
 ---
 
@@ -380,6 +382,7 @@ Templates are **never** tracked in the issue system. They are framework files, g
 
 | Version | Date | Change |
 |---------|------|--------|
+| 1.6 | 2026-03-28 | Clarified that ad-hoc chat tasks should also be captured as tracking issues when the issue backend is enabled. |
 | 1.5 | 2026-03-23 | Clarified that assignee state is the source of truth for next action and that human-needed work must be explicitly reassigned to the human owner. |
 | 1.4 | 2026-03-09 | Consolidated backend configuration here and removed the duplicate `WORK-BACKEND.md` doc. Clarified this file's scope vs. `github-issues.md`. |
 | 1.2 | 2026-03-08 | Added assignment discipline section covering issues, PRs, and reviews — mandatory assignees, handoff protocols for both issues and PRs, next-action clarity, unassigned item sweep, agent identity. Human approval via comment+re-assign (agents handle labels). |


### PR DESCRIPTION
## Summary
- require ad-hoc chat tasks to become issue-backed work when the issue backend is enabled
- document that the issue is the durable work interface and audit record
- clarify the rule in the global agent instructions and issue-backend docs

## Why
Chat is useful for interaction, but it is a weak system of record. For issue-backed operating models, ad-hoc work should not live only in chat. This change makes tracking, ownership, status, blockers, handoffs, and closure explicit in the issue system.

## What changed
- `AGENTS.md`
  - add a generic rule for ad-hoc chat work under the governed process rules
- `docs/github-issues.md`
  - clarify that chat-initiated work must be captured in a tracking issue before execution continues
- `docs/work-backends.md`
  - add a backend-contract note that ad-hoc chat work should also be represented as tracking issues when the issue backend is enabled

## Review focus
- is the rule generic enough for upstream and free of Sagicorp-specific policy?
- is the wording strict enough to drive behavior without over-specifying local workflow details?
- are the doc placements right for discoverability?
