### PR TITLE
fix: enforce structured policy compliance mappings

### DIFF
--- a/org/4-quality/policies/agent-security.md
+++ b/org/4-quality/policies/agent-security.md
@@ -3,7 +3,7 @@
 > **Applies to:** All AI agents, agent instructions, tool integrations, and workflows processing external content
 > **Enforced by:** Quality Layer eval agents
 > **Authority:** Security & Compliance team
-> **Version:** 1.2 | **Last updated:** 2026-05-23
+> **Version:** 1.3 | **Last updated:** 2026-06-09
 
 ---
 
@@ -158,10 +158,27 @@ This policy addresses the following OWASP LLM Top 10 (2025) categories:
 
 ---
 
+## Compliance Mapping
+
+| Framework | Requirement | Policy Section |
+|-----------|-------------|----------------|
+| **ISO 27001:2022** | A.8.25 Secure development life cycle | §1, §2, §4 |
+| **ISO 27001:2022** | A.8.28 Secure coding | §1.1, §3, §4 |
+| **NIST AI RMF** | GOVERN 1 Policies and accountability for AI risk | Principles; §2 |
+| **NIST AI RMF** | MAP 5 Impacts from third-party AI components | §2.1, §2.4 |
+| **NIST AI RMF** | MEASURE 2 Trustworthiness evaluation | §4 |
+| **EU AI Act** | Art. 14 Human oversight | §2.3 |
+| **EU AI Act** | Art. 15 Accuracy, robustness, and cybersecurity | §1, §2, §4 |
+| **NIST CSF 2.0** | PR.AA-05 Access permissions and authorizations are managed | §2.1, §2.2 |
+| **NIST CSF 2.0** | PR.PS-06 Secure software development practices are integrated | §4 |
+
+---
+
 ## Changelog
 
 | Version | Date | Change |
 |---|---|---|
+| 1.3 | 2026-06-09 | Added structured compliance mappings for secure development, AI risk controls, human oversight, and NIST CSF safeguards. |
 | 1.2 | 2026-05-23 | Added MCP-specific threat scoping to §2.1, including untrusted-context handling, lifecycle and supply-chain assessment, and explicit linkage to vendor-risk-management.md. |
 | 1.1 | 2026-03-15 | Added §4.3 CI Content Security Scanning — automated enforcement via `validate_content_security.py` blocking CI job; added content security CI evaluation criterion; updated OWASP LLM01 coverage map |
 | 1.0 | 2026-03-13 | Initial version — prompt injection mitigations, tool abuse prevention, insecure output handling, security testing requirements, OWASP LLM Top 10 coverage map |

--- a/org/4-quality/policies/architecture.md
+++ b/org/4-quality/policies/architecture.md
@@ -3,7 +3,7 @@
 > **Applies to:** All code changes, new services, API designs, data models, system integrations
 > **Enforced by:** Quality Layer eval agents
 > **Authority:** Architecture Governors (Steering Layer delegates)
-> **Version:** 1.2 | **Last updated:** 2026-02-25
+> **Version:** 1.3 | **Last updated:** 2026-06-09
 
 ---
 
@@ -80,10 +80,26 @@
 
 ---
 
+## Compliance Mapping
+
+| Framework | Requirement | Policy Section |
+|-----------|-------------|----------------|
+| **SOC 2** | CC8.1 Change management | Technical Design; Architecture Decision Records |
+| **ISO 27001:2022** | A.8.25 Secure development life cycle | Technical Design; Code Quality |
+| **ISO 27001:2022** | A.8.31 Separation of development, test, and production environments | Service Design; Technical Design |
+| **ISO 27001:2022** | A.8.32 Change management | Architecture Decision Records |
+| **ISO 27001:2022** | A.8.34 Protection during audit testing | Technical Design; Observability |
+| **ISO 9001:2015** | 8.3 Design and development | Technical Design; Service Design |
+| **ISO 22301:2019** | 8.1 Operational planning and control | Technical Design; Observability |
+| **NIST CSF 2.0** | PR.PS-01 Configuration management practices are established and applied | Service Design; Data Architecture |
+
+---
+
 ## Changelog
 
 | Version | Date | Change |
 |---|---|---|
