### PR TITLE
chore: switch default work backend to GitHub Issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Agent Instructions (Global)
 
-> **Version:** 4.4 | **Last updated:** 2026-03-29
+> **Version:** 4.5 | **Last updated:** 2026-06-02
 
 Every AI agent in this repository must follow these instructions. Layer-specific and division-specific instructions extend (never contradict) these rules.
 
@@ -30,7 +30,7 @@ Every claim must be grounded in evidence. Never fabricate data, metrics, or sour
 Never commit scope, timelines, resources, or strategic direction. Draft, analyze, propose — humans approve via PR merge or configured mechanism. When uncertain, escalate.
 
 ### 3. Process is governed
-- Work tracked in the **configured work backend** — Markdown in `work/` or issues in the tracker (`CONFIG.yaml → work_backend`, see [docs/work-backends.md](docs/work-backends.md))
+- Work tracked in the **configured work backend** — GitHub Issues by default, or Markdown in `work/` when `CONFIG.yaml → work_backend.type` is set to `git-files` (see [docs/work-backends.md](docs/work-backends.md))
 - **Git-files:** Changes → PRs → merges. **Issues:** State transitions + human comments. Governance backbone (org structure, policies, templates) always in Git.
 - **Assignment:** Every issue/PR must have an assignee at all times. Agent-owned → agent. Human-owned → human. Never unassigned. Assignee state is the source of truth for who must act next; do not leave human-needed work assigned to an agent or hide the handoff only in comments/body text.
 - **Handoffs:** Re-assign to human with comment: (a) what was done, (b) what to review, (c) options (approve/reject/request changes). Human comments decision and re-assigns back. Comments explain the handoff; assignment makes the required next actor explicit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ The framework uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html): `
 
 ### Changed
 
+- `CONFIG.yaml` — changed the shipped default `work_backend.type` from `git-files` to `github-issues` and bumped `framework_version` from `4.0.1` to `4.1.0`. Closes #272.
+- `AGENTS.md`, `docs/work-backends.md`, `docs/github-issues.md`, and `docs/customization-guide.md` — updated the operating guidance to describe GitHub Issues as the default work backend while preserving `git-files` as the self-contained legacy mode. Closes #272.
+- `README.md` — updated the framework version badge to `4.1.0`. Closes #272.
 - `docs/compliance/iso-42001.md` — updated control coverage for A.8.3, A.8.5, and A.10.4 to reflect the new governance and customer-policy guidance, while preserving adopter-specific follow-up notes.
 - `README.md`, `docs/README.md`, and `docs/architecture/agentic-enterprise-architecture.md` — linked the new Paperclip boundary document so the runtime-agnostic architecture story has an explicit practical split between runtime substrate and enterprise governance overlay. Closes #243.
 - `AGENTS.md` — bumped document version to 4.4 for Rules 19 and 20 additions.

--- a/CONFIG.yaml
+++ b/CONFIG.yaml
@@ -14,7 +14,7 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # Tracks the overall framework release. Update when cutting a new version.
 # See CHANGELOG.md for what changed. Uses semantic versioning (MAJOR.MINOR.PATCH).
-framework_version: "4.0.1"
+framework_version: "4.1.0"
 # ═══════════════════════════════════════════════════════════════════════════
 
 # ───────────────────────────────────────────────────────────────────────────
@@ -209,8 +209,8 @@ knowledge:
 # decisions, etc.) and HOW they flow. WHERE they live is configurable.
 #
 # Options:
-#   "git-files"      — All work artifacts are Markdown files in work/ (original model)
-#   "github-issues"  — Work artifacts are tracked as GitHub Issues with structured labels
+#   "github-issues"  — Work artifacts are tracked as GitHub Issues with structured labels (default)
+#   "git-files"      — All work artifacts are Markdown files in work/ (legacy/self-contained mode)
 #
 # See docs/work-backends.md for the full guide, label taxonomy, and migration paths.
 #
@@ -219,7 +219,7 @@ knowledge:
 # (signals, missions, tasks, decisions, releases, retrospectives) are affected.
 
 work_backend:
-  type: "git-files"                   # "git-files" | "github-issues"
+  type: "github-issues"               # "github-issues" | "git-files"
 
   # Configuration for github-issues backend
   github_issues:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <img src="https://img.shields.io/badge/model-Agentic%20Enterprise-blueviolet" alt="Agentic Enterprise">
-  <img src="https://img.shields.io/badge/version-4.0.1-brightgreen" alt="Version">
+  <img src="https://img.shields.io/badge/version-4.1.0-brightgreen" alt="Version">
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License">
   <img src="https://img.shields.io/badge/runtime-bring%20your%20own-orange" alt="Runtime">
   <a href="https://github.com/wlfghdr/agentic-enterprise/actions/workflows/validate.yml">

--- a/docs/customization-guide.md
+++ b/docs/customization-guide.md
@@ -1,6 +1,6 @@
 # Customization Guide — Agentic Enterprise Operating Model
 
-> **Version:** 3.6 | **Last updated:** 2026-03-14
+> **Version:** 3.7 | **Last updated:** 2026-06-02
 
 > **Start here** after cloning the framework.
 > Fastest safe path: fill `CONFIG.yaml`, install the GitHub issue-backend kit if needed, then run `python3 scripts/instantiate_instance.py cleanup-instance`.
@@ -56,8 +56,8 @@ Also decide whether operational work lives in the same repo as the governance ba
 
 | Backend | Best For | Set In CONFIG.yaml |
 |---------|----------|--------------------|
-| **Git files** | Self-contained, maximum auditability | `work_backend.type: "git-files"` |
-| **GitHub Issues** | Better human collaboration and visibility | `work_backend.type: "github-issues"` |
+| **GitHub Issues** | Default; best for human collaboration and visibility | `work_backend.type: "github-issues"` |
+| **Git files** | Legacy self-contained mode with maximum repository-local auditability | `work_backend.type: "git-files"` |
 
 If you choose GitHub Issues, use:
 - [docs/work-backends.md](work-backends.md) for backend choice and contract
@@ -192,7 +192,7 @@ The last item is the key: even "nothing to improve" is worth filing. It keeps th
 - ❌ Heavyweight project management tool — missions **are** your tickets (whether as issues or files)
 - ❌ Standup meetings — mission status updates **are** the standup (issue comments or STATUS.md)
 - ❌ Separate OKR framework — `CONFIG.yaml` vision + active missions = your strategy
-- ✅ An issue tracker is optional but **recommended** for human-facing visibility (`work_backend.type: "github-issues"`)
+- ✅ GitHub Issues is the default work backend for human-facing visibility (`work_backend.type: "github-issues"`)
 
 ---
 

--- a/docs/github-issues.md
+++ b/docs/github-issues.md
@@ -1,6 +1,6 @@
 # GitHub Issues Backend Guide
 
-> **Version:** 2.5 | **Last updated:** 2026-03-28
+> **Version:** 2.6 | **Last updated:** 2026-06-02
 
 > **What this document is:** The concrete implementation guide for running operational work artifacts in GitHub Issues. Use this when `CONFIG.yaml → work_backend.type` is `github-issues`.
 
@@ -8,7 +8,7 @@
 
 ## Goal
 
-This guide is the canonical operating guide for the GitHub issue backend.
+This guide is the canonical operating guide for the GitHub issue backend. The shipped default `CONFIG.yaml` uses this backend for operational work tracking.
 
 Use it for:
 - labels
@@ -25,7 +25,7 @@ For the shortest setup path, start with [github/setup-checklist.md](github/setup
 
 Complete these steps before using the issue backend in a real fork:
 
-1. Set `work_backend.type: "github-issues"` in `CONFIG.yaml`.
+1. Confirm `work_backend.type: "github-issues"` in `CONFIG.yaml` (this is the shipped default).
 2. Enable GitHub Issues and Issue Forms.
 3. Create a GitHub Project (v2) with `Backlog`, `Triage`, `Approved`, `Planning`, `In Progress`, `Blocked`, `Done`.
 4. Prefer the scripted install path: `python3 scripts/instantiate_instance.py install-github-work-repo --main-repo your-org/your-instance --target-dir <issue-hosting-repo>`.
@@ -428,6 +428,7 @@ Git still holds the durable review-heavy artifacts.
 
 | Version | Date | Change |
 |---|---|---|
+| 2.6 | 2026-06-02 | Clarified that GitHub Issues is the shipped default work backend. |
 | 2.5 | 2026-03-28 | Added the rule that ad-hoc chat tasks must become issue-backed work when the issue backend is enabled. |
 | 2.4 | 2026-03-23 | Clarified that assignee state is the source of truth for next action and that human-needed work must be reassigned to the human owner rather than implied only in comments or body text. |
 | 2.3 | 2026-03-21 | Added template asset references for label bootstrap, slim work-repo CI, dynamic label sync from issue forms, and the GitHub setup checklist. |

--- a/docs/work-backends.md
+++ b/docs/work-backends.md
@@ -1,6 +1,6 @@
 # Work Backends — Git Files vs. Issue Tracker
 
-> **Version:** 1.6 | **Last updated:** 2026-03-28
+> **Version:** 1.7 | **Last updated:** 2026-06-02
 
 > **What this document is:** The backend selection and contract guide.
 
@@ -13,8 +13,8 @@
 
 The operating model defines the artifacts and flow. The backend decides where active work is tracked.
 
-- **Git files** optimize for auditability and self-containment.
-- **Issue backends** optimize for visibility, assignment, comments, notifications, and mobile use.
+- **Issue backends** optimize for visibility, assignment, comments, notifications, and mobile use. The shipped default is GitHub Issues.
+- **Git files** optimize for auditability and self-containment when an adopter deliberately wants all operational artifacts in the repository.
 
 The choice is made via `CONFIG.yaml → work_backend`.
 
@@ -99,7 +99,7 @@ work_backend:
     # lock: "git-files"  ← always git, not configurable
 ```
 
