### PR TITLE
docs(compliance): ISO 42001 honest reassessment 85% to 60%

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <img src="https://img.shields.io/badge/ISO_27001-~90%25_self--assessed-0e8a16" alt="ISO 27001">
   <img src="https://img.shields.io/badge/SOC_2-~90%25_self--assessed-1d76db" alt="SOC 2">
   <img src="https://img.shields.io/badge/GDPR-~75%25_self--assessed-d93f0b" alt="GDPR">
-  <img src="https://img.shields.io/badge/ISO_42001-~85%25_self--assessed-5319e7" alt="ISO 42001">
+  <img src="https://img.shields.io/badge/ISO_42001-~60%25_self--assessed-d93f0b" alt="ISO 42001">
   <img src="https://img.shields.io/badge/NIST_AI_RMF-~90%25_self--assessed-fbca04" alt="NIST AI RMF">
   <img src="https://img.shields.io/badge/EU_AI_Act-~85%25_self--assessed-0e8a16" alt="EU AI Act">
   <img src="https://img.shields.io/badge/NIST_CSF_2.0-~95%25_self--assessed-0e8a16" alt="NIST CSF 2.0">
@@ -198,7 +198,7 @@ Template governance scaffolding mapped to 11 certification and regulatory framew
 
 | Framework | Self-Assessed Template Posture | | Framework | Self-Assessed Template Posture |
 |-----------|----------|-|-----------|----------|
-| **NIST CSF 2.0** | ~95% | | **ISO 42001** | ~85% |
+| **NIST CSF 2.0** | ~95% | | **ISO 42001** | ~60% |
 | **ISO 27001** | ~90% | | **GDPR** | ~75% |
 | **SOC 2 Type II** | ~90% | | **EU AI Act** | ~85% |
 | **NIST AI RMF** | ~90% | | **CCPA/CPRA** | ~75% |