+| 1.3 | 2026-06-09 | Added structured compliance mappings for governed design, secure development, operational planning, and configuration management. |
 | 1.0 | 2026-02-19 | Initial version |
 | 1.2 | 2026-02-25 | Added observability design to Technical Design checklist; updated evaluation criteria to include design-time observability |
 | 1.1 | 2026-02-23 | Replace {{DESIGN_SYSTEM_NAME}} placeholder with generic "company design system" language |

--- a/org/4-quality/policies/content.md
+++ b/org/4-quality/policies/content.md
@@ -3,7 +3,7 @@
 > **Applies to:** All externally-facing content — documentation, blog posts, marketing materials, press releases, website copy, social media, presentations
 > **Enforced by:** Quality Layer eval agents
 > **Authority:** Content & Communications leads
-> **Version:** 1.0 | **Last updated:** 2026-02-19
+> **Version:** 1.1 | **Last updated:** 2026-06-09
 
 ---
 
@@ -63,8 +63,22 @@
 
 ---
 
+## Compliance Mapping
+
+| Framework | Requirement | Policy Section |
+|-----------|-------------|----------------|
+| **ISO 9001:2015** | 7.5 Documented information | Documentation Quality |
+| **ISO 9001:2015** | 8.2 Requirements for products and services | Accuracy & Claims; Documentation Quality |
+| **GDPR** | Art. 12 Transparent, intelligible, and accessible information | Accuracy & Claims; Documentation Quality |
+| **GDPR** | Art. 13 Information provided when personal data are collected | Legal & Compliance |
+| **EU AI Act** | Art. 13 Transparency and provision of information | Accuracy & Claims; Documentation Quality |
+| **EU AI Act** | Art. 50 Transparency obligations | Accuracy & Claims; Legal & Compliance |
+
+---
+
 ## Changelog
 
 | Version | Date | Change |
 |---|---|---|
+| 1.1 | 2026-06-09 | Added structured compliance mappings for documented information, transparent communications, and AI disclosure obligations. |
 | 1.0 | 2026-02-19 | Initial version |

--- a/org/4-quality/policies/customer.md
+++ b/org/4-quality/policies/customer.md
@@ -3,7 +3,7 @@
 > **Applies to:** All customer-facing interactions — proposals, QBRs, support responses, onboarding, renewals, escalations
 > **Enforced by:** Quality Layer eval agents
 > **Authority:** Customer Success & Sales leadership
-> **Version:** 1.1 | **Last updated:** 2026-05-23
+> **Version:** 1.2 | **Last updated:** 2026-06-09
 
 ---
 
@@ -80,9 +80,23 @@
 
 ---
 
+## Compliance Mapping
+
+| Framework | Requirement | Policy Section |
+|-----------|-------------|----------------|
+| **ISO 9001:2015** | 4.2 Needs and expectations of interested parties | Proposals & Sales Materials; Customer Success Interactions |
+| **ISO 9001:2015** | 8.2 Requirements for products and services | Proposals & Sales Materials; AI System Customer Requirements |
+| **ISO 9001:2015** | 9.1 Monitoring, measurement, analysis, and evaluation | Customer Success Interactions; Support Interactions |
+| **ISO 42001:2023** | A.10.4 Customer requirements | AI System Customer Requirements |
+| **GDPR** | Art. 12 Transparent information and communication | Proposals & Sales Materials; Data & Privacy |
+| **GDPR** | Art. 13 Information provided when personal data are collected | Data & Privacy |
+
+---
+
 ## Changelog
 
 | Version | Date | Change |
 |---|---|---|
+| 1.2 | 2026-06-09 | Added structured compliance mappings for customer requirements, AI responsibility allocation, and privacy transparency. |
 | 1.1 | 2026-05-23 | Added AI-specific customer requirements, domain-of-use communication expectations, and provider/customer responsibility allocation guidance for ISO 42001 A.10.4. Closes #254. |
 | 1.0 | 2026-02-19 | Initial version |

