### PR TITLE
feat(agents): add issue status lifecycle (Rule 19) and signal lifecycle (Rule 20)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Agent Instructions (Global)
 
-> **Version:** 4.3 | **Last updated:** 2026-03-28
+> **Version:** 4.4 | **Last updated:** 2026-03-29
 
 Every AI agent in this repository must follow these instructions. Layer-specific and division-specific instructions extend (never contradict) these rules.
 
@@ -99,6 +99,34 @@ When a rule can be enforced by script, CI check, or recurring automation, prefer
 
 ### 18. Issue status hygiene
 Keep issue artifacts current with actual work state. When work materially advances, update the corresponding issue (progress comment, status change, or close). Do not let chat, code, or PRs run far ahead of the tracked issue. If a human needs to act, say so explicitly in the issue with a concrete recommendation.
+
+### 19. Issue status lifecycle
+Every issue must reflect its actual work status at all times. Status is the primary signal for what is active, blocked, or waiting. Use the project board's Status field (or an equivalent tracked field) as the source of truth.
+
+**Standard status values:**
+- **Backlog** → exists but work has not started
+- **In Progress** → actively being worked
+- **Blocked** → waiting on an external dependency, decision, or upstream fix
+- **Review Needed** → work done; assigned to a human reviewer with a comment explaining what to review and what the options are
+- **Done** → completed and closed
+
+**Rules:**
+- Every new issue must be placed in the project board at creation time.
+- When an agent starts work, move the issue to `In Progress` immediately — not after the first commit.
+- When review is needed, set status to `Review Needed`, assign to the reviewer, and add a comment with context.
+- When work is paused, leave the status as-is and add a comment explaining the pause.
+- Auditors treat issues actively worked but still in `Backlog` as a finding.
+
+### 20. Signal lifecycle
+Signals (`artifact:signal`) are transient by design — they capture observations, not permanent state. They must be resolved or absorbed within a reasonable time.
+
+**Signal closure rules:**
+1. **Absorbed:** When a signal is addressed by creating a downstream artifact (digest, mission, task, or PR), close the signal with a comment linking to the downstream artifact.
+2. **Ambiguous:** If unclear whether a signal is still relevant, assign it to the appropriate human with a comment requesting a review or closure decision. Do not leave stale signals open indefinitely.
+3. **Superseded:** If a newer signal covers the same ground, close the older one as `not_planned` with a reference to the newer signal.
+4. **Auto-close via PR:** If a task created from a signal is completed via PR merge using `closes #N` syntax, the signal closes automatically. Prefer this path when possible.
+
+Auditors treat open signals older than 14 days without linked downstream work as a finding.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,19 @@ The framework uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html): `
 
 ### Added
 
+- `AGENTS.md` Rule 19 "Issue status lifecycle" — defines standard status values (Backlog, In Progress, Blocked, Review Needed, Done), transition rules, and audit expectations for issue status accuracy. Ported and generalized from Sagicorp instance rule S7b.
+- `AGENTS.md` Rule 20 "Signal lifecycle" — defines signal closure rules (absorbed, ambiguous, superseded, auto-close via PR) and a 14-day staleness threshold for open signals without linked downstream work. Ported and generalized from Sagicorp instance rule S7c.
+
+### Changed
+
+- `AGENTS.md` — bumped document version to 4.4 for Rules 19 and 20 additions.
+
+---
+
+## [4.3.0] — 2026-03-28
+
+### Added
+
 - `AGENTS.md` Rule 15 "Challenge before creating" — codifies that missions and tasks must be reflected and challenged before creation, not created reflexively. Agents must assign to human owner when genuinely unsure.
 - `.github/ISSUE_TEMPLATE/config.yml` — set `blank_issues_enabled: false` to enforce structured issue creation via templates.
 - `docs/compliance/templates/_TEMPLATE-autonomy-tier-rollout-checklist.md` — adopter-facing checklist for raising an agent, workflow, or team's autonomy tier with named approver/supervisor/override roles, readiness signoff, monitoring ownership, rollback path, and change-management confirmation. Related to #190.


### PR DESCRIPTION
## What

Ports two Sagicorp-proven governance rules to the upstream framework as generic, instance-agnostic rules.

**Rule 19 — Issue status lifecycle:**
Defines canonical status values (Backlog → In Progress → Blocked → Review Needed → Done), transition rules, board placement requirements, and audit expectations. Addresses the gap where Rule 18 was only a prose reminder without explicit states or transition discipline.

**Rule 20 — Signal lifecycle:**
Defines four signal closure paths (absorbed, ambiguous, superseded, auto-close via PR) and a 14-day staleness threshold. Prevents signal accumulation that bloats the work queue and obscures real priorities.

## Why

These rules were validated in the Sagicorp instance (S7b/S7c) and have driven consistent audit findings when absent. They are generic enough to apply to any instance of this framework.

## Changes

- `AGENTS.md` — added Rules 19 and 20, bumped to v4.4
- `CHANGELOG.md` — documented additions under [Unreleased], moved prior v4.3 content under a dated [4.3.0] header

## Review options

- **Approve and merge** — adopt as-is
- **Request changes** — suggest rewording or scope adjustments
- **Close** — if the approach doesn't fit upstream direction

## Links

- Origin: WulfAI/sagicorp#32 (task tracking this port)
- Signal: WulfAI/sagicorp#30 (closes via PR merge)

closes WulfAI/sagicorp#32