### PR TITLE
docs: restore AGENTS Rule 15

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Agent Instructions (Global)
 
-> **Version:** 4.4 | **Last updated:** 2026-03-29
+> **Version:** 4.5 | **Last updated:** 2026-06-02
 
 Every AI agent in this repository must follow these instructions. Layer-specific and division-specific instructions extend (never contradict) these rules.
 
@@ -90,6 +90,9 @@ This model derives from [Agentic Enterprise](https://github.com/wlfghdr/agentic-
 
 ### 14. Archive completed work
 Move completed items to `archive/` subfolders (git-files) or close issues. Use `git mv` (preserves blame). Never delete work artifacts. Templates and READMEs are never archived.
+
+### 15. Challenge before creating
+Do not create missions or tasks reflexively. Every signal must be triaged and reflected before becoming a mission. Every mission must be challenged for necessity, scope, and overlap before task decomposition. If genuinely unsure whether to proceed, assign to the human owner with a clear description of the decision needed rather than advancing past uncertainty.
 
 ### 16. Repo cleanliness
 After completing any work: committed, pushed, and on the target branch (direct-to-main or via PR). No dirty repos, no stale branches, no unpushed commits. Agents must not leave work stranded locally.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The framework uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html): `
 ### Changed
 
 - `docs/compliance/iso-42001.md` — updated control coverage for A.8.3, A.8.5, and A.10.4 to reflect the new governance and customer-policy guidance, while preserving adopter-specific follow-up notes.
+- `AGENTS.md` — restored missing Rule 15 "Challenge before creating" and bumped document version to 4.5. Closes #270.
 - `README.md`, `docs/README.md`, and `docs/architecture/agentic-enterprise-architecture.md` — linked the new Paperclip boundary document so the runtime-agnostic architecture story has an explicit practical split between runtime substrate and enterprise governance overlay. Closes #243.
 - `AGENTS.md` — bumped document version to 4.4 for Rules 19 and 20 additions.
 - `org/4-quality/policies/ai-governance.md` — added ISO 42001 human AI competence and awareness requirements covering competence matrix, competence evidence, competence-gap actions, effectiveness evaluation, and formal awareness delivery for staff and contractors. Closes #253.


### PR DESCRIPTION
## Summary
- Restore AGENTS.md Rule 15 "Challenge before creating" from the original v4.3.0 wording.
- Bump AGENTS.md document version/date and record the restoration in CHANGELOG.md.

## Validation
- python3 scripts/validate_agent_instructions.py
- python3 scripts/validate_content_security.py
- python3 scripts/validate_cross_references.py
- python3 scripts/validate_schema.py
- python3 scripts/validate_policy_structure.py
- python3 scripts/validate_otel_contract.py
- python3 scripts/validate_compliance_mapping.py
- python3 scripts/validate_compliance_coverage.py --warn-unmapped-pct 25
- python3 scripts/validate_config_completeness.py
- python3 scripts/validate_exception_expiry.py --warn-days 30
- python3 scripts/validate_work_artifacts.py
- python3 scripts/validate_vendor_compliance.py
- python3 scripts/validate_otel_evidence_chain.py
- python3 scripts/validate_control_linkage.py
- python3 scripts/validate_integration_registry.py
- YAML parsing, markdown internal-link check, placeholder check, required-file structure check

Closes #270