--- a/org/4-quality/policies/delivery.md
+++ b/org/4-quality/policies/delivery.md
@@ -3,7 +3,7 @@
 > **Applies to:** All deployments, releases, rollouts, and operational changes
 > **Enforced by:** Quality Layer eval agents
 > **Authority:** Release Management / DevOps leads
-> **Version:** 1.1 | **Last updated:** 2026-05-23
+> **Version:** 1.2 | **Last updated:** 2026-06-09
 
 ---
 
@@ -108,9 +108,27 @@ When an active production incident requires an immediate fix:
 
 ---
 
+## Compliance Mapping
+
+| Framework | Requirement | Policy Section |
+|-----------|-------------|----------------|
+| **SOC 2** | CC8.1 Change management | Environment Progression; Pre-Deployment; Deployment Process |
+| **SOC 2** | A1.3 Recovery testing | Rollback Criteria; Post-Deployment |
+| **ISO 22301:2019** | 8.3 Business continuity strategies and solutions | Deployment Process; Rollback Criteria |
+| **ISO 22301:2019** | 8.4 Business continuity plans and procedures | Pre-Deploy Readiness Checklist; Rollback Criteria |
+| **ISO 22301:2019** | 8.5 Exercise programme | Environment Progression; Post-Deployment |
+| **ISO 9001:2015** | 8.5 Production and service provision | Deployment Process |
+| **ISO 9001:2015** | 8.6 Release of products and services | Pre-Deployment; Pre-Deploy Readiness Checklist |
+| **ISO 9001:2015** | 8.7 Control of nonconforming outputs | Rollback Criteria; Emergency / Hotfix Deployments |
+| **NIST CSF 2.0** | PR.IR-03 Mechanisms are implemented to achieve resilience requirements | Progressive rollout; Rollback Criteria |
+| **NIST CSF 2.0** | RC.RP-03 Recovery actions and restoration are verified | Post-Deployment; Rollback Criteria |
+
+---
+
 ## Changelog
 
 | Version | Date | Change |
 |---|---|---|
+| 1.2 | 2026-06-09 | Added structured compliance mappings for governed change, continuity, release control, and recovery verification. |
 | 1.1 | 2026-05-23 | Added SDLC gate cross-reference, formal AI impact assessment deploy gate, AI-specific penetration-testing deploy gate, and pre-deploy readiness checklist as a blocking production gate. |
 | 1.0 | 2026-02-19 | Initial version |

--- a/org/4-quality/policies/experience.md
+++ b/org/4-quality/policies/experience.md
@@ -3,7 +3,7 @@
 > **Applies to:** All user-facing surfaces — UI, CLI, APIs, documentation, error messages
 > **Enforced by:** Quality Layer eval agents
 > **Authority:** UX/Design team leads
-> **Version:** 1.1 | **Last updated:** 2026-02-23
+> **Version:** 1.2 | **Last updated:** 2026-06-09
 
 ---
 
@@ -60,9 +60,21 @@
 
 ---
 
+## Compliance Mapping
+
+| Framework | Requirement | Policy Section |
+|-----------|-------------|----------------|
+| **ISO 9001:2015** | 8.2 Requirements for products and services | Interaction Design; Content & Microcopy |
+| **ISO 9001:2015** | 9.1 Monitoring, measurement, analysis, and evaluation | Performance (User-Perceived); Evaluation Criteria |
+| **GDPR** | Art. 12 Transparent and accessible information | Content & Microcopy; Accessibility |
+| **CCPA/CPRA** | §1798.135 Accessible opt-out mechanism | Interaction Design; Accessibility |
+
+---
+
 ## Changelog
 
 | Version | Date | Change |
 |---|---|---|
+| 1.2 | 2026-06-09 | Added structured compliance mappings for service quality, transparent information, and accessible privacy controls. |
 | 1.0 | 2026-02-19 | Initial version |
 | 1.1 | 2026-02-23 | Replace {{DESIGN_SYSTEM_NAME}} placeholder with generic "company design system" language |