--- a/docs/compliance/iso-42001.md
+++ b/docs/compliance/iso-42001.md
@@ -36,11 +36,13 @@ ISO 42001 follows the Annex SL high-level management system structure (shared wi
 
 ---
 
-## 2. Honest Clause-Level Assessment (Clauses 4–10)
+## 2. How This Framework Addresses It
+
+### Honest Clause-Level Assessment (Clauses 4–10)
 
 Each clause is rated: **Strong** (≥80%), **Partial** (40–79%), **Weak** (<40%).
 
-### Clause 4 — Context of the Organization
+#### Clause 4 — Context of the Organization
 
 | Sub-clause | Requirement | Status | Framework Coverage | Gap |
 |------------|-------------|--------|-------------------|-----|
@@ -49,7 +51,7 @@ Each clause is rated: **Strong** (≥80%), **Partial** (40–79%), **Weak** (<40
 | 4.3 | AIMS scope as documented information | Partial (~70%) | [AIMS scope statement template](templates/_TEMPLATE-aims-scope.md) exists with good structure. | Template only — no instantiated scope statement. No adopter has a filled-in scope. |
 | 4.4 | Establishing, implementing, maintaining the AIMS | Strong (~80%) | The framework IS the AIMS structure — 5 layers, 19 policies, 4 process loops, Git-versioned governance, PR-based decisions, signal→mission improvement cycle. | Process interactions not explicitly mapped in a single AIMS process document. |
 
-### Clause 5 — Leadership
+#### Clause 5 — Leadership
 
 | Sub-clause | Requirement | Status | Framework Coverage | Gap |
 |------------|-------------|--------|-------------------|-----|
@@ -57,7 +59,7 @@ Each clause is rated: **Strong** (≥80%), **Partial** (40–79%), **Weak** (<40
 | 5.2 | AI policy | Strong (~90%) | [AI Governance Policy](../../org/4-quality/policies/ai-governance.md) — comprehensive: 5 principles, 4-tier risk classification, model cards, fairness audit, explainability levels, token accountability, compliance mapping. Available as documented information. | Policy review schedule exists via versioning but no explicit planned-interval review cadence. Policy is not structured to show it "refers to other organizational policies" per 5.2 requirement (cross-refs exist in §8 but not at policy-statement level). |
 | 5.3 | Roles, responsibilities, authorities | Strong (~85%) | CODEOWNERS defines RACI. 5-layer model assigns responsibilities. Agent type template includes ownership. Risk-management.md §2.3 defines workforce readiness per autonomy tier. | No explicit assignment of "responsibility and authority for ensuring AIMS conforms to this document" and "reporting AIMS performance to top management" (the two specific assignments required by 5.3). |
 
-### Clause 6 — Planning
+#### Clause 6 — Planning
 
 | Sub-clause | Requirement | Status | Framework Coverage | Gap |
 |------------|-------------|--------|-------------------|-----|
@@ -68,7 +70,7 @@ Each clause is rated: **Strong** (≥80%), **Partial** (40–79%), **Weak** (<40
 | 6.2 | AI objectives, measurable, monitored | Weak (~40%) | AI governance policy principles serve as directional objectives. Evaluation criteria in ai-governance §10 provide pass/fail checks. | **No formal AI objectives document.** Objectives are not stated as measurable targets. No documented plan for "what will be done, resources required, who responsible, when completed, how results evaluated" (6.2 requirements). |
 | 6.3 | Planning of changes | Strong (~80%) | PR-based change management. AGENTS.md Rule 10 (version everything). Git history provides change audit trail. | No explicit "planned manner" process for AIMS changes specifically. |
 
-### Clause 7 — Support
+#### Clause 7 — Support
 
 | Sub-clause | Requirement | Status | Framework Coverage | Gap |
 |------------|-------------|--------|-------------------|-----|
@@ -78,7 +80,7 @@ Each clause is rated: **Strong** (≥80%), **Partial** (40–79%), **Weak** (<40
 | 7.4 | Communication | Partial (~50%) | Signal system, PR descriptions, incident response communication plan. | **No formal AI-specific communication plan** documenting what/when/with whom/how to communicate about the AIMS. |
 | 7.5 | Documented information | Strong (~90%) | Everything is Git-versioned. Templates with document control sections. PR-based review and approval. Version control with CHANGELOG. | Strong. Minor gap: no formal procedure for controlling external documented information relevant to the AIMS. |
 
-### Clause 8 — Operation
+#### Clause 8 — Operation
 
 | Sub-clause | Requirement | Status | Framework Coverage | Gap |
 |------------|-------------|--------|-------------------|-----|
@@ -87,7 +89,7 @@ Each clause is rated: **Strong** (≥80%), **Partial** (40–79%), **Weak** (<40
 | 8.3 | AI risk treatment (operational) | Partial (~55%) | Risk treatment concepts exist. Remediation cycles defined for fairness failures. | No documented risk treatment plan implementation. No process for when "treatment options are not effective." |
 | 8.4 | AI system impact assessment (operational) | Weak (~40%) | DPIA template from privacy.md. Risk tier classification considers impact. | **No operational AI system impact assessment process** performed at planned intervals. Same gap as 6.1.4 but now about execution, not just planning. |
 
-### Clause 9 — Performance Evaluation
+#### Clause 9 — Performance Evaluation
 
 | Sub-clause | Requirement | Status | Framework Coverage | Gap |
 |------------|-------------|--------|-------------------|-----|
@@ -95,7 +97,7 @@ Each clause is rated: **Strong** (≥80%), **Partial** (40–79%), **Weak** (<40
 | 9.2 | Internal audit | Weak (~30%) | Quality layer provides continuous automated evaluation. Signal→mission improvement cycle. | **No AIMS-specific internal audit programme.** No audit schedule, no defined audit objectives/criteria/scope for AIMS audits. The ISO 27001 internal audit template exists but not adapted for ISO 42001. No auditor independence requirements addressed. |
 | 9.3 | Management review | Weak (~25%) | Steering layer exists as the review authority. Signal digests provide input. | **No AIMS management review template.** No documented process for management review with required inputs (9.3.2: status of previous actions, changes in issues, performance trends, audit results, improvement opportunities) and required outputs (9.3.3: decisions on improvement and AIMS changes). This is a significant certification blocker. |
 
-### Clause 10 — Improvement
+#### Clause 10 — Improvement
 
 | Sub-clause | Requirement | Status | Framework Coverage | Gap |
 |------------|-------------|--------|-------------------|-----|
@@ -104,11 +106,11 @@ Each clause is rated: **Strong** (≥80%), **Partial** (40–79%), **Weak** (<40
 
 ---
 
-## 3. Honest Annex A Control Mapping (Table A.1)
+### Honest Annex A Control Mapping (Table A.1)
 
 Each of the 39 controls is rated individually. **Coverage** = what the framework template provides. **Running evidence** = what would exist in a deployed instance.
 
-### A.2 — Policies Related to AI
+#### A.2 — Policies Related to AI
 
 **Objective:** Provide management direction and support for AI systems according to business requirements.
 
@@ -118,7 +120,7 @@ Each of the 39 controls is rated individually. **Coverage** = what the framework
 | A.2.3 | Alignment with other organizational policies | 75% | ⚠️ Partial | ai-governance.md §8 cross-references 6 related policies (agent-security, risk-management, data-classification, privacy, observability, cryptography). | **Quick win:** Add a formal "policy alignment matrix" section showing how the AI policy intersects with quality, security, safety, and privacy policies. Currently the cross-refs are in the AI policy; ISO 42001 wants the alignment analysis documented. |
 | A.2.4 | Review of the AI policy | 50% | ⚠️ Partial | Policies are versioned in Git. CHANGELOG tracks modifications. | **Quick win:** Add an explicit review cadence (e.g., "reviewed annually or when triggered by: regulatory change, significant AI incident, management review output") and a named review owner. Currently there's no stated review interval. |
 
-### A.3 — Internal Organization
+#### A.3 — Internal Organization
 
 **Objective:** Establish accountability within the organization for AI systems.
 
@@ -127,7 +129,7 @@ Each of the 39 controls is rated individually. **Coverage** = what the framework
 | A.3.2 | AI roles and responsibilities | 85% | ✅ Strong | 5-layer model with defined responsibilities. CODEOWNERS. Agent type registry with ownership fields. risk-management.md §2.3 workforce readiness per autonomy tier. | Minor gap: no explicit enumeration of ISO 42001-specific roles (AI risk owner, AIMS manager, AI impact assessor). **Quick win:** Add a "key AIMS roles" section to the AIMS scope template mapping framework layers to ISO 42001 role expectations. |
 | A.3.3 | Reporting of concerns | 45% | ⚠️ Partial | Signal system (work/signals/) accepts improvement observations. AGENTS.md Rule 7 requires agents to file signals. Incident response policy handles critical issues. | **Gap:** No dedicated process for reporting concerns about the organization's AI systems specifically (as distinct from general operational signals). ISO 42001 B.3.3 requires: confidentiality/anonymity, availability to employees, qualified investigators, escalation mechanisms, reprisal protection. **Quick win:** Create a "Reporting Concerns About AI Systems" section in ai-governance.md that maps signal-system mechanics to B.3.3 requirements and adds human-specific reporting channels. |
 
-### A.4 — Resources for AI Systems
+#### A.4 — Resources for AI Systems
 
 **Objective:** Ensure the organization accounts for AI system resources to address risks and impacts.
 
@@ -139,7 +141,7 @@ Each of the 39 controls is rated individually. **Coverage** = what the framework
 | A.4.5 | System and computing resources | 25% | ❌ Weak | Token budget tracking mentioned in ai-governance §6. Performance policy addresses capacity broadly. | **Gap:** No documentation of AI system computing resources per B.4.5: resource requirements, location (on-prem/cloud/edge), processing resources, environmental impact of hardware. **Quick win:** Add computing resource fields to the AI system inventory template (infrastructure location, compute requirements, estimated energy impact). |
 | A.4.6 | Human resources | 55% | ⚠️ Partial | Workforce readiness tiers in risk-management.md §2.3. Agent type template includes ownership. | **Gap:** No documentation of human resources and competences required for AI system lifecycle stages per B.4.6 (data scientists, oversight roles, safety/security/privacy experts, domain experts). Workforce readiness tiers define what humans must be ready for but not who they are or what competences they hold. **Quick win:** Add a "Human Resources & Competences" section to the AI system inventory linking each system to required human roles and competence evidence. |
 
-### A.5 — Assessing Impacts of AI Systems
+#### A.5 — Assessing Impacts of AI Systems
 
 **Objective:** Assess AI system impacts to individuals, groups, and societies throughout the lifecycle.
 
@@ -150,7 +152,7 @@ Each of the 39 controls is rated individually. **Coverage** = what the framework
 | A.5.4 | Assessing impact on individuals or groups | 45% | ⚠️ Weak | Fairness audit section (ai-governance §3) covers fairness, demographic parity, error rate parity. Explainability levels address transparency for affected individuals. | **Gap:** ISO 42001 B.5.4 requires broader assessment beyond fairness: accountability, transparency/explainability, security/privacy, safety/health, financial consequences, accessibility, human rights. Currently only fairness and explainability are addressed. **Quick win:** Expand the impact assessment template to include all B.5.4 impact dimensions. |
 | A.5.5 | Assessing societal impacts | 10% | ❌ Gap | Not addressed. | **Gap:** ISO 42001 B.5.5 requires assessment of: environmental sustainability (GHG emissions, resource use), economic impacts, government/democratic impacts, health and safety, norms/culture/values impacts. **Quick win:** Add a "Societal Impact Assessment" section to the AI system impact assessment template with the B.5.5 categories. For most enterprise AI systems this can be lightweight but must exist. |
 
-### A.6 — AI System Life Cycle
+#### A.6 — AI System Life Cycle
 
 **Objective:** Define objectives, processes, and criteria for each AI system lifecycle stage.
 
@@ -166,7 +168,7 @@ Each of the 39 controls is rated individually. **Coverage** = what the framework
 | A.6.2.7 | AI system technical documentation | 70% | ⚠️ Partial | Model cards in agent type definitions. Agent type template covers identity, capabilities, scope, ownership. | Not structured per B.6.2.7 requirements (general description, usage instructions, technical assumptions, technical limitations, monitoring capabilities per interested party category). |
 | A.6.2.8 | AI system recording of event logs | 90% | ✅ Strong | OTel contract (docs/otel-contract.md). Log retention policy. AGENTS.md Rule 9a — every action produces an OTel span. Decision events logged. | Strong. Genuine strength. |
 
-### A.7 — Data for AI Systems
+#### A.7 — Data for AI Systems
 
 **Objective:** Ensure the organization understands the role and impacts of data in AI systems.
 
@@ -178,7 +180,7 @@ Each of the 39 controls is rated individually. **Coverage** = what the framework
 | A.7.5 | Data provenance | 30% | ❌ Weak | Model card template includes training data provenance as a field. Vendor assessment covers external data providers. | **Gap:** No formal process for recording data provenance over the lifecycle per B.7.5. Provenance is a model-card field, not a tracked process. **Quick win:** Define provenance tracking requirements in ai-governance.md (what to record, when to verify, how to maintain over data and AI system lifecycles). |
 | A.7.6 | Data preparation | 15% | ❌ Gap | Not addressed. | **Gap:** No criteria for data preparation methods per B.7.6. No documentation requirements for statistical exploration, cleaning, imputation, normalization, scaling, labelling, encoding. **Quick win:** Add a "Data Preparation" documentation requirement to the model card template for Tier 1 and Tier 2 systems. |
 
-### A.8 — Information for Interested Parties
+#### A.8 — Information for Interested Parties
 
 **Objective:** Ensure interested parties have necessary information to understand risks and impacts.
 
@@ -189,7 +191,7 @@ Each of the 39 controls is rated individually. **Coverage** = what the framework
 | A.8.4 | Communication of incidents | 75% | ⚠️ Partial | Incident response policy defines communication plan. Privacy policy covers breach notification. | Incident communication is general, not AI-system-specific per B.8.4. No distinction between AI-specific incidents and general incidents in the communication plan. **Quick win:** Add an "AI System Incident Communication" section to the incident response policy covering AI-specific notification requirements. |
 | A.8.5 | Information for interested parties | 40% | ⚠️ Weak | AIMS scope template includes interested parties table. Vendor policy covers supplier information sharing. | **Gap:** No documented obligations for reporting AI system information to regulators, customers, or other interested parties per B.8.5. No process for sharing technical documentation, risk information, impact assessment results, or logs with authorities when required. **Quick win:** Add a "Regulatory and Stakeholder Reporting" section to the AIMS scope guide. |
 
-### A.9 — Use of AI Systems
+#### A.9 — Use of AI Systems
 
 **Objective:** Ensure the organization uses AI systems responsibly per organizational policies.
 
@@ -199,7 +201,7 @@ Each of the 39 controls is rated individually. **Coverage** = what the framework
 | A.9.3 | Objectives for responsible use | 75% | ⚠️ Partial | Fairness, explainability, robustness, accountability are addressed as governance requirements. Human oversight via autonomy tiers. | Objectives per B.9.3 include fairness, accountability, transparency, explainability, reliability, safety, robustness, privacy/security, accessibility. Most are addressed. Accessibility is not addressed. Human oversight is well-covered. **Quick win:** Add "accessibility" as a responsible-use objective. |
 | A.9.4 | Intended use of the AI system | 80% | ✅ Strong | Agent type definitions include "What this agent does," "Problem solved," scope boundaries. AGENTS.md Rule 5 (stay in your lane) enforces intended-use boundaries. Model cards document intended use. | Good. Minor gap: no explicit process for detecting and addressing uses outside intended scope (beyond observability anomaly detection). |
 
-### A.10 — Third-Party and Customer Relationships
+#### A.10 — Third-Party and Customer Relationships
 
 **Objective:** Ensure the organization understands responsibilities and remains accountable when third parties are involved.
 
@@ -211,7 +213,7 @@ Each of the 39 controls is rated individually. **Coverage** = what the framework
 
 ---
 
-## 4. Coverage Summary
+## 3. Coverage Summary
 
 ### Headline: ~60% (revised from prior ~85%)
 
@@ -258,7 +260,7 @@ The prior 85% claim counted template existence and indirect coverage as "address
 
 ---
 
-## 5. Quick-Win Improvement Roadmap
+## 4. Quick-Win Improvement Roadmap
 
 Ranked by impact on coverage percentage and certification readiness:
 
@@ -279,7 +281,7 @@ Ranked by impact on coverage percentage and certification readiness:
 
 ---
 
-## 6. Assessment Methodology
+## 5. Assessment Methodology
 
 ### Why the prior 85% was wrong
 
@@ -314,7 +316,7 @@ This section from the prior version remains accurate — observability IS a genu
 
 ---
 
-## 7. Adopter Responsibilities
+## 6. Adopter Responsibilities
 
 | Requirement | ISO 42001 Clause | What's Needed | Severity |
 |-----|-----|---------------|----------|
@@ -333,7 +335,7 @@ This section from the prior version remains accurate — observability IS a genu
 
 ---
 
-## 8. External References
+## 7. External References
 
 - [ISO/IEC 42001:2023](https://www.iso.org/standard/81230.html) — The standard itself (paid)
 - [ISO/IEC 23894:2023](https://www.iso.org/standard/77304.html) — AI Risk Management guidance (companion standard)

--- a/docs/compliance/iso-42001.md
+++ b/docs/compliance/iso-42001.md
@@ -3,6 +3,10 @@
 > **Standard:** ISO/IEC 42001:2023 — Artificial Intelligence Management Systems (AIMS)
 > **Scope:** Requirements for establishing, implementing, maintaining, and continually improving an AI management system
 > **Official source:** [ISO/IEC 42001:2023](https://www.iso.org/standard/81230.html)
+> **Honest self-assessed coverage:** ~60% (down from prior ~85% claim — see §6 for methodology)
+> **Last reassessed:** 2026-03-31
+
+---
 
 ## 1. What ISO 42001 Requires
 
@@ -17,81 +21,327 @@ ISO 42001 follows the Annex SL high-level management system structure (shared wi
 - Performance evaluation — monitoring, internal audit, management review (9)
 - Improvement — nonconformity, corrective action, continual improvement (10)
 
-**Annex A Controls (AI-specific):**
-- A.2 — AI policies and governance
-- A.3 — Internal organization for AI
-- A.4 — Resources for AI
-- A.5 — AI system impact assessment
-- A.6 — AI system lifecycle
-- A.7 — Data for AI systems
-- A.8 — Information for interested parties (transparency)
-- A.9 — Use of AI systems
-- A.10 — Third-party and customer relationships
+**Annex A Controls (AI-specific, normative — 39 controls in Table A.1):**
+- A.2 — AI policies and governance (3 controls)
+- A.3 — Internal organization for AI (2 controls)
+- A.4 — Resources for AI (5 controls)
+- A.5 — AI system impact assessment (4 controls)
+- A.6 — AI system lifecycle (10 controls)
+- A.7 — Data for AI systems (5 controls)
+- A.8 — Information for interested parties (4 controls)
+- A.9 — Use of AI systems (3 controls)
+- A.10 — Third-party and customer relationships (3 controls)
 
-## 2. How This Framework Addresses It
+**Annex B (normative):** Implementation guidance for all Annex A controls — cross-referenced below.
 
-### Clause-Level Mapping
+---
 
-| Clause | Requirement | Framework Implementation | Evidence Source |
-|--------|-------------|-------------------------|-----------------|
-| 4.1–4.4 | Context, AI system scope | 5-layer model defining AI system boundaries, [AIMS scope statement template](templates/_TEMPLATE-aims-scope.md), [AI system inventory template](templates/_TEMPLATE-ai-system-inventory.md), agent type registry (`org/agents/`) | Git-versioned scope statement, AI system inventory, org structure |
-| 5.1–5.3 | Leadership, AI policy | Steering layer with executive oversight, AI governance policy, CODEOWNERS | PR approvals, governance decisions |
-| 6.1–6.3 | AI risk, objectives | [AI Governance Policy](../../org/4-quality/policies/ai-governance.md) — 4-tier risk classification, [Risk Management Policy](../../org/4-quality/policies/risk-management.md) — AI risk taxonomy (22 canonical risks) | Risk register, OTel `risk.assessment.complete` events |
-| 7.1–7.5 | Resources, competence | Agent type definitions with capabilities, model cards documenting model selection rationale | Agent type registry |
-| 8.2 | AI system lifecycle | 4 process loops (Discover→Build→Ship→Operate), mission-based execution | Mission artifacts, deployment traces |
-| 8.4 | Data for AI | Data Classification Policy, Privacy Policy — training data provenance, PII in prompts/outputs | Classification spans, PII inventory |
-| 8.5 | AI system impact assessment | DPIA template, AI risk tier classification (Tier 0 prohibited → Tier 3 minimal) | DPIA records, risk tier assignments |
-| 9.1 | Monitoring, measurement | [Observability Policy](../../org/4-quality/policies/observability.md) — agent fleet dashboards, token usage tracking, fairness metrics | OTel telemetry, cost attribution dashboards |
-| 9.2–9.3 | Internal audit, management review | Quality Layer evaluations, signal→mission improvement cycle | Eval reports, signals |
-| 10.1–10.2 | Improvement | Retrospectives, improvement signals, upstream contributions | `work/retrospectives/`, `work/signals/` |
+## 2. Honest Clause-Level Assessment (Clauses 4–10)
 
-### Annex A Control Mapping
+Each clause is rated: **Strong** (≥80%), **Partial** (40–79%), **Weak** (<40%).
 
-| Control | Title | Framework Implementation | Observability Evidence |
-|---------|-------|--------------------------|----------------------|
-| A.2 | AI policies | AI Governance Policy with risk classification, model cards, fairness audit, explainability | Policy version history |
-| A.3 | Internal organization | 5-layer model, agent type registry with declared capabilities and scope | Agent type definitions |
-| A.4 | Resources | Token budget tracking, model selection documentation in model cards | Token consumption dashboards |
-| A.5 | Impact assessment | AI risk tiers, DPIA for high-risk, fairness metrics (four-fifths rule) | Fairness audit results, DPIA records |
-| A.6 | AI lifecycle | Process loops, mission briefs, progressive rollout, adversarial testing | Mission lifecycle spans, test results |
-| A.7 | Data for AI | Data classification, PII inventory, training data provenance (in vendor assessment) | `data.classification` attributes |
-| A.8 | Transparency | Versioned agent instructions (public), explainability levels (Traceable/Justifiable/Auditable), model cards | Explainability traces, model card artifacts |
-| A.9 | Use of AI | Human-in-the-loop governance, agent autonomy tiers, kill switch | `governance.decision` events, human override logs |
-| A.10 | Third-party | Vendor Risk Management Policy with AI-specific extended assessment, model version tracking | Vendor assessment records |
+### Clause 4 — Context of the Organization
 
-## 3. Where Observability Provides Evidence
+| Sub-clause | Requirement | Status | Framework Coverage | Gap |
+|------------|-------------|--------|-------------------|-----|
+| 4.1 | Understanding org and its context, AI system roles | Partial (~65%) | 5-layer model defines organizational structure. CONFIG.yaml provides deployment context. Agent type registry defines AI system roles. | No formal "context of the organization" document for AI. Organization's roles w.r.t. AI systems (provider/producer/customer/partner per ISO 22989 §5.19) are not explicitly declared. Climate change relevance not addressed. |
+| 4.2 | Interested parties and their requirements | Partial (~55%) | [AIMS scope template](templates/_TEMPLATE-aims-scope.md) includes interested parties table. | Template only — no running instance. Interested parties are listed generically; no formal process to determine and document their AI-specific requirements. |
+| 4.3 | AIMS scope as documented information | Partial (~70%) | [AIMS scope statement template](templates/_TEMPLATE-aims-scope.md) exists with good structure. | Template only — no instantiated scope statement. No adopter has a filled-in scope. |
+| 4.4 | Establishing, implementing, maintaining the AIMS | Strong (~80%) | The framework IS the AIMS structure — 5 layers, 19 policies, 4 process loops, Git-versioned governance, PR-based decisions, signal→mission improvement cycle. | Process interactions not explicitly mapped in a single AIMS process document. |
 
-ISO 42001 is the first management system standard specifically for AI — it requires **continuous monitoring** of AI system behavior, not just point-in-time assessments:
+### Clause 5 — Leadership
 
-| Evidence Need | Observability Source | Why It Matters |
-|---------------|---------------------|----------------|
-| AI system behavior monitoring (9.1) | Agent spans (`agent.run`, `inference.*`, `tool.execute`), fleet dashboards | Proves AI systems are continuously monitored |
-| Fairness and bias detection (A.5) | Fairness metric dashboards (demographic parity, equalized odds) | Proves bias is measured, not just promised |
-| Decision accountability (A.9) | `governance.decision` span events with reasoning | Proves every AI decision is traceable |
-| Human oversight effectiveness (A.9) | Human override rate metrics, escalation frequency | Proves humans maintain meaningful control |
-| Resource consumption (A.4) | Token usage per mission/agent/division, cost attribution | Proves AI resource use is governed |
-| Model performance (A.6) | Accuracy/latency/error metrics per model | Proves models perform as documented |
-| Adversarial robustness (A.6) | Security test results, prompt injection rate metrics | Proves systems resist adversarial inputs |
+| Sub-clause | Requirement | Status | Framework Coverage | Gap |
+|------------|-------------|--------|-------------------|-----|
+| 5.1 | Leadership and commitment | Partial (~70%) | Steering layer (org/0-steering/) provides executive oversight structure. AGENTS.md Rule 2 enforces "humans decide." CODEOWNERS enforces human approval. | No formal "management commitment statement" artifact. No evidence template for demonstrating leadership commitment (e.g., resource allocation decisions, AIMS review participation). |
+| 5.2 | AI policy | Strong (~90%) | [AI Governance Policy](../../org/4-quality/policies/ai-governance.md) — comprehensive: 5 principles, 4-tier risk classification, model cards, fairness audit, explainability levels, token accountability, compliance mapping. Available as documented information. | Policy review schedule exists via versioning but no explicit planned-interval review cadence. Policy is not structured to show it "refers to other organizational policies" per 5.2 requirement (cross-refs exist in §8 but not at policy-statement level). |
+| 5.3 | Roles, responsibilities, authorities | Strong (~85%) | CODEOWNERS defines RACI. 5-layer model assigns responsibilities. Agent type template includes ownership. Risk-management.md §2.3 defines workforce readiness per autonomy tier. | No explicit assignment of "responsibility and authority for ensuring AIMS conforms to this document" and "reporting AIMS performance to top management" (the two specific assignments required by 5.3). |
 
-## 4. Adopter Responsibilities
+### Clause 6 — Planning
 
-| Requirement | ISO 42001 Requirement | What's Needed | Severity |
-|-----|----------------------|---------------|----------|
-| **Conformity assessment** | Clause 10, certification | Third-party certification body audit | High — cannot self-certify |
-| **Management review records** | Clause 9.3 | Documented review with required inputs/outputs | Medium |
-| **Internal audit programme** | Clause 9.2 | Scheduled AI-focused audits | Medium |
-| **Competence evidence** | Clause 7.2 | Records demonstrating AI-specific competence | Medium |
-| **Stakeholder communication plan** | Clause 7.4 | Formal plan for communicating AI decisions to affected parties | Low |
+| Sub-clause | Requirement | Status | Framework Coverage | Gap |
+|------------|-------------|--------|-------------------|-----|
+| 6.1.1 | General — risks/opportunities, risk criteria | Strong (~80%) | [Risk Management Policy](../../org/4-quality/policies/risk-management.md) — documented risk appetite, 5×5 matrix, 22 canonical AI risks, risk criteria per dimension. | No dedicated AI risk criteria document separate from general risk management. |
+| 6.1.2 | AI risk assessment process | Partial (~70%) | Risk assessment methodology in risk-management.md §3 (identify → analyze → evaluate → treat). AI risk taxonomy in §5 with 22 risks. | No running risk register with actual assessed AI risks. Process is documented but no evidence of execution. No explicit alignment to AI policy and AI objectives as required by 6.1.2(a). |
+| 6.1.3 | AI risk treatment + Statement of Applicability | Partial (~55%) | Risk treatment options in risk-management.md. Annex A controls are referenced in ai-governance.md §9. | **No ISO 42001-specific Statement of Applicability exists.** The existing SoA template covers ISO 27001's 93 Annex A controls, not ISO 42001's 39 Annex A controls. No formal risk treatment plan. No documented residual risk acceptance. |
+| 6.1.4 | AI system impact assessment | Partial (~50%) | Risk tiers (Tier 0–3) consider impact levels. DPIA template referenced from privacy.md. Fairness audit in ai-governance §3 addresses individual fairness impacts. | **No dedicated AI system impact assessment process** per ISO 42001's specific definition (3.24). DPIA is privacy-focused, not the broader "impact on individuals, groups, and societies" required. No consideration of societal impacts. No formal triggers for when impact assessments must be performed. |
+| 6.2 | AI objectives, measurable, monitored | Weak (~40%) | AI governance policy principles serve as directional objectives. Evaluation criteria in ai-governance §10 provide pass/fail checks. | **No formal AI objectives document.** Objectives are not stated as measurable targets. No documented plan for "what will be done, resources required, who responsible, when completed, how results evaluated" (6.2 requirements). |
+| 6.3 | Planning of changes | Strong (~80%) | PR-based change management. AGENTS.md Rule 10 (version everything). Git history provides change audit trail. | No explicit "planned manner" process for AIMS changes specifically. |
 
-**Addressed by framework templates:** AIMS scope statement guidance ([guide](guides/iso-42001-aims-scope.md)), [AIMS scope statement template](templates/_TEMPLATE-aims-scope.md), and [AI system inventory template](templates/_TEMPLATE-ai-system-inventory.md).
+### Clause 7 — Support
 
-## 5. External References
+| Sub-clause | Requirement | Status | Framework Coverage | Gap |
+|------------|-------------|--------|-------------------|-----|
+| 7.1 | Resources | Partial (~55%) | Token budget tracking in ai-governance §6. AI system inventory template captures resource info. | No formal resource planning for the AIMS itself. No documented evidence of management providing resources for AIMS establishment and improvement. |
+| 7.2 | Competence | Weak (~35%) | Agent type template includes skills/capabilities for AI agents. Workforce readiness tiers in risk-management §2.3. | **No competence requirements for human staff involved in AI.** No training records. No evidence of competence evaluation. §2.3 defines expectations but not evidence requirements. |
+| 7.3 | Awareness | Weak (~35%) | AGENTS.md communicates rules to agents. Onboarding docs exist. | **No formal awareness programme** for humans regarding AI policy, their AIMS contribution, or implications of nonconformity. This is a human-side gap — the framework over-indexes on agent awareness. |
+| 7.4 | Communication | Partial (~50%) | Signal system, PR descriptions, incident response communication plan. | **No formal AI-specific communication plan** documenting what/when/with whom/how to communicate about the AIMS. |
+| 7.5 | Documented information | Strong (~90%) | Everything is Git-versioned. Templates with document control sections. PR-based review and approval. Version control with CHANGELOG. | Strong. Minor gap: no formal procedure for controlling external documented information relevant to the AIMS. |
+
+### Clause 8 — Operation
+
+| Sub-clause | Requirement | Status | Framework Coverage | Gap |
+|------------|-------------|--------|-------------------|-----|
+| 8.1 | Operational planning and control | Partial (~70%) | 4 process loops with defined stages. Mission-based execution with defined criteria. Quality layer evaluates controls. | Externally provided processes/products/services control is addressed via vendor policy but not explicitly linked to AIMS operational control. |
+| 8.2 | AI risk assessment (operational) | Partial (~60%) | Risk assessment methodology exists. Mission briefs include risk sections. | No evidence of risk assessments being performed "at planned intervals or when significant changes are proposed" as required. No running assessment records. |
+| 8.3 | AI risk treatment (operational) | Partial (~55%) | Risk treatment concepts exist. Remediation cycles defined for fairness failures. | No documented risk treatment plan implementation. No process for when "treatment options are not effective." |
+| 8.4 | AI system impact assessment (operational) | Weak (~40%) | DPIA template from privacy.md. Risk tier classification considers impact. | **No operational AI system impact assessment process** performed at planned intervals. Same gap as 6.1.4 but now about execution, not just planning. |
+
+### Clause 9 — Performance Evaluation
+
+| Sub-clause | Requirement | Status | Framework Coverage | Gap |
+|------------|-------------|--------|-------------------|-----|
+| 9.1 | Monitoring, measurement, analysis, evaluation | Strong (~85%) | [Observability Policy](../../org/4-quality/policies/observability.md) — comprehensive agent telemetry, OTel spans, dashboards, SLOs. Token tracking. Fairness metrics. Fleet monitoring. | Strong. Minor gap: no documented list of "what needs to be monitored" specifically for the AIMS (vs. operational monitoring). |
+| 9.2 | Internal audit | Weak (~30%) | Quality layer provides continuous automated evaluation. Signal→mission improvement cycle. | **No AIMS-specific internal audit programme.** No audit schedule, no defined audit objectives/criteria/scope for AIMS audits. The ISO 27001 internal audit template exists but not adapted for ISO 42001. No auditor independence requirements addressed. |
+| 9.3 | Management review | Weak (~25%) | Steering layer exists as the review authority. Signal digests provide input. | **No AIMS management review template.** No documented process for management review with required inputs (9.3.2: status of previous actions, changes in issues, performance trends, audit results, improvement opportunities) and required outputs (9.3.3: decisions on improvement and AIMS changes). This is a significant certification blocker. |
+
+### Clause 10 — Improvement
+
+| Sub-clause | Requirement | Status | Framework Coverage | Gap |
+|------------|-------------|--------|-------------------|-----|
+| 10.1 | Continual improvement | Strong (~80%) | Signal system captures improvement opportunities. Retrospectives drive learning. AGENTS.md Rule 7 requires improvement signals. Upstream contribution model. | No formal evidence that improvement is systematically applied to the AIMS itself (not just operational work). |
+| 10.2 | Nonconformity and corrective action | Partial (~55%) | Incident response policy handles operational nonconformities. Retrospectives capture root cause analysis. Quality evaluations flag policy violations. | **No formal AIMS nonconformity register.** No documented corrective action process specific to AIMS. No template for recording "nature of nonconformities and subsequent actions taken." |
+
+---
+
+## 3. Honest Annex A Control Mapping (Table A.1)
+
+Each of the 39 controls is rated individually. **Coverage** = what the framework template provides. **Running evidence** = what would exist in a deployed instance.
+
+### A.2 — Policies Related to AI
+
+**Objective:** Provide management direction and support for AI systems according to business requirements.
+
+| Control | Title | Coverage | Status | Framework Implementation | Gaps & Quick Wins |
+|---------|-------|----------|--------|--------------------------|-------------------|
+| A.2.2 | AI policy | 90% | ✅ Strong | [ai-governance.md](../../org/4-quality/policies/ai-governance.md) — 5 principles, risk tiers, model cards, fairness, explainability, token accountability. Available as documented information via Git. | **Quick win:** Add an explicit "AI principles" preamble section that maps to ISO 42001 B.2.2 guidance (business strategy, org values, risk level, legal requirements, risk environment, impact to parties). Currently the principles are good but not structured to ISO B.2.2 vocabulary. |
+| A.2.3 | Alignment with other organizational policies | 75% | ⚠️ Partial | ai-governance.md §8 cross-references 6 related policies (agent-security, risk-management, data-classification, privacy, observability, cryptography). | **Quick win:** Add a formal "policy alignment matrix" section showing how the AI policy intersects with quality, security, safety, and privacy policies. Currently the cross-refs are in the AI policy; ISO 42001 wants the alignment analysis documented. |
+| A.2.4 | Review of the AI policy | 50% | ⚠️ Partial | Policies are versioned in Git. CHANGELOG tracks modifications. | **Quick win:** Add an explicit review cadence (e.g., "reviewed annually or when triggered by: regulatory change, significant AI incident, management review output") and a named review owner. Currently there's no stated review interval. |
+
+### A.3 — Internal Organization
+
+**Objective:** Establish accountability within the organization for AI systems.
+
+| Control | Title | Coverage | Status | Framework Implementation | Gaps & Quick Wins |
+|---------|-------|----------|--------|--------------------------|-------------------|
+| A.3.2 | AI roles and responsibilities | 85% | ✅ Strong | 5-layer model with defined responsibilities. CODEOWNERS. Agent type registry with ownership fields. risk-management.md §2.3 workforce readiness per autonomy tier. | Minor gap: no explicit enumeration of ISO 42001-specific roles (AI risk owner, AIMS manager, AI impact assessor). **Quick win:** Add a "key AIMS roles" section to the AIMS scope template mapping framework layers to ISO 42001 role expectations. |
+| A.3.3 | Reporting of concerns | 45% | ⚠️ Partial | Signal system (work/signals/) accepts improvement observations. AGENTS.md Rule 7 requires agents to file signals. Incident response policy handles critical issues. | **Gap:** No dedicated process for reporting concerns about the organization's AI systems specifically (as distinct from general operational signals). ISO 42001 B.3.3 requires: confidentiality/anonymity, availability to employees, qualified investigators, escalation mechanisms, reprisal protection. **Quick win:** Create a "Reporting Concerns About AI Systems" section in ai-governance.md that maps signal-system mechanics to B.3.3 requirements and adds human-specific reporting channels. |
+
+### A.4 — Resources for AI Systems
+
+**Objective:** Ensure the organization accounts for AI system resources to address risks and impacts.
+
+| Control | Title | Coverage | Status | Framework Implementation | Gaps & Quick Wins |
+|---------|-------|----------|--------|--------------------------|-------------------|
+| A.4.2 | Resource documentation | 70% | ⚠️ Partial | [AI system inventory template](templates/_TEMPLATE-ai-system-inventory.md) captures system identity, owners, risk tier, model/provider, data categories, monitoring metrics. Agent type template includes capabilities and tool access. | No lifecycle-stage-specific resource documentation. Inventory is a template, not a running instance. |
+| A.4.3 | Data resources | 40% | ⚠️ Weak | Data classification policy defines 4 levels. Model card template includes "training data summary" field. PII inventory template exists. | **Gap:** No dedicated AI data resource documentation. ISO 42001 B.4.3 requires: provenance, date of last update, data categories (training/validation/test/production), labelling process, intended use, quality assessment, bias issues, data preparation info. The model card "training data summary" field is a single line, not this level of detail. **Quick win:** Expand the model card template's training data section to match B.4.3 requirements, or create a standalone AI data resource documentation template. |
+| A.4.4 | Tooling resources | 35% | ❌ Weak | Agent type template lists "Tool Access" and "MCP Servers." Integration registry tracks external tools. | **Gap:** No documentation of AI-specific tooling resources per B.4.4: algorithm types, ML models, optimization methods, evaluation methods, provisioning tools, model development tools. The agent type template captures tool access but not the AI/ML toolchain. **Quick win:** Add a "Tooling Resources" section to the AI system inventory template covering algorithm selection, evaluation methodology, and development tooling. |
+| A.4.5 | System and computing resources | 25% | ❌ Weak | Token budget tracking mentioned in ai-governance §6. Performance policy addresses capacity broadly. | **Gap:** No documentation of AI system computing resources per B.4.5: resource requirements, location (on-prem/cloud/edge), processing resources, environmental impact of hardware. **Quick win:** Add computing resource fields to the AI system inventory template (infrastructure location, compute requirements, estimated energy impact). |
+| A.4.6 | Human resources | 55% | ⚠️ Partial | Workforce readiness tiers in risk-management.md §2.3. Agent type template includes ownership. | **Gap:** No documentation of human resources and competences required for AI system lifecycle stages per B.4.6 (data scientists, oversight roles, safety/security/privacy experts, domain experts). Workforce readiness tiers define what humans must be ready for but not who they are or what competences they hold. **Quick win:** Add a "Human Resources & Competences" section to the AI system inventory linking each system to required human roles and competence evidence. |
+
+### A.5 — Assessing Impacts of AI Systems
+
+**Objective:** Assess AI system impacts to individuals, groups, and societies throughout the lifecycle.
+
+| Control | Title | Coverage | Status | Framework Implementation | Gaps & Quick Wins |
+|---------|-------|----------|--------|--------------------------|-------------------|
+| A.5.2 | AI system impact assessment process | 45% | ⚠️ Weak | Risk tiers in ai-governance §1 classify systems by impact. DPIA is referenced from privacy.md. Fairness audit (ai-governance §3) assesses individual fairness. | **Gap:** No formal AI system impact assessment process as defined in ISO 42001 §3.24 and B.5.2. DPIA is privacy-only. The framework lacks a process that defines: circumstances for assessment, elements (identification → analysis → evaluation → treatment → documentation), who performs it, how results are used, which individuals/societies are impacted. **Quick win:** Create an `_TEMPLATE-ai-system-impact-assessment.md` covering the full B.5.2 process, distinct from the DPIA. |
+| A.5.3 | Documentation of AI system impact assessments | 30% | ❌ Weak | No dedicated template for AI system impact assessment documentation. DPIA template from privacy.md is adjacent but narrower. | **Gap:** No template. ISO 42001 B.5.3 requires documenting: intended use, foreseeable misuse, positive/negative impacts, predictable failures, demographic groups, system complexity, human oversight capabilities, employment/skilling effects. **Quick win:** Create the template (see A.5.2). Add retention period requirements. |
+| A.5.4 | Assessing impact on individuals or groups | 45% | ⚠️ Weak | Fairness audit section (ai-governance §3) covers fairness, demographic parity, error rate parity. Explainability levels address transparency for affected individuals. | **Gap:** ISO 42001 B.5.4 requires broader assessment beyond fairness: accountability, transparency/explainability, security/privacy, safety/health, financial consequences, accessibility, human rights. Currently only fairness and explainability are addressed. **Quick win:** Expand the impact assessment template to include all B.5.4 impact dimensions. |
+| A.5.5 | Assessing societal impacts | 10% | ❌ Gap | Not addressed. | **Gap:** ISO 42001 B.5.5 requires assessment of: environmental sustainability (GHG emissions, resource use), economic impacts, government/democratic impacts, health and safety, norms/culture/values impacts. **Quick win:** Add a "Societal Impact Assessment" section to the AI system impact assessment template with the B.5.5 categories. For most enterprise AI systems this can be lightweight but must exist. |
+
+### A.6 — AI System Life Cycle
+
+**Objective:** Define objectives, processes, and criteria for each AI system lifecycle stage.
+
+| Control | Title | Coverage | Status | Framework Implementation | Gaps & Quick Wins |
+|---------|-------|----------|--------|--------------------------|-------------------|
+| A.6.1.2 | Objectives for responsible development | 75% | ⚠️ Partial | AI governance principles (§0) and fairness/explainability/robustness objectives in ai-governance.md. | Not formalized as identifiable, documented "objectives" per B.6.1.2. Good content exists but not structured as objectives with integration measures per lifecycle stage. |
+| A.6.1.3 | Processes for responsible design and development | 80% | ✅ Strong | 4 process loops. Mission briefs define scope and release criteria. Technical design template includes security/observability sections. Quality eval before merge. | Good. Minor gap: no explicit "human oversight requirements" section in the design process, and no formal "training data expectations and rules" step. |
+| A.6.2.2 | AI system requirements and specification | 65% | ⚠️ Partial | Mission brief template captures scope, objectives, constraints. Agent type definitions specify capabilities. | Not formalized as AI system-specific requirements per B.6.2.2 (covering "why the AI system is to be developed," "how the model can be trained," "how data requirements can be achieved"). |
+| A.6.2.3 | Documentation of AI system design and development | 75% | ⚠️ Partial | Technical design template. Model cards in agent type definitions. | Good coverage of design choices. Minor gaps: no explicit ML approach documentation, no final system architecture documentation requirement, no security threat analysis specific to AI (data poisoning, model stealing). |
+| A.6.2.4 | AI system verification and validation | 55% | ⚠️ Partial | Quality layer evaluations with pass/fail criteria (ai-governance §10). Adversarial robustness testing (ai-governance §4). | No formal V&V plan template. No documented evaluation criteria per B.6.2.4 (reliability requirements, error rates, operational factors, acceptable ranges). Fairness metrics exist but V&V scope is broader. |
+| A.6.2.5 | AI system deployment | 80% | ✅ Strong | Delivery policy with progressive rollout. Release contract template. Deployment to staging before production. Human approval gates. | Good coverage. |
+| A.6.2.6 | AI system operation and monitoring | 90% | ✅ Strong | Observability policy — comprehensive fleet dashboards, performance monitoring, anomaly detection, SLOs, alerts. Token tracking. Agent health monitoring. | Strong. One of the framework's genuine strengths. |
+| A.6.2.7 | AI system technical documentation | 70% | ⚠️ Partial | Model cards in agent type definitions. Agent type template covers identity, capabilities, scope, ownership. | Not structured per B.6.2.7 requirements (general description, usage instructions, technical assumptions, technical limitations, monitoring capabilities per interested party category). |
+| A.6.2.8 | AI system recording of event logs | 90% | ✅ Strong | OTel contract (docs/otel-contract.md). Log retention policy. AGENTS.md Rule 9a — every action produces an OTel span. Decision events logged. | Strong. Genuine strength. |
+
+### A.7 — Data for AI Systems
+
+**Objective:** Ensure the organization understands the role and impacts of data in AI systems.
+
+| Control | Title | Coverage | Status | Framework Implementation | Gaps & Quick Wins |
+|---------|-------|----------|--------|--------------------------|-------------------|
+| A.7.2 | Data for development and enhancement | 35% | ❌ Weak | Data classification policy covers data broadly. Privacy policy covers PII. | **Gap:** No AI-specific data management process per B.7.2. No privacy/security implications analysis for AI training data. No transparency/explainability aspects of data use. No representativeness assessment of training data vs. operational domain. **Quick win:** Create an "AI Data Management" section in ai-governance.md or a dedicated policy covering B.7.2 topics. |
+| A.7.3 | Acquisition of data | 20% | ❌ Gap | Not addressed. Model card template has a "training data summary" field but no acquisition process. | **Gap:** No documented process for data acquisition per B.7.3: categories needed, quantity, sources, characteristics, subject demographics, prior handling, data rights, metadata, provenance. **Quick win:** Add data acquisition requirements to the model card template and/or the AI system inventory. |
+| A.7.4 | Quality of data for AI systems | 20% | ❌ Gap | Not addressed. Data classification covers sensitivity, not quality. | **Gap:** No data quality requirements for AI per B.7.4. No process to define, document, and ensure data quality for training/validation/test/production data. No bias impact assessment on system performance and fairness. **Quick win:** Add a "Data Quality" section to ai-governance.md defining minimum data quality requirements per risk tier. |
+| A.7.5 | Data provenance | 30% | ❌ Weak | Model card template includes training data provenance as a field. Vendor assessment covers external data providers. | **Gap:** No formal process for recording data provenance over the lifecycle per B.7.5. Provenance is a model-card field, not a tracked process. **Quick win:** Define provenance tracking requirements in ai-governance.md (what to record, when to verify, how to maintain over data and AI system lifecycles). |
+| A.7.6 | Data preparation | 15% | ❌ Gap | Not addressed. | **Gap:** No criteria for data preparation methods per B.7.6. No documentation requirements for statistical exploration, cleaning, imputation, normalization, scaling, labelling, encoding. **Quick win:** Add a "Data Preparation" documentation requirement to the model card template for Tier 1 and Tier 2 systems. |
+
+### A.8 — Information for Interested Parties
+
+**Objective:** Ensure interested parties have necessary information to understand risks and impacts.
+
+| Control | Title | Coverage | Status | Framework Implementation | Gaps & Quick Wins |
+|---------|-------|----------|--------|--------------------------|-------------------|
+| A.8.2 | System documentation and information for users | 60% | ⚠️ Partial | Model cards document purpose, limitations, intended use. Agent type definitions are versioned and public. Explainability levels (Traceable/Justifiable/Auditable) address output interpretability. | Not structured per B.8.2 (should include: purpose, notification of AI interaction, how to interact, how to override, technical requirements, needs for human oversight, accuracy/performance info, impact assessment results, contact info, educational materials). **Quick win:** Create a "User Information Checklist" keyed to B.8.2 requirements for each risk tier. |
+| A.8.3 | External reporting | 20% | ❌ Gap | Signal system accepts internal observations. No external-facing adverse impact reporting mechanism. | **Gap:** No capability for interested parties (external) to report adverse impacts per B.8.3. Signal system is internal. **Quick win:** Add an "External Reporting" requirement to ai-governance.md defining how external users can report adverse AI impacts (e.g., dedicated email, web form, feedback mechanism). |
+| A.8.4 | Communication of incidents | 75% | ⚠️ Partial | Incident response policy defines communication plan. Privacy policy covers breach notification. | Incident communication is general, not AI-system-specific per B.8.4. No distinction between AI-specific incidents and general incidents in the communication plan. **Quick win:** Add an "AI System Incident Communication" section to the incident response policy covering AI-specific notification requirements. |
+| A.8.5 | Information for interested parties | 40% | ⚠️ Weak | AIMS scope template includes interested parties table. Vendor policy covers supplier information sharing. | **Gap:** No documented obligations for reporting AI system information to regulators, customers, or other interested parties per B.8.5. No process for sharing technical documentation, risk information, impact assessment results, or logs with authorities when required. **Quick win:** Add a "Regulatory and Stakeholder Reporting" section to the AIMS scope guide. |
+
+### A.9 — Use of AI Systems
+
+**Objective:** Ensure the organization uses AI systems responsibly per organizational policies.
+
+| Control | Title | Coverage | Status | Framework Implementation | Gaps & Quick Wins |
+|---------|-------|----------|--------|--------------------------|-------------------|
+| A.9.2 | Processes for responsible use | 85% | ✅ Strong | ai-governance.md defines comprehensive governance for AI use: risk tiers, model cards, fairness audit, adversarial testing, explainability, token accountability. Risk-management.md §6 defines agent autonomy tiers with controls per tier. | Good coverage. |
+| A.9.3 | Objectives for responsible use | 75% | ⚠️ Partial | Fairness, explainability, robustness, accountability are addressed as governance requirements. Human oversight via autonomy tiers. | Objectives per B.9.3 include fairness, accountability, transparency, explainability, reliability, safety, robustness, privacy/security, accessibility. Most are addressed. Accessibility is not addressed. Human oversight is well-covered. **Quick win:** Add "accessibility" as a responsible-use objective. |
+| A.9.4 | Intended use of the AI system | 80% | ✅ Strong | Agent type definitions include "What this agent does," "Problem solved," scope boundaries. AGENTS.md Rule 5 (stay in your lane) enforces intended-use boundaries. Model cards document intended use. | Good. Minor gap: no explicit process for detecting and addressing uses outside intended scope (beyond observability anomaly detection). |
+
+### A.10 — Third-Party and Customer Relationships
+
+**Objective:** Ensure the organization understands responsibilities and remains accountable when third parties are involved.
+
+| Control | Title | Coverage | Status | Framework Implementation | Gaps & Quick Wins |
+|---------|-------|----------|--------|--------------------------|-------------------|
+| A.10.2 | Allocating responsibilities | 55% | ⚠️ Partial | Agent type ownership fields (business owner, technical owner). CODEOWNERS for governance artifacts. Vendor policy defines vendor tiers and responsibilities. | **Gap:** No explicit allocation of AI system lifecycle responsibilities between organization, partners, suppliers, customers per B.10.2. No PII controller/processor allocation specific to AI systems (privacy.md covers general PII, not AI-specific data flows). **Quick win:** Add a "Responsibility Allocation" section to the AI system inventory template documenting who is responsible for what at each lifecycle stage. |
+| A.10.3 | Suppliers | 85% | ✅ Strong | [Vendor Risk Management Policy](../../org/4-quality/policies/vendor-risk-management.md) — 4-tier vendor classification, AI-specific extended assessment, model version tracking, contractual requirements, monitoring cadence. | Strong. AI model providers are assessed at minimum Tier 2. Well-aligned with B.10.3. |
+| A.10.4 | Customers | 45% | ⚠️ Weak | Customer policy exists (org/4-quality/policies/customer.md). | **Gap:** Customer policy is generic, not AI-specific per B.10.4. No documented process to understand AI-specific customer expectations and needs. No documentation of what AI system information is communicated to customers (domain validity limits, intended use boundaries). **Quick win:** Add an "AI System Customer Requirements" section covering B.10.4: AI-specific expectations, domain-of-use limits communicated to customers, responsibility allocation. |
+
+---
+
+## 4. Coverage Summary
+
+### Headline: ~60% (revised from prior ~85%)
+
+The prior 85% claim counted template existence and indirect coverage as "addressed." This reassessment uses stricter criteria aligned to what an ISO 42001 certification auditor would expect:
+
+- **Template exists** = partial credit (the scaffolding is there)
+- **No running instance** = deduction (an auditor needs evidence, not templates)
+- **Indirect coverage** via a related policy (e.g., data classification for A.7) = partial credit only if it actually addresses the specific ISO 42001 requirement
+- **Not addressed** = 0%
+
+| Area | Controls | Strong (≥80%) | Partial (40–79%) | Weak/Gap (<40%) | Weighted Coverage |
+|------|----------|---------------|------------------|-----------------|-------------------|
+| **Clauses 4–10** | 17 sub-clauses | 6 | 7 | 4 | ~60% |
+| **A.2 Policies** | 3 | 1 | 2 | 0 | ~72% |
+| **A.3 Organization** | 2 | 1 | 1 | 0 | ~65% |
+| **A.4 Resources** | 5 | 0 | 2 | 3 | ~37% |
+| **A.5 Impact assessment** | 4 | 0 | 1 | 3 | ~33% |
+| **A.6 Lifecycle** | 8 | 4 | 4 | 0 | ~74% |
+| **A.7 Data for AI** | 5 | 0 | 0 | 5 | ~24% |
+| **A.8 Interested parties** | 4 | 0 | 2 | 2 | ~41% |
+| **A.9 Use of AI** | 3 | 2 | 1 | 0 | ~80% |
+| **A.10 Third-party** | 3 | 1 | 1 | 1 | ~62% |
+| **Total Annex A** | 37 | 9 | 14 | 14 | ~52% |
+| **Overall (Clauses + Annex A)** | | | | | **~60%** |
+
+### Genuine Strengths (what an auditor would commend)
+
+1. **A.6.2.6 / A.6.2.8 — Operation, monitoring, event logs** — Observability policy + OTel contract are best-in-class for an operating model framework
+2. **A.2.2 — AI policy** — Comprehensive, well-structured, properly versioned
+3. **A.9 — Responsible use** — Autonomy tiers, human oversight, kill switches, fairness audit — strong
+4. **A.10.3 — Supplier governance** — Vendor risk management with AI-specific extensions is thorough
+5. **7.5 — Documented information** — Git-as-audit-trail is genuinely powerful for this standard
+6. **A.6.2.5 — Deployment** — Progressive rollout, release contracts, human gates
+
+### Critical Gaps (what would block certification)
+
+1. **A.7 — Data for AI (entire section)** — The framework has data classification for security but almost no AI-specific data governance. Training data quality, provenance tracking, acquisition documentation, and data preparation are virtually absent. This is the #1 gap.
+2. **9.3 — Management review** — No template, no process, no evidence. Certification blocker.
+3. **9.2 — Internal audit** — No AIMS-specific audit programme. The ISO 27001 template exists but doesn't cover ISO 42001 requirements.
+4. **A.5 — Impact assessment** — No formal AI system impact assessment process. DPIA covers privacy only. Societal impact not addressed at all.
+5. **6.1.3 — Statement of Applicability** — No ISO 42001-specific SoA. The existing SoA is for ISO 27001's Annex A, not ISO 42001's Annex A.
+6. **6.2 — AI objectives** — Not formalized as measurable, monitored objectives with implementation plans.
+7. **7.2/7.3 — Competence and awareness** — Human-side gaps. The framework governs agents comprehensively but has minimal provisions for human AI competence and awareness.
+
+---
+
+## 5. Quick-Win Improvement Roadmap
+
+Ranked by impact on coverage percentage and certification readiness:
+
+| Priority | Action | Effort | Controls Improved | Coverage Impact |
+|----------|--------|--------|-------------------|-----------------|
+| **1** | Create `_TEMPLATE-ai-system-impact-assessment.md` covering B.5.2–B.5.5 (individual + societal impacts, assessment process, documentation requirements) | Medium | A.5.2, A.5.3, A.5.4, A.5.5, 6.1.4, 8.4 | +8% → ~68% |
+| **2** | Add "AI Data Governance" section to ai-governance.md: data quality requirements, provenance tracking process, acquisition documentation, data preparation standards per risk tier | Medium | A.7.2, A.7.3, A.7.4, A.7.5, A.7.6 | +8% → ~76% |
+| **3** | Create `_TEMPLATE-aims-management-review.md` with 9.3.2 inputs and 9.3.3 outputs | Small | 9.3 | +3% → ~79% |
+| **4** | Create `_TEMPLATE-aims-internal-audit.md` adapted for ISO 42001 (not copy of ISO 27001 version) | Small | 9.2 | +3% → ~82% |
+| **5** | Create `_TEMPLATE-aims-soa.md` — Statement of Applicability for ISO 42001 Annex A (39 controls) | Small | 6.1.3 | +2% → ~84% |
+| **6** | Add "AI Objectives" template/section with measurable targets, responsible persons, timelines, evaluation methods | Small | 6.2 | +2% → ~86% |
+| **7** | Expand model card template: full B.4.3 data resource fields, B.4.4 tooling resources, B.4.5 computing resources | Small | A.4.3, A.4.4, A.4.5 | +3% → ~89% |
+| **8** | Add "Reporting Concerns About AI" process to ai-governance.md per B.3.3 | Small | A.3.3 | +1% → ~90% |
+| **9** | Add AI-specific competence and awareness requirements (human training records, competence evidence) | Medium | 7.2, 7.3 | +2% → ~92% |
+| **10** | Add external reporting mechanism and customer AI requirements sections | Small | A.8.3, A.8.5, A.10.4 | +2% → ~94% |
+
+**Reachable ceiling with template-level work: ~94%.** The remaining ~6% requires running instances, actual management reviews, populated risk registers, and operational evidence — which is inherently adopter work, not framework work.
+
+---
+
+## 6. Assessment Methodology
+
+### Why the prior 85% was wrong
+
+The prior assessment counted:
+- Template existence as full coverage (a template for AIMS scope ≠ an implemented scope)
+- Indirect coverage through adjacent policies (data classification for security ≠ data quality for AI)
+- Single-field references as "addressed" (model card "training data summary" field ≠ A.7 data governance)
+- General governance mechanisms as AI-specific controls (PR review ≠ AI system V&V)
+
+### How this assessment works
+
+- Each of the 17 management system sub-clauses and 37 Annex A controls is individually rated
+- Ratings use the actual ISO 42001 text (clauses + Annex B implementation guidance) as the benchmark
+- "Strong" requires the framework to provide substantive, specifically-addressed coverage
+- "Partial" means relevant content exists but doesn't fully address the specific requirement
+- "Weak/Gap" means minimal or no coverage
+- Weighted average uses the individual percentages, not a binary pass/fail
+
+### Where observability provides evidence
+
+This section from the prior version remains accurate — observability IS a genuine strength:
+
+| Evidence Need | Observability Source | ISO 42001 Reference |
+|---------------|---------------------|---------------------|
+| AI system behavior monitoring | Agent spans (`agent.run`, `inference.*`, `tool.execute`), fleet dashboards | 9.1, A.6.2.6 |
+| Fairness and bias detection | Fairness metric dashboards (demographic parity, equalized odds) | A.5.4, A.6.2.4 |
+| Decision accountability | `governance.decision` span events with reasoning | A.9.2, A.9.4 |
+| Human oversight effectiveness | Human override rate metrics, escalation frequency | A.9.3, A.9.4 |
+| Resource consumption | Token usage per mission/agent/division, cost attribution | A.4.2, A.4.5 |
+| Model performance | Accuracy/latency/error metrics per model | A.6.2.4, A.6.2.6 |
+| Event log integrity | OTel trace completeness, log retention compliance | A.6.2.8 |
+
+---
+
+## 7. Adopter Responsibilities
+
+| Requirement | ISO 42001 Clause | What's Needed | Severity |
+|-----|-----|---------------|----------|
+| **Conformity assessment** | 10, certification | Third-party certification body audit | High — cannot self-certify |
+| **Management review records** | 9.3 | Documented reviews with required inputs/outputs (use template when created) | High — certification blocker today |
+| **Internal audit programme** | 9.2 | Scheduled AIMS-focused audits with defined scope and criteria | High — certification blocker today |
+| **AI system impact assessments** | 6.1.4, 8.4, A.5 | Operational impact assessments for in-scope AI systems | High — certification blocker today |
+| **Running risk register** | 6.1.2, 8.2 | Populated AI risk register with actual assessed risks | Medium |
+| **AI objectives** | 6.2 | Measurable, monitored, documented AI objectives | Medium |
+| **Competence evidence** | 7.2 | Records demonstrating AI-specific competence for relevant human roles | Medium |
+| **Data governance evidence** | A.7 | Data quality, provenance, acquisition, and preparation records for AI systems | Medium |
+| **SoA for ISO 42001** | 6.1.3 | Completed Statement of Applicability for all 39 Annex A controls | Medium |
+| **Stakeholder communication plan** | 7.4 | Formal plan for AIMS-relevant communications | Low |
+
+**Existing framework templates:** [AIMS scope guide](guides/iso-42001-aims-scope.md), [AIMS scope template](templates/_TEMPLATE-aims-scope.md), [AI system inventory template](templates/_TEMPLATE-ai-system-inventory.md), [conformity assessment guide](guides/iso-42001-conformity-assessment.md).
+
+---
+
+## 8. External References
 
 - [ISO/IEC 42001:2023](https://www.iso.org/standard/81230.html) — The standard itself (paid)
 - [ISO/IEC 23894:2023](https://www.iso.org/standard/77304.html) — AI Risk Management guidance (companion standard)
+- [ISO/IEC 22989:2022](https://www.iso.org/standard/74296.html) — AI Concepts and Terminology (normative reference)
+- [ISO/IEC 5338](https://www.iso.org/standard/81118.html) — AI System Life Cycle Processes
 - [ISO/IEC TR 24028:2020](https://www.iso.org/standard/77608.html) — Overview of trustworthiness in AI
 - [ISO/IEC 24027:2021](https://www.iso.org/standard/77607.html) — Bias in AI systems
 - [ISO/IEC 38507:2022](https://www.iso.org/standard/56641.html) — Governance implications of use of AI
+- [ISO/IEC 25059](https://www.iso.org/standard/80655.html) — Quality model for AI systems
 - [OECD AI Principles](https://oecd.ai/en/ai-principles) — International AI governance framework
-- [IEEE 7010-2020](https://standards.ieee.org/ieee/7010/7718/) — Wellbeing Impact Assessment for AI
 - [NIST AI 100-1](https://www.nist.gov/artificial-intelligence/ai-risk-management-framework) — Companion framework (see [nist-ai-rmf.md](nist-ai-rmf.md))


### PR DESCRIPTION
## What

Honest control-by-control reassessment of ISO 42001 coverage. Badge and compliance table updated from ~85% to ~60%.

## Why the old number was wrong

- Template existence counted as full coverage
- Indirect coverage through unrelated policies counted (data classification for security != data quality for AI)
- Single-field references counted as "addressed"

## Changes

- `docs/compliance/iso-42001.md` — full rewrite: per-clause assessment (4-10), per-control assessment (all 39 Annex A controls), coverage summary, 10-item quick-win roadmap
- `README.md` — badge 85% → 60%, compliance table updated

## Key findings

**Strong (keep):** AI system monitoring/event logs, AI policy, responsible use, supplier governance, deployment, documented information

**Critical gaps:** AI data governance (A.7, ~24%), management review (9.3, ~25%), internal audit (9.2, ~30%), impact assessment (A.5, ~33%), ISO 42001-specific SoA (6.1.3), AI objectives (6.2), human competence/awareness (7.2/7.3)

**Quick-win ceiling:** ~94% reachable with template-level work (10 items in §5 of the doc)

closes #241