-When `work_backend.type` is `"git-files"` (the default), the framework behaves exactly as before — all work artifacts are Markdown files in `work/`.
+When `work_backend.type` is `"github-issues"` (the default), operational work artifacts are tracked as issues. Set `work_backend.type` to `"git-files"` only when you want the legacy self-contained mode where all operational artifacts are Markdown files in `work/`.
 
 ---
 
@@ -382,6 +382,7 @@ Templates are **never** tracked in the issue system. They are framework files, g
 
 | Version | Date | Change |
 |---------|------|--------|
+| 1.7 | 2026-06-02 | Updated the backend guide to reflect GitHub Issues as the shipped default and git-files as the legacy self-contained mode. |
 | 1.6 | 2026-03-28 | Clarified that ad-hoc chat tasks should also be captured as tracking issues when the issue backend is enabled. |
 | 1.5 | 2026-03-23 | Clarified that assignee state is the source of truth for next action and that human-needed work must be explicitly reassigned to the human owner. |
 | 1.4 | 2026-03-09 | Consolidated backend configuration here and removed the duplicate `WORK-BACKEND.md` doc. Clarified this file's scope vs. `github-issues.md`. |


### PR DESCRIPTION
## Summary
- Change the shipped `work_backend.type` default to `github-issues`
- Update agent and backend docs to describe GitHub Issues as the default and `git-files` as the legacy self-contained mode
- Bump framework version metadata to `4.1.0`