--- a/org/4-quality/policies/observability.md
+++ b/org/4-quality/policies/observability.md
@@ -4,7 +4,7 @@
 > **Enforced by:** Quality Layer eval agents, including the dedicated [Observability Compliance Agent](../../agents/quality/observability-compliance-agent.md)
 > **Authority:** Operations leads + Architecture Governors
 > **Principle:** If it runs, it must be observable. If it's not observable, it doesn't ship.
-> **Version:** 1.4.1 | **Last updated:** 2026-03-14
+> **Version:** 1.5.0 | **Last updated:** 2026-06-09
 
 ---
 
@@ -313,10 +313,27 @@ All telemetry data collected under this policy is subject to the retention, immu
 
 ---
 
+## Compliance Mapping
+
+| Framework | Requirement | Policy Section |
+|-----------|-------------|----------------|
+| **SOC 2** | CC7.1 System operations monitoring | Mandatory Requirements; Dashboards & Visualization |
+| **SOC 2** | CC7.2 Anomaly detection | Alerting & Anomaly Detection |
+| **ISO 27001:2022** | A.8.15 Logging | The Three Pillars; Log Retention & Immutability |
+| **ISO 27001:2022** | A.8.16 Monitoring activities | Dashboards & Visualization; Alerting & Anomaly Detection |
+| **HIPAA** | §164.312(b) Audit controls | Agent Observability; Log Retention & Immutability |
+| **ISO 22301:2019** | 9.1 Monitoring, measurement, analysis, and evaluation | Service Health Target Requirements; Verification Gates |
+| **NIST CSF 2.0** | DE.CM-01 Networks and network services are monitored | The Three Pillars; Dashboards & Visualization |
+| **NIST CSF 2.0** | DE.CM-03 Personnel activity and technology usage are monitored | Agent Observability |
+| **NIST CSF 2.0** | DE.AE-02 Potentially adverse events are analyzed | Alerting & Anomaly Detection |
+
+---
+
 ## Changelog
 
 | Version | Date | Change |
 |---|---|---|
+| 1.5.0 | 2026-06-09 | Added structured compliance mappings for monitoring, audit controls, continuity measurement, and NIST CSF detection outcomes. |
 | 1.4 | 2026-03-14 | Added Log Retention & Immutability section cross-referencing log-retention.md; added telemetry retention evaluation criteria |
 | 1.3 | 2026-03-10 | Added an explicit policy requirement that downstream activity records remain trace-linkable via canonical `trace.id`, `span.id`, and `parent.span.id` identifiers defined in `docs/otel-contract.md`. |
 | 1.1 | 2026-02-25 | Added Design-Time Observability section (shift-left); added design-time stage gate and verification gate (At Design Time); added design-time observability evaluation criterion; cross-referenced AGENTS.md Rule 9c and Technical Design template |

--- a/org/4-quality/policies/performance.md
+++ b/org/4-quality/policies/performance.md
@@ -3,7 +3,7 @@
 > **Applies to:** All services, APIs, data pipelines, and user-facing applications
 > **Enforced by:** Quality Layer eval agents
 > **Authority:** Engineering leads
-> **Version:** 1.0 | **Last updated:** 2026-02-19
+> **Version:** 1.1 | **Last updated:** 2026-06-09
 
 ---
 
@@ -63,8 +63,21 @@
 
 ---
 
+## Compliance Mapping
+
+| Framework | Requirement | Policy Section |
+|-----------|-------------|----------------|
+| **SOC 2** | A1.1 Capacity planning and performance commitments | Service Performance; Scalability |
+| **ISO 27001:2022** | A.8.6 Capacity management | Resource Efficiency; Scalability |
+| **ISO 9001:2015** | 9.1 Monitoring, measurement, analysis, and evaluation | Monitoring & Alerting; Evaluation Criteria |
+| **ISO 22301:2019** | 8.2 Business impact analysis and risk assessment | Service Performance; Scalability |
+| **NIST CSF 2.0** | ID.IM-04 Incident response and recovery plans are maintained and improved | Monitoring & Alerting; Scalability |
+
+---
+
 ## Changelog
 
 | Version | Date | Change |
 |---|---|---|
+| 1.1 | 2026-06-09 | Added structured compliance mappings for capacity, measurement, continuity impact, and resilience improvement. |
 | 1.0 | 2026-02-19 | Initial version |

--- a/org/4-quality/policies/privacy.md
+++ b/org/4-quality/policies/privacy.md
@@ -3,7 +3,7 @@
 > **Applies to:** All personal-data processing, product features, AI workflows, support operations, integrations, and customer environments
 > **Enforced by:** Quality Layer eval agents
 > **Authority:** Privacy / Legal / Security leadership
-> **Version:** 1.0 | **Last updated:** 2026-03-13
+> **Version:** 1.1 | **Last updated:** 2026-06-09
 
 ---
 
@@ -143,8 +143,35 @@ Observability does not replace legal judgment, but it materially improves provab
 
 ---
 
+## Compliance Mapping
+
+| Framework | Requirement | Policy Section |
+|-----------|-------------|----------------|
+| **GDPR** | Art. 5(1)(a) Lawfulness, fairness, and transparency | Principles; §1 |
+| **GDPR** | Art. 6 Lawfulness of processing | §1 |
+| **GDPR** | Art. 12 Transparent information and rights handling | §3 |
+| **GDPR** | Art. 15–21 Data subject rights | §3 |
+| **GDPR** | Art. 28 Processor obligations | §2 |
+| **GDPR** | Art. 33–34 Personal data breach notification | §4 |
+| **GDPR** | Art. 35 Data protection impact assessment | §5 |
+| **CCPA/CPRA** | §1798.100 Right to know and notice at collection | §1, §3 |
+| **CCPA/CPRA** | §1798.105 Right to delete | §3 |
+| **CCPA/CPRA** | §1798.106 Right to correct | §3 |
+| **CCPA/CPRA** | §1798.110 Right to know | §3 |
+| **CCPA/CPRA** | §1798.120 Opt-out of sale or sharing | §6 |
+| **CCPA/CPRA** | §1798.121 Limit use of sensitive personal information | §1, §6 |
+| **CCPA/CPRA** | §1798.125 Non-discrimination | Principles |
+| **CCPA/CPRA** | §1798.135 Opt-out preference mechanism | §6 |
+| **HIPAA** | §164.502(a) Permitted uses and disclosures | §1 |
+| **HIPAA** | §164.502(b) Minimum necessary standard | Principles; §1 |
+| **HIPAA** | §164.524 Individual access | §3 |
+| **HIPAA** | §164.526 Amendment of protected health information | §3 |
+
+---
+
 ## Changelog
 
 | Version | Date | Change |
 |---|---|---|
+| 1.1 | 2026-06-09 | Added structured compliance mappings for GDPR, CCPA/CPRA, and HIPAA privacy requirements. |
 | 1.0 | 2026-03-13 | Initial privacy policy covering GDPR role/lawful-basis mapping, DPA, DSAR, breach notification, DPIA, consent, and transfer controls |

--- a/org/4-quality/policies/risk-management.md
+++ b/org/4-quality/policies/risk-management.md
@@ -3,7 +3,7 @@
 > **Applies to:** All organizational layers, agent types, missions, integrations, and operational processes
 > **Enforced by:** Quality Layer eval agents
 > **Authority:** Security & Compliance team, Steering Layer
-> **Version:** 1.3 | **Last updated:** 2026-03-27
+> **Version:** 1.4 | **Last updated:** 2026-06-09
 
 ---
 
@@ -430,10 +430,33 @@ This table maps the organization's existing quality policies to the risk categor
 
 ---
 