## Validation
- `python3 scripts/check_placeholders.py --self-check`
- `python3 scripts/check_placeholders.py`
- `python3 scripts/validate_schema.py`
- `python3 scripts/validate_content_security.py`
- `python3 scripts/validate_policy_structure.py`
- `python3 scripts/validate_otel_contract.py`
- `python3 scripts/validate_compliance_mapping.py`
- `python3 scripts/validate_compliance_coverage.py --warn-unmapped-pct 25`
- `python3 scripts/validate_config_completeness.py --self-check`
- `python3 scripts/validate_config_completeness.py`
- `python3 scripts/validate_exception_expiry.py --self-check`
- `python3 scripts/validate_exception_expiry.py --warn-days 30`
- `python3 scripts/validate_vendor_compliance.py --self-check`
- `python3 scripts/validate_vendor_compliance.py`
- `python3 scripts/validate_otel_evidence_chain.py --self-check`
- `python3 scripts/validate_otel_evidence_chain.py`
- `python3 scripts/validate_control_linkage.py --self-check`
- `python3 scripts/validate_control_linkage.py`
- `python3 scripts/validate_integration_registry.py`
- `python3 scripts/validate_agent_instructions.py`
- `python3 scripts/validate_work_artifacts.py`
- `python3 scripts/validate_cross_references.py`
- markdown internal-link check from `.github/workflows/validate.yml`
- versioning checks from `.github/workflows/validate.yml`
- `conftest test CONFIG.yaml --policy policy/ --data policy/ --namespace config --output table`
- `conftest test .github/workflows/ --policy policy/ --data policy/ --namespace workflows --output table`
- `python3 scripts/check_github_governance.py` (local branch-protection probe skipped because `GITHUB_REPOSITORY` is unset)
- `git diff --check`

Closes #272