+## Compliance Mapping
+
+| Framework | Requirement | Policy Section |
+|-----------|-------------|----------------|
+| **SOC 2** | CC3.1 Risk identification | §3.1, §5 |
+| **SOC 2** | CC3.2 Risk analysis | §3.2 |
+| **SOC 2** | CC3.3 Fraud risk consideration | §5.5 |
+| **SOC 2** | CC3.4 Stakeholder involvement in risk assessment | §3.1, §9 |
+| **ISO 27001:2022** | A.5.7 Threat intelligence | §5, §8 |
+| **ISO 27001:2022** | A.5.31 Legal, statutory, regulatory, and contractual requirements | §1, §7 |
+| **HIPAA** | §164.308(a)(1) Security management process | §2, §3, §4 |
+| **ISO 22301:2019** | 6.1 Actions to address risks and opportunities | §2, §3 |
+| **ISO 22301:2019** | 8.2 Business impact analysis and risk assessment | §3, §5 |
+| **NIST AI RMF** | GOVERN 1 Policies and accountability | §1, §2, §6 |
+| **NIST AI RMF** | MAP 1 Context is established and understood | §3.1, §5 |
+| **NIST AI RMF** | MANAGE 1 AI risks are prioritized and treated | §3.3, §3.4 |
+| **NIST CSF 2.0** | GV.RM-01 Risk management objectives are established and agreed to | §2 |
+| **NIST CSF 2.0** | ID.RA-01 Vulnerabilities in assets are identified and recorded | §3.1, §4 |
+| **NIST CSF 2.0** | ID.RA-05 Threats, vulnerabilities, likelihoods, and impacts are used to understand inherent risk | §3.2 |
+
+---
+
 ## Changelog
 
 | Version | Date | Change |
 |---|---|---|
+| 1.4 | 2026-06-09 | Added structured compliance mappings for enterprise, AI, continuity, HIPAA, and NIST CSF risk management requirements. |
 | 1.3 | 2026-03-27 | Added workforce-readiness and change-management expectations tied to agent autonomy tiers, including minimum human readiness controls before autonomy increases |
 | 1.2 | 2026-03-14 | Extended §6.4 to reference vendor-risk-management.md for general vendor governance; added vendor concentration risk requirement (#92) |
 | 1.0 | 2026-03-13 | Initial version — risk appetite framework, 5×5 scoring methodology, AI risk taxonomy (22 canonical risks across 5 dimensions), agent autonomy tiers, observability-driven KRIs, regulatory crosswalk (ISO 31000 / NIST RMF / NIST AI RMF / ISO 27001 / SOC 2 / EU AI Act), policy-to-risk control mapping |

--- a/org/4-quality/policies/sdlc-gates.md
+++ b/org/4-quality/policies/sdlc-gates.md
@@ -3,7 +3,7 @@
 > **Applies to:** All software, AI system, agent, integration, and operational changes that progress through the delivery lifecycle
 > **Enforced by:** Quality Layer eval agents, release coordinators, and human approvers for mandatory gates
 > **Authority:** Release Management / DevOps leads, Security & Compliance team
-> **Version:** 1.0 | **Last updated:** 2026-05-23
+> **Version:** 1.1 | **Last updated:** 2026-06-09
 
 ---
 
@@ -94,8 +94,27 @@ A pre-deploy readiness checklist must confirm at minimum:
 
 ---
 
+## Compliance Mapping
+
+| Framework | Requirement | Policy Section |
+|-----------|-------------|----------------|
+| **SOC 2** | CC8.1 Change management | SDLC Stage-Gate Map; Named Deploy Gates |
+| **ISO 27001:2022** | A.8.25 Secure development life cycle | SDLC Stage-Gate Map |
+| **ISO 27001:2022** | A.8.31 Separation of development, test, and production environments | SDLC Stage-Gate Map |
+| **ISO 27001:2022** | A.8.32 Change management | Production Deployment Gates; Evidence and Exceptions |
+| **ISO 27001:2022** | A.8.34 Protection during audit testing | Evidence and Exceptions |
+| **ISO 9001:2015** | 8.1 Operational planning and control | SDLC Gate Coverage |
+| **ISO 9001:2015** | 8.3 Design and development | SDLC Stage-Gate Map |
+| **ISO 9001:2015** | 8.6 Release of products and services | Named Deploy Gates |
+| **ISO 9001:2015** | 8.7 Control of nonconforming outputs | Evidence and Exceptions |
+| **NIST CSF 2.0** | ID.IM-02 Improvements are identified from security tests and exercises | Operational Feedback |
+| **NIST CSF 2.0** | PR.PS-06 Secure software development practices are integrated | Named Deploy Gates |
+
+---
+
 ## Changelog
 
 | Version | Date | Change |
 |---|---|---|
+| 1.1 | 2026-06-09 | Added structured compliance mappings for change control, secure development, release gates, and continuous improvement. |
 | 1.0 | 2026-05-23 | Initial version. Added explicit SDLC stage-gate mapping, named deploy gates, AI impact assessment deploy gate, AI-specific penetration testing gate, and minimum pre-deploy readiness checklist requirements. |

--- a/org/4-quality/policies/security.md
+++ b/org/4-quality/policies/security.md
@@ -3,7 +3,7 @@
 > **Applies to:** All code, infrastructure configuration, API definitions, data pipelines, integrations
 > **Enforced by:** Quality Layer eval agents
 > **Authority:** Security & Compliance team
-> **Version:** 1.3 | **Last updated:** 2026-03-14
+> **Version:** 1.4 | **Last updated:** 2026-06-09
 
 ---
 
@@ -69,10 +69,33 @@
 
 ---
 
+## Compliance Mapping
+
+| Framework | Requirement | Policy Section |
+|-----------|-------------|----------------|
+| **SOC 2** | CC6.1 Logical access controls | Authentication & Authorization; Secrets Management |
+| **SOC 2** | CC6.6 Boundary protection | Input Validation; Container & Infrastructure Security |
+| **SOC 2** | CC7.1 Security monitoring | Dependency & Vendor Security; Container & Infrastructure Security |
+| **ISO 27001:2022** | A.5.15 Access control | Authentication & Authorization |
+| **ISO 27001:2022** | A.8.5 Secure authentication | Authentication & Authorization |
+| **ISO 27001:2022** | A.8.25 Secure development life cycle | Input Validation; Dependency & Vendor Security |
+| **ISO 27001:2022** | A.8.28 Secure coding | Input Validation; Secrets Management |
+| **HIPAA** | §164.308(a)(4) Information access management | Authentication & Authorization |
+| **HIPAA** | §164.312(a) Access control | Authentication & Authorization |
+| **HIPAA** | §164.312(d) Person or entity authentication | Authentication & Authorization |
+| **CCPA/CPRA** | §1798.100(e) Reasonable security procedures and practices | All mandatory requirements |
+| **CCPA/CPRA** | §1798.150 Security breach private right of action | Data Protection; Dependency & Vendor Security |
+| **NIST CSF 2.0** | PR.AA-01 Identities and credentials are managed | Authentication & Authorization; Secrets Management |
+| **NIST CSF 2.0** | PR.DS-01 Data at rest are protected | Data Protection |
+| **NIST CSF 2.0** | PR.PS-06 Secure software development practices are integrated | Input Validation; Dependency & Vendor Security |
+
+---
+
 ## Changelog
 
 | Version | Date | Change |
 |---|---|---|
+| 1.4 | 2026-06-09 | Added structured compliance mappings for access control, secure development, HIPAA safeguards, CCPA reasonable security, and NIST CSF protection outcomes. |
 | 1.3 | 2026-03-14 | Dependency Security section renamed to Dependency & Vendor Security; added vendor assessment and attestation requirements referencing vendor-risk-management.md (#92) |
 | 1.2 | 2026-03-14 | Data retention requirement now references log-retention.md (#94) |
 | 1.1 | 2026-03-14 | Data Protection section now references data-classification.md for classification taxonomy; evaluation criterion updated (#93) |

--- a/scripts/validate_policy_structure.py
+++ b/scripts/validate_policy_structure.py
@@ -63,19 +63,6 @@ FLEXIBLE_SECTIONS = {
     },
 }
 
-# ── Known compliance frameworks ──────────────────────────────────────────────
-
-KNOWN_FRAMEWORKS = [
-    "SOC 2",
-    "ISO 27001",
-    "GDPR",
-    "ISO 42001",
-    "NIST AI RMF",
-    "EU AI Act",
-    "HIPAA",
-]
-
-
 def get_sections(text: str) -> dict[str, int]:
     """Return dict of second-level heading titles → line numbers."""
     sections: dict[str, int] = {}
@@ -158,31 +145,19 @@ def validate_policy(path: Path) -> list[str]:
                 errors.append(f"{rel}: missing '## {section_name}' section or numbered requirement subsections")
 
     # ── Compliance mapping ────────────────────────────────────────────────
-    # Policies that deal with governance, security, privacy, risk, or data
-    # MUST have compliance framework references. Others get a warning.
-    compliance_critical_keywords = [
-        "security", "privacy", "risk", "governance", "data-classification",
-        "cryptography", "incident", "log-retention", "availability",
-        "vendor", "agent-security", "agent-eval",
-    ]
-    is_compliance_critical = any(kw in path.stem for kw in compliance_critical_keywords)
-
-    has_compliance_ref = any(
-        fw.lower() in text.lower() for fw in KNOWN_FRAMEWORKS
-    )
-    compliance_section = any(
-        "compliance" in s.lower() and "mapping" in s.lower()
-        for s in sections
-    )
-    if not has_compliance_ref and not compliance_section:
-        if is_compliance_critical:
-            errors.append(
-                f"{rel}: compliance-critical policy missing compliance framework references "
-                f"(expected references to SOC 2, ISO 27001, GDPR, etc.)"
-            )
-        else:
-            # Non-critical: print warning but don't fail
-            print(f"  ⚠  {rel}: no compliance mapping section (recommended but not required)")
+    # Framework references in prose are not a substitute for the structured
+    # table consumed by the compliance mapping and coverage validators.
+    compliance_section = next((
+        section
+        for section in sections
+        if "compliance" in section.lower() and "mapping" in section.lower()
+    ), None)
+    if compliance_section is None:
+        errors.append(f"{rel}: missing required section '## Compliance Mapping'")
+    else:
+        empty_err = check_non_empty_section(text, compliance_section, sections)
+        if empty_err:
+            errors.append(f"{rel}: {empty_err}")
 
     # ── Changelog table ───────────────────────────────────────────────────
     if "Changelog" in sections:
@@ -211,6 +186,18 @@ def suggest_fix(path: Path) -> str:
     for section in REQUIRED_SECTIONS:
         if section not in sections:
             suggestions.append(f"Add section:\n## {section}\n\n[TODO: Add content]\n")
+
+    if not any(
+        "compliance" in section.lower() and "mapping" in section.lower()
+        for section in sections
+    ):
+        suggestions.append(
+            "Add section:\n"
+            "## Compliance Mapping\n\n"
+            "| Framework | Requirement | Policy Section |\n"
+            "|-----------|-------------|----------------|\n"
+            "| **FRAMEWORK** | CONTROL-ID Description | Section |\n"
+        )
 
     for name, pattern in REQUIRED_METADATA:
         if not re.search(pattern, text):


### PR DESCRIPTION
## Summary
- require every quality policy to include a structured `## Compliance Mapping` section
- add parseable compliance mappings to the 12 policies that were missing them
- update policy versions, dates, and changelogs for the new sections

## Root Cause
`validate_policy_structure.py` accepted framework keywords in prose as an alternative to a structured mapping section, while the coverage validator only consumes mapping tables.

## Impact
- policy mapping sections: 8 -> 20
- mapping rows: 113 -> 231
- documented compliance coverage: 13.9% -> 34.5%
- CCPA/CPRA, HIPAA, ISO 22301, and NIST CSF no longer report 0% coverage

## Validation
- all validation commands in `.github/workflows/validate.yml` passed locally
- focused regression check confirms framework prose without a Compliance Mapping section fails structure validation
- `git diff --check`

Closes #